### PR TITLE
Remove reference to CKEditor

### DIFF
--- a/site/guide/collaborate-on-documentation-projects.qmd
+++ b/site/guide/collaborate-on-documentation-projects.qmd
@@ -92,7 +92,7 @@ All users associated with a project, such as model developers and model validato
 
 ## Real-time collaboration
 
-Users can simultaneously edit the documentation project, leave and respond to comments suggestions, and access revision history. CKEditor is also integrated with ValidMind's activity feed, so changes to the documentation project are automatically added to the activity feed.
+Users can simultaneously edit the documentation project, leave and respond to comments suggestions, and access revision history. Changes to the documentation project are also automatically added to ValidMind's activity feed.
 
 ## Additional features
 


### PR DESCRIPTION
## Internal Notes for Reviewers
Removed reference to CKEditor in 'Real-time collaboration' section.
<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->