### PR TITLE
Add CLA and metadata files from gist

### DIFF
--- a/CLA.txt
+++ b/CLA.txt
@@ -1,0 +1,73 @@
+This agreement is based on the Apache Software Foundation Individual Contributor License V2.0, with modifications.
+
+Thank you for your interest in the ValidMind Developer Framework.
+
+To clarify the intellectual property license granted with Contributions from any person or entity, ValidMind Inc. must have
+on file a signed Contributor License Agreement ("CLA") from each Contributor, indicating agreement with the license terms
+below.
+
+This agreement is for your protection as a Contributor as well as the protection of ValidMind Inc. and its users. It does
+not change your rights to use your own Contributions for any other purpose.
+
+If you have any questions about these terms, please contact us at support@validmind.com.
+
+Please read this document carefully before signing and keep a copy for your records.
+
+Terms and Conditions
+
+You accept and agree to the following terms and conditions for Your Contributions (present and future) that you submit to
+ValidMind Inc.. Except for the license granted herein to ValidMind Inc. and recipients of software distributed by ValidMind
+Inc., You reserve all right, title, and interest in and to Your Contributions.
+
+1. Definitions. "You" (or "Your") shall mean the copyright owner or legal entity authorized by the copyright owner that is
+making this Agreement with ValidMind Inc.. For legal entities, the entity making a Contribution and all other entities that
+control, are controlled by, or are under common control with that entity are considered to be a single Contributor. For the
+purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or
+(iii) beneficial ownership of such entity. "Contribution" shall mean any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted by You to ValidMind Inc. for inclusion in,
+or documentation of, any of the products owned or managed by ValidMind Inc. (the "Work"). For the purposes of this
+definition, "submitted" means any form of electronic, verbal, or written communication sent to ValidMind Inc. or its
+representatives, including but not limited to communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, ValidMind Inc. for the purpose of discussing and improving the
+Work, but excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a
+Contribution."
+
+2. Grant of Copyright License. Subject to the terms and conditions of this Agreement, You hereby grant to ValidMind Inc. and
+to recipients of software distributed by ValidMind Inc. a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and
+distribute Your Contributions and such derivative works.
+
+3. Grant of Patent License. Subject to the terms and conditions of this Agreement, You hereby grant to ValidMind Inc. and to
+recipients of software distributed by ValidMind Inc. a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and
+otherwise transfer the Work, where such license applies only to those patent claims licensable by You that are necessarily
+infringed by Your Contribution(s) alone or by combination of Your Contribution(s) with the Work to which such Contribution(s) was
+submitted. If any entity institutes patent litigation against You or any other entity (including a cross-claim or
+counterclaim in a lawsuit) alleging that your Contribution, or the Work to which you have contributed, constitutes direct or
+contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution
+or Work shall terminate as of the date such litigation is filed.
+ 
+4. You represent that you are legally entitled to grant the above license. If your employer(s) has rights to intellectual
+property that you create that includes your Contributions, you represent that you have received permission to make
+Contributions on behalf of that employer, that your employer has waived such rights for your Contributions to ValidMind Inc., or
+that your employer has executed a separate Corporate CLA with ValidMind Inc..
+
+5. You represent that each of Your Contributions is Your original creation (see section 7 for submissions on behalf of
+others). You represent that Your Contribution submissions include complete details of any third-party license or other
+restriction (including, but not limited to, related patents and trademarks) of which you are personally aware and which are
+associated with any part of Your Contributions.
+
+6. You are not expected to provide support for Your Contributions, except to the extent You desire to provide support. You
+may provide support for free, for a fee, or not at all. Unless required by applicable law or agreed to in writing, You
+provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+7. Should You wish to submit work that is not Your original creation, You may submit it to ValidMind Inc. separately from
+any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not
+limited to, related patents, trademarks, and license agreements) of which you are personally aware, and conspicuously
+marking the work as "Submitted on behalf of a third-party: [named here]".
+
+8. You agree to notify ValidMind Inc. of any facts or circumstances of which you become aware that would make these
+representations inaccurate in any respect.

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,19 @@
+{
+    "name": {
+        "title": "Full Name",
+        "type": "string",
+        "githubKey": "name",
+        "required": true
+    },
+    "email": {
+        "title": "E-Mail",
+        "type": "string",
+        "githubKey": "email",
+        "required": true
+    },
+    "agreement": {
+        "title": "I have read and agree to the CLA",
+        "type": "boolean",
+        "required": true
+    }
+}


### PR DESCRIPTION
## Internal Notes for Reviewers
Addressing this story: https://app.shortcut.com/validmind/story/1970/create-contributor-license-agreement-cla-for-open-source-repos

Added CLA (can also be found on this [Notion doc](https://www.notion.so/validmind/Contributor-License-Agreement-5f3fc70ac5ad445f860b9d1e3fb404a9)) and metadata file. Following the [instructions for the CLA assistant](https://cla-assistant.io/), the CLA and metadata files need to be linked to the repository as a GitHub gist.
<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->