### PR TITLE
Fixed missing toc-expand value

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -187,4 +187,4 @@ format:
     css: styles.css
 #    link-external-newwindow: true
     toc: true
-    toc-expand: 
+    toc-expand: 2


### PR DESCRIPTION
Adds the missing `toc-expand` value to our Quarto config.

Fixes https://app.shortcut.com/validmind/story/1372