### PR TITLE
Hide AWS PrivateLink service info

### DIFF
--- a/site/_site/guide/configure-aws-privatelink.html
+++ b/site/_site/guide/configure-aws-privatelink.html
@@ -375,11 +375,12 @@ Recording: 46:00 FR InfoSec log in and set up endpoint > request pending, need t
 <tbody>
 <tr class="odd">
 <td>us-west-2</td>
-<td>com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538</td>
-<td><a href="https://private.prod.vm.validmind.ai">https://private.prod.vm.validmind.ai</a></td>
+<td>Email <a href="mailto:support@validmind.com" class="email">support@validmind.com</a></td>
+<td>Email <a href="mailto:support@validmind.com" class="email">support@validmind.com</a></td>
 </tr>
 </tbody>
 </table>
+<!--- | us-west-2    | com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538 | [https://private.prod.vm.validmind.ai](https://private.prod.vm.validmind.ai) | --->
 <!--- | us-east-1    | com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538 | private.prod.vm.validmind.ai | --->
 <!--- | eu-west-1    | com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538 | private.prod.vm.validmind.ai | --->
 <!--- | eu-central-1 | com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538 | private.prod.vm.validmind.ai | --->

--- a/site/_site/search.json
+++ b/site/_site/search.json
@@ -557,7 +557,7 @@
     "href": "guide/configure-aws-privatelink.html#prerequisites",
     "title": "Configure AWS PrivateLink",
     "section": "Prerequisites",
-    "text": "Prerequisites\nYou must have access to the AWS Console for your company and the necessary expertise to set up, configure, and maintain AWS services.\nThese steps assume that you already have established connectivity between your own company network and AWS VPC and know which company VPC you want to connect to.\n\nVPC service information\n\n\n\n\nRegion\nService name\nPrivate DNS name\n\n\n\n\nus-west-2\ncom.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538\nhttps://private.prod.vm.validmind.ai"
+    "text": "Prerequisites\nYou must have access to the AWS Console for your company and the necessary expertise to set up, configure, and maintain AWS services.\nThese steps assume that you already have established connectivity between your own company network and AWS VPC and know which company VPC you want to connect to.\n\nVPC service information\n\n\n\n\nRegion\nService name\nPrivate DNS name\n\n\n\n\nus-west-2\nEmail support@validmind.com\nEmail support@validmind.com"
   },
   {
     "objectID": "guide/configure-aws-privatelink.html#steps",

--- a/site/guide/configure-aws-privatelink.qmd
+++ b/site/guide/configure-aws-privatelink.qmd
@@ -36,7 +36,9 @@ Recording: 46:00 FR InfoSec log in and set up endpoint > request pending, need t
 
 | Region       | Service name                                            | Private DNS name             |
  ------------- | ------------------------------------------------------- | ---------------------------- |
-| us-west-2    | com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538 | [{{< var vm_ui_privatelink >}}]({{< var vm_ui_privatelink >}}) | 
+| us-west-2    | Email <support@validmind.com> | Email <support@validmind.com> | 
+
+<!--- | us-west-2    | com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538 | [{{< var vm_ui_privatelink >}}]({{< var vm_ui_privatelink >}}) | --->
 <!--- | us-east-1    | com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538 | private.prod.vm.validmind.ai | --->
 <!--- | eu-west-1    | com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538 | private.prod.vm.validmind.ai | --->
 <!--- | eu-central-1 | com.amazonaws.vpce.us-west-2.vpce-svc-0b956fa3e03afa538 | private.prod.vm.validmind.ai | --->


### PR DESCRIPTION
After a convo with Andres, we determined that we need to hide the `prod` AWS PrivateLink info from our docs, as the VPC infra hasn't been set up, yet. This PR replaces that info with a request to email support. 