### PR TITLE
Disable edit links

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -12,9 +12,9 @@ website:
 #    hypothesis: 
 #      theme: clean
   
-  repo-url: https://github.com/validmind/documentation/
-  repo-subdir: site/
-  repo-actions: [edit, issue]
+#  repo-url: https://github.com/validmind/documentation/
+#  repo-subdir: site/
+#  repo-actions: [edit, issue]
 
   navbar:
     logo: guide/ValidMind-logo-color.svg


### PR DESCRIPTION
JPMC does not have access to our private documentation repo and so the edit links we currently show lead to 404s for them. Best to just disable the links.

Before and after: 

<img width="2560" alt="image" src="https://github.com/validmind/documentation/assets/15148011/0ea928c3-d01f-42b7-a75e-170bbbfe4bd6">

Closes https://app.shortcut.com/validmind/story/1373/turn-off-edit-this-page-feature