### PR TITLE
Fix clone action in Makefile

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -25,7 +25,7 @@ clean:
 
 # Clone the source repository we need
 clone:
-	git clone git@github.com:validmind/validmind-python.git $(SRC_DIR)
+	git clone -b prod git@github.com:validmind/validmind-python.git $(SRC_DIR)
 
 # Copy over Jupyter notebooks
 notebooks:


### PR DESCRIPTION
Our Makefile for the documentation repo clones the validmind-python repo. [This convo](https://validmind.slack.com/archives/C04PMBF8MKQ/p1686611277448869) with Andres made me realize that we just pull content out of `main` which is a bug. We should be using `prod` instead. 

## External Release Notes
Test description 5 for bug label.