### PR TITLE
Make it easier for contributors to preview docs site locally

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -51,10 +51,15 @@ notebooks:
 
 # Make Python library docs & copy them over
 python-docs:
-	@echo "\nUpdating Python documentation ..."
-	@rm -rf $(DEST_DIR_PYTHON)
-	@mkdir -p $(DEST_DIR_PYTHON)
-	@cp -r $(SRC_DIR)/docs/_build/. $(DEST_DIR_PYTHON)
+	@if [ -d "$(SRC_DIR)/docs/_build/" ]; then \
+		echo "\nUpdating Python documentation ..."; \
+		rm -rf $(DEST_DIR_PYTHON); \
+		mkdir -p $(DEST_DIR_PYTHON); \
+		cp -r $(SRC_DIR)/docs/_build/. $(DEST_DIR_PYTHON); \
+	else \
+		echo "\nNo updated Python documentation available locally, skipping step ..."; \
+	fi
+
 
 test-descriptions:
 	@echo "\nUpdating test descriptions source ..."


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR makes it easier for contributors to preview our docs site locally, without having to fetch content from other repos first. 

### Context 

@robinzimmermann encountered an issue where the Python documentation that gets copied into our docs site in a [post-render step](https://github.com/validmind/documentation/blob/main/site/_quarto.yml#L3) was unavailable locally. This occurred because, as a new contributor, he hadn't run the `make get-source` command to fetch content from the developer-framework repository yet. Consequently, he was unable to preview his changes using `quarto preview`.

Typically, updating the Python documentation is a task for writers preparing to publish the latest version of our docs site, making it unnecessary for contributors like Robin to deal with. To simplify the process for doc changes, this PR introduces a conditional check to check for the presence of the Python documentation in `site/_source/developer-framework/docs/_build`. If absent, it bypasses the copying of the Python docs in the post-render step and enables the docs site preview to work locally as expected. 

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

We made it easier for contributors to preview and render the docs site locally, without having to fetch content from other repos first.

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->