### PR TITLE
Fix primary color. Propose git URL for repo

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -23,7 +23,7 @@ clean:
 
 # Clone the source repository we need
 clone:
-	git clone https://github.com/validmind/validmind-python.git $(SRC_DIR)
+	git clone git@github.com:validmind/validmind-python.git $(SRC_DIR)
 
 # Copy over Jupyter notebooks
 notebooks:
@@ -32,7 +32,7 @@ notebooks:
 	cp -r $(SRC_DIR)/notebooks/. $(DEST_DIR_NB)
 
 # Make Python library docs & copy them over
-python-docs: 
+python-docs:
 	$(MAKE) -C $(SRC_DIR)/docs markdown
 	rm -rf $(DEST_DIR_PYTHON)
 	mkdir -p $(DEST_DIR_PYTHON)
@@ -42,6 +42,6 @@ python-docs:
 get-source: clean clone notebooks python-docs
 
 # Get all source files
-docs-site: clean clone notebooks python-docs 
+docs-site: clean clone notebooks python-docs
 	quarto render
 

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -38,19 +38,19 @@ website:
         - validmind/test_plans.md
         - validmind/vm_models.md
       - guide/restapi.qmd
- 
+
     - guide/glossary.qmd
     - guide/support.qmd
     - guide/releasenotes.qmd
 
-  page-footer: 
-    background: "#C61E6E"
-    left: "_© Copyright 2023 ValidMind Inc All Rights Reserved._" 
-    right: 
+  page-footer:
+    background: "#DE257E"
+    left: "_© Copyright 2023 ValidMind Inc All Rights Reserved._"
+    right:
       - icon: github
         href: https://github.com/validmind/documentation
-      - icon: linkedin 
-        href: https://www.linkedin.com/company/validmind/ 
+      - icon: linkedin
+        href: https://www.linkedin.com/company/validmind/
 
 format:
   html:


### PR DESCRIPTION
Couple of minor changes:

- Use actual primary color code
- I suggest we use the SSH (`git`) based URL for cloning

## About cloning the `validmind-python` repo

`make get-source` requires that we setup some Python dependencies for generating the docs. I manually installed these dependencies in order to get this running as described here:

```
You need:

- Sphinx `docutils`
- Supporting tools: `sphinx_markdown_builder`, `myst_parser`, `dython`, `pandas_profiling`, and `shap`
```

I'm not sure why these dependencies are required for generating docs, I need to look into that. In any case, I'm almost leaning to propose that we setup `poetry` on this repo so we're ready to generate docs after cloning the repo. This will also make it easier for us to implement the CI/CD component for it (and even leverage GitHub caching).

I'll think about this in terms of preparation for our CI/CD and have a proposed solution for next week.
