### PR TITLE
Executable Python experiment — DO NOT REVIEW

### DIFF
--- a/site/guide/about.qmd
+++ b/site/guide/about.qmd
@@ -1,5 +1,33 @@
 ---
-title: "About"
+title: "About the ValidMind platform"
+keywords: "about,compliance,third party dependencies,model risk management, ValidMind"
 ---
 
-About this site
+
+## Regulatory compliance 
+
+<!---
+Placeholder for SOC 2, etc.
+--->
+
+## Third-party dependencies
+
+```{python}
+import csv
+
+def csv_to_markdown_table(csv_path):
+    with open(csv_path, newline='') as csvfile:
+        reader = csv.reader(csvfile)
+        headers = next(reader)
+        table = []
+        table.append(headers)
+        table.append(['---' for i in range(len(headers))])
+        for row in reader:
+            table.append(row)
+        return '\n'.join(['|'.join(row) for row in table])
+
+if __name__ == '__main__':
+    csv_path = 'oss.csv'
+    markdown_table = csv_to_markdown_table(csv_path)
+    print(markdown_table)
+```

--- a/site/guide/oss.csv
+++ b/site/guide/oss.csv
@@ -1,0 +1,16 @@
+Software,License Type,Details
+Python,Python Software Foundation License (PSFL) (BSD-style),API backend runs on Python
+PostgreSQL,"PostgreSQL License (BSD, MIT-style)",Application database
+React,MIT,Frontend application code
+Node.js,MIT,JavaScript backend for compiling static assets
+TypeScript,Apache 2.0,Superset of JavaScript. Used to write frontend code
+Nginx,FreeBSD,Open source HTTP server
+Poetry,MIT,Python dependency management library
+Jupyter Notebook,3-Clause BSD License,Web-based IDE for computational work
+Sentry Client,MIT,JavaScript and Python clients for error logging
+Auth0 React,MIT,Client-side authentication library
+LibreOffice,Mozilla Public License 2.0,Report generation from DOCX templates
+Flask,3-Clause BSD License,Python HTTP server
+Pandas,3-Clause BSD License,Data manipulation library
+NumPy,3-Clause BSD License,Scientific computing library
+SQLAlchemy,MIT,ORM library for Python


### PR DESCRIPTION
Just a sideshow to what I am actually working on this afternoon ... here's an incomplete PR that uses some executable Python code in Quarto to generate a Markdown table from a CSV files exported from [Morgan Stanley - Tech Passport Application](https://docs.google.com/spreadsheets/d/1b7ULWQH4Q459Jcpqgd39udSwK8hX8bfGr_iahXr_euQ/edit?usp=sharing)

The good:
- It sort of works ... we do generate a lovely Markdown table. Yay!

The bad: 
- It's just an executable Python codeblock and so both the Python script and the Markdown output are included. 🙃 

Still a great little experiment to learn more about what you can do with Quarto. In the future, we might use a variant of this to include third-party and OSS dependencies in our docs. 

<img width="1427" alt="image" src="https://user-images.githubusercontent.com/15148011/226061993-e466dc09-dc91-4e72-a11f-b34381b2be53.png">

