### PR TITLE
Add initial GitHub Action to deploy to S3

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -20,4 +20,4 @@ jobs:
 
       - name: Sync to S3
         run: 
-          aws s3 sync site/_site s3://${{ vars.S3_BUCKET }}/site --delete --exclude ".git/*"
+          aws s3 sync site/_site s3://${{ vars.S3_BUCKET }}/site --delete


### PR DESCRIPTION
This PR adds an inital GitHub action to deploy our docs site to S3. 

## How it works

- The action is triggered when changes are pushed to the `main` branch.
- The steps of the action include:
    - The `checkout` step to get the repository code into the virtual machine running the GitHub action.
    - The `aws configure` command to set up the AWS CLI: 
        - [Repository secrets](https://github.com/validmind/documentation/settings/secrets/actions): Supplies the credentials for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.*
        - [Repository variables](https://github.com/validmind/documentation/settings/variables/actions): Supplies the default `AWS_REGION` and the `S3_BUCKET` to sync to.
    -  The `aws s3 sync` command to synchronize the local files with `S3_BUCKET` with the `--delete` option to delete any files in the S3 bucket that are not in the local directory.

*Currently, this uses my AWS credentials. We'll need to replace these when we go into production.

Relates to [#594](https://app.shortcut.com/validmind/story/594/create-initial-plumbing-for-documentation-ci-cd)

## How to test this PR

Since the PR requires a push against `main` which is not great for testing, the easiest is to change the branch to `ci-cd-experiments` [here](https://github.com/validmind/documentation/pull/6/files#diff-6b9dee97646fd776b3b1817c5acecf97313875bd711c2355c0d9f4014fb993bdR8) and push a change against the PR branch. 

The push should trigger an action in https://github.com/validmind/documentation/actions.

## For discussion with Andres

Do we need to run `make docs-site` as part of this PR, or at least `quarto render` together with grabbing the latest files? 

Some considerations: 

- We should run render the docs site using the latest source files _at some point_ to make sure that we always deploy an up-to-date version of the docs site available and that the site builds cleanly. 
- The only question is whether we assume that whoever is pushing a PR against the documentation repo has already rendered the most recent files for the docs site or whether we want CI to do it. 
- Alternatives:
    - You could create a "make docs-site lite": clone the validmind-python repo via a GitHub action and a new secret key (e.g. via this [marketplace action](https://github.com/marketplace/actions/clone-github-repo-action)), copy the required notebooks and Python docs over using our existing makefile, and then render the docs site with `quarto render`. 
    - An even simpler step would be to assume that whoever is pushing to `main` has updated the source files already and all we need to do is `quarto render` to make sure that they build cleanly before deploying. But is that actually good enough?
    - There's an even simpler solution: defer this discussion to later and do nothing for now — just approve this PR as is. This would enable Spencer to move ahead with setting up the other CI/CD infra we need along with the `staging` and `prod` branches. We would then sort out a separate CI check via a GitHub action later.

When I experimented with rendering the site as part of the GitHub action, I ran into a couple of issues: 

- We need Quarto CLI to render the site as part of the GitHub action. ~This part is probably fairly straightforward, though I am not sure we want to pull the files down from Quarto each and every single time we push to `main`. The Ubuntu .deb package is 85MB (see https://quarto.org/docs/get-started/).~ There is an officially supported GitHub action you can use, see https://github.com/quarto-dev/quarto-actions/blob/main/examples/quarto-publish-example.yml.
- To render the site with `make docs-site` requires cloning the private validmind-python repo. Cloning that repo via SSH requires additional setup steps to run properly, though it's probably the most thorough solution. (Some folks seem to recommend using Docker images at this point, though [this article](https://samyaktjain24.medium.com/how-to-clone-a-private-repository-in-github-action-using-ssh-38d0de8c09d8) shows how it could be done.)
