### PR TITLE
Extract basic changelog

### DIFF
--- a/site-unused/releases.qmd
+++ b/site-unused/releases.qmd
@@ -1,0 +1,19 @@
+title:	v1.13.9
+tag:	v1.13.9
+draft:	false
+prerelease:	false
+author:	cachafla
+created:	2023-05-24T19:50:26Z
+published:	2023-05-26T04:29:47Z
+url:	https://github.com/validmind/validmind-python/releases/tag/v1.13.9
+--
+## What's Changed
+* [sc-1521] Enable interactive Plotly plots on non colab by @cachafla in https://github.com/validmind/validmind-python/pull/163
+* Add Support for Global Config for Test Suites and Test Plans by @johnwalz97 in https://github.com/validmind/validmind-python/pull/157
+* [SC-1516] Add sensitivity analysis test plan for time series models by @juanmleng in https://github.com/validmind/validmind-python/pull/164
+* [SC-1527] Improve figures in time series model by @juanmleng in https://github.com/validmind/validmind-python/pull/165
+* [sc-1476] Support for uploading multiple figures with a single API call by @johnwalz97 in https://github.com/validmind/validmind-python/pull/166
+* Use ploty for PR curve and ROC curve, and more improvements by @cachafla in https://github.com/validmind/validmind-python/pull/167
+
+
+**Full Changelog**: https://github.com/validmind/validmind-python/compare/v1.13.6...v1.13.9


### PR DESCRIPTION
This is an experiment that basically just runs `gh release view > ../../guide/releases.qmd` to generate a basic Markdown file we can include in our release notes. 

This file would require some editing to work in the docs site as the links would not be available to our end users and we would want to edit out a few lines. 