### PR TITLE
Run release notes check only if not in draft mode

### DIFF
--- a/.github/workflows/release_notes_check.yml
+++ b/.github/workflows/release_notes_check.yml
@@ -2,7 +2,7 @@ name: Release notes check
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled, unlabeled, edited]
+    types: [opened, synchronize, labeled, unlabeled, edited, ready_for_review]
 
 jobs:
   ci_check:

--- a/.github/workflows/release_notes_check.yml
+++ b/.github/workflows/release_notes_check.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   ci_check:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release_notes_check.yml
+++ b/.github/workflows/release_notes_check.yml
@@ -25,3 +25,4 @@ jobs:
         run: python .github/scripts/release_notes_check.py ${{ github.event.pull_request.html_url }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          

--- a/.github/workflows/release_notes_check.yml
+++ b/.github/workflows/release_notes_check.yml
@@ -25,4 +25,3 @@ jobs:
         run: python .github/scripts/release_notes_check.py ${{ github.event.pull_request.html_url }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR makes a small tweak to our release notes check so that it runs only if a PR is not in draft mode. This should avoid frequent CI check failures when a PR is in progress. 

Here's how the CI check gets skipped after you change the PR to draft mode and then make a commit: 

<img width="1045" alt="image" src="https://github.com/validmind/documentation/assets/15148011/5ea6a6ad-6e14-4e2c-b8cc-c2ece9871315">

And here's what happens when you change the PR back to ready for review: 

<img width="965" alt="image" src="https://github.com/validmind/documentation/assets/15148011/db8b3657-e33c-4b44-8db4-9c2d9d166aea">

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->