### PR TITLE
Fix typo in menu

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -40,7 +40,7 @@ website:
           file: notebooks/Quickstart_Customer Churn_full_suite.ipynb
         - text: "{{< fa book >}} Full Introduction · `Customer Churn` · `Binary Classification`"
           file: notebooks/Introduction_Customer_Churn.ipynb
-        - text: "{{< fa book >}} Forecasting · `Credit Risk - Load Underwriting` · `Time Series`"
+        - text: "{{< fa book >}} Forecasting · `Credit Risk Scorecard` · `Time Series`"
           file: notebooks/time_series/tutorial_time_series_forecasting.ipynb
         - text: "{{< fa book >}} Natural Language Processing · `Sensitivity Analysis` · `Binary Classification`"
           file: notebooks/nlp/nlp_sentiment_analysis_catboost_demo.ipynb


### PR DESCRIPTION
As reported by Juan in message, we have typo in our new menu. This PR fixes that typo.

![image](https://github.com/validmind/documentation/assets/15148011/a4966222-85fe-48f6-b6c6-41ef9fcdaab2)

## Internal Notes for Reviewers

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->