### PR TITLE
Add QuickStart video to the docs site

### DIFF
--- a/site/_site/about/glossary/glossary.html
+++ b/site/_site/about/glossary/glossary.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-08">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Glossary</title>
 <style>
@@ -394,7 +394,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 8, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/about/style-guide.html
+++ b/site/_site/about/style-guide.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-08">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - ValidMind style guide</title>
 <style>
@@ -458,7 +458,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 8, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/guide/developer-getting-started-video.html
+++ b/site/_site/guide/developer-getting-started-video.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-08">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - FUTURE: VIDEO</title>
 <style>
@@ -213,7 +213,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 8, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/guide/get-started-developer-framework.html
+++ b/site/_site/guide/get-started-developer-framework.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-08">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Get started with the ValidMind Developer Framework</title>
 <style>
@@ -1633,7 +1633,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 8, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   
@@ -1748,6 +1748,11 @@ A collection of tests which are run together to generate model documentation end
 </section>
 <section id="getting-started" class="level2">
 <h2 class="anchored" data-anchor-id="getting-started">Getting started</h2>
+<div class="grid">
+<div class="g-col-10">
+<div class="quarto-video ratio ratio-16x9"><iframe data-external="1" src="https://www.youtube.com/embed/rIR8Mql7eGs" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></div>
+</div>
+</div>
 <p>After you <a href="https://app.prod.validmind.ai"><strong>sign up</strong></a> for ValidMind to get access, try one our getting started guide:</p>
 <div id="listing-developer-getting-started" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">

--- a/site/_site/guide/get-started.html
+++ b/site/_site/guide/get-started.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-08">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Get started</title>
 <style>
@@ -350,7 +350,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 8, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/guide/guides.html
+++ b/site/_site/guide/guides.html
@@ -783,7 +783,7 @@ No matching items
 <p>To document and test your models in your own model development environment:</p>
 <div id="listing-guides-developer-framework" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1715281712000" data-listing-file-modified-sort="1715281712700" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1715281714000" data-listing-file-modified-sort="1715281714766" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3">
 <a href="../guide/get-started-developer-framework.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/guides.html
+++ b/site/_site/guide/guides.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-08">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Guides</title>
 <style>
@@ -596,7 +596,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 8, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   
@@ -783,7 +783,7 @@ No matching items
 <p>To document and test your models in your own model development environment:</p>
 <div id="listing-guides-developer-framework" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1715206079000" data-listing-file-modified-sort="1715206079871" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1715281712000" data-listing-file-modified-sort="1715281712700" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3">
 <a href="../guide/get-started-developer-framework.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -833,7 +833,7 @@ Documentation templates offer a standardized approach to creating consistent and
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1715206079000" data-listing-file-modified-sort="1715206079872" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1715272446000" data-listing-file-modified-sort="1715272446223" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2">
 <a href="../guide/working-with-model-documentation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -872,7 +872,7 @@ No matching items
 <p>To set up approvals, prepare validation reports, collaborate with model developers, link evidence to your reports, or work with model documentation findings:</p>
 <div id="listing-guides-model-validation" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1715206079000" data-listing-file-modified-sort="1715206079872" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1715272446000" data-listing-file-modified-sort="1715272446222" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2">
 <a href="../guide/preparing-validation-reports.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/preparing-validation-reports.html
+++ b/site/_site/guide/preparing-validation-reports.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-08">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Preparing validation reports</title>
 <style>
@@ -485,7 +485,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 8, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/guide/quickstart-explore-sample-model-documentation.html
+++ b/site/_site/guide/quickstart-explore-sample-model-documentation.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-07">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Explore sample model documentation</title>
 <style>
@@ -310,7 +310,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 7, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/guide/quickstart-generate-documentation-for-your-model.html
+++ b/site/_site/guide/quickstart-generate-documentation-for-your-model.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-07">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Generate documentation for your model</title>
 <style>
@@ -311,7 +311,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 7, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/guide/quickstart-register-your-first-model.html
+++ b/site/_site/guide/quickstart-register-your-first-model.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-07">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Register your first model</title>
 <style>
@@ -311,7 +311,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 7, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/guide/quickstart-try-developer-framework-in-your-own-developer-environment.html
+++ b/site/_site/guide/quickstart-try-developer-framework-in-your-own-developer-environment.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-07">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Try it in your own developer environment</title>
 <style>
@@ -345,7 +345,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 7, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/guide/quickstart-try-developer-framework-with-colab.html
+++ b/site/_site/guide/quickstart-try-developer-framework-with-colab.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-07">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Try it with Google Colaboratory</title>
 <style>
@@ -311,7 +311,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 7, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/guide/quickstart-try-developer-framework-with-jupyterhub.html
+++ b/site/_site/guide/quickstart-try-developer-framework-with-jupyterhub.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-07">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Try it with Jupyter Hub (recommended)</title>
 <style>
@@ -344,7 +344,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 7, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   
@@ -355,6 +355,11 @@ cookieconsent.run({
 </header>
 
 <p>Learn how to document a model with ValidMind on Jupyter Hub.</p>
+<div class="grid">
+<div class="g-col-10">
+<div class="quarto-video ratio ratio-16x9"><iframe data-external="1" src="https://www.youtube.com/embed/rIR8Mql7eGs" title="" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen=""></iframe></div>
+</div>
+</div>
 <section id="before-you-begin" class="level2">
 <h2 class="anchored" data-anchor-id="before-you-begin">Before you begin</h2>
 <p>To try out ValidMind, you need to be a registered user on the ValidMind Platform.</p>

--- a/site/_site/guide/testing-overview.html
+++ b/site/_site/guide/testing-overview.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-08">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Run tests and test suites</title>
 <style>
@@ -1664,7 +1664,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 8, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   
@@ -1859,7 +1859,7 @@ No matching items
 <p>Building on previous sections, add your own test provider, set up datasets, run tests on individual sections in your model documentation, and more:</p>
 <div id="listing-tests-intermediate" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1715206079877" data-listing-reading-time-sort="13">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1715272446230" data-listing-reading-time-sort="13">
 <a href="../notebooks/code_samples/custom_tests/integrate_external_test_providers.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/working-with-model-documentation.html
+++ b/site/_site/guide/working-with-model-documentation.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-05-08">
+<meta name="dcterms.date" content="2024-05-09">
 
 <title>ValidMind - Working with model documentation</title>
 <style>
@@ -486,7 +486,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">May 8, 2024</p>
+      <p class="date">May 9, 2024</p>
     </div>
   </div>
   

--- a/site/_site/search.json
+++ b/site/_site/search.json
@@ -3553,7 +3553,7 @@
     "href": "guide/get-started-developer-framework.html#getting-started",
     "title": "Get started with the ValidMind Developer Framework",
     "section": "Getting started",
-    "text": "Getting started\nAfter you sign up for ValidMind to get access, try one our getting started guide:\n\n\n\n\n\n\n\nQuickstart for model documentation\n\n\n\n\n\n\n\n\n\n\n\n\n\nValidMind Introduction for Model Developers\n\n\n\n\n\n\n\n\n\n\nNo matching items"
+    "text": "Getting started\n\n\n\n\n\nAfter you sign up for ValidMind to get access, try one our getting started guide:\n\n\n\n\n\n\n\nQuickstart for model documentation\n\n\n\n\n\n\n\n\n\n\n\n\n\nValidMind Introduction for Model Developers\n\n\n\n\n\n\n\n\n\n\nNo matching items"
   },
   {
     "objectID": "guide/get-started-developer-framework.html#learn-how-to-run-tests",

--- a/site/guide/get-started-developer-framework.qmd
+++ b/site/guide/get-started-developer-framework.qmd
@@ -58,9 +58,13 @@ The Developer Framework is designed to be model agnostic. If your model is built
 :::
 
 ## Getting started
-
-   {{< video https://youtu.be/rIR8Mql7eGs >}}
    
+::: {.grid}
+::: {.g-col-10}
+{{< video https://youtu.be/rIR8Mql7eGs >}}
+:::
+:::
+
 After you [**sign up**](https://app.prod.validmind.ai) for ValidMind to get access, try one our getting started guide:
 
 :::{#developer-getting-started}

--- a/site/guide/get-started-developer-framework.qmd
+++ b/site/guide/get-started-developer-framework.qmd
@@ -59,6 +59,8 @@ The Developer Framework is designed to be model agnostic. If your model is built
 
 ## Getting started
 
+   {{< video https://youtu.be/rIR8Mql7eGs >}}
+   
 After you [**sign up**](https://app.prod.validmind.ai) for ValidMind to get access, try one our getting started guide:
 
 :::{#developer-getting-started}

--- a/site/guide/quickstart-try-developer-framework-with-jupyterhub.qmd
+++ b/site/guide/quickstart-try-developer-framework-with-jupyterhub.qmd
@@ -5,7 +5,11 @@ date: last-modified
 
 Learn how to document a model with ValidMind on Jupyter Hub.
 
-   {{< video https://youtu.be/rIR8Mql7eGs >}}
+::: {.grid}
+::: {.g-col-10}
+{{< video https://youtu.be/rIR8Mql7eGs >}}
+:::
+:::
 
 ## Before you begin
 

--- a/site/guide/quickstart-try-developer-framework-with-jupyterhub.qmd
+++ b/site/guide/quickstart-try-developer-framework-with-jupyterhub.qmd
@@ -5,6 +5,8 @@ date: last-modified
 
 Learn how to document a model with ValidMind on Jupyter Hub.
 
+   {{< video https://youtu.be/rIR8Mql7eGs >}}
+
 ## Before you begin
 
 To try out ValidMind, you need to be a registered user on the ValidMind Platform.


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR embeds the new QuickStart video into a couple of places.

Into the QuickStart for JupyterHub:

<img width="1896" alt="image" src="https://github.com/validmind/documentation/assets/15148011/3d2dff61-cc88-47cc-af77-58b823b8fd4e">

Into the "Getting started" section for the developer framework:

<img width="1318" alt="image" src="https://github.com/validmind/documentation/assets/15148011/d37c8204-ed6f-47b6-9fa7-44fbd07a5a17">

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

A new three-minute QuickStart video walks you through documenting a model with ValidMind. We demo how to run our QuickStart notebook on JuypyterHub and show you how to work with model documentation on the ValidMind platform. [Watch it ...](../../guide/quickstart-try-developer-framework-with-jupyterhub.qmd)