### PR TITLE
New "Assign documentation section statuses" page in Guides

### DIFF
--- a/site/_site/guide/guides.html
+++ b/site/_site/guide/guides.html
@@ -876,7 +876,7 @@ Documentation templates offer a standardized approach to creating consistent and
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1716411738000" data-listing-file-modified-sort="1716411738750" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="516">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1716414270000" data-listing-file-modified-sort="1716414270623" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="516">
 <a href="../guide/working-with-model-documentation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/testing-overview.html
+++ b/site/_site/guide/testing-overview.html
@@ -2066,7 +2066,7 @@ To support running tests that require more than one dataset, ValidMind provides 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1716411299194" data-listing-reading-time-sort="15" data-listing-word-count-sort="2813">
+<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1716414238429" data-listing-reading-time-sort="15" data-listing-word-count-sort="2813">
 <a href="../notebooks/how_to/run_unit_metrics.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/working-with-model-documentation.html
+++ b/site/_site/guide/working-with-model-documentation.html
@@ -607,7 +607,7 @@ Focuses on the model’s ongoing monitoring plan, implementation, and governance
 <ul>
 <li>Any <a href="../guide/collaborate-with-others.html#commenting">unresolved conversations</a></li>
 <li>The number of <a href="../guide/work-with-model-findings.html">model findings</a></li>
-<li>The <a href="documentation-section-statuses.qmd">completion status</a> for your model’s documentation</li>
+<li>The <a href="../guide/assign-documentation-section-statuses.html">completion status</a> for your model’s documentation</li>
 </ul></li>
 </ol>
 <section id="unresolved-conversations" class="level4">
@@ -704,7 +704,21 @@ Make edits to your model documentation or validation reports by adding or removi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-date-sort="1711385588000" data-listing-file-modified-sort="1711385588621" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="715">
+<div class="g-col-1" data-index="2" data-listing-date-sort="1716414238000" data-listing-file-modified-sort="1716414238423" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="163">
+<a href="../guide/assign-documentation-section-statuses.html" class="quarto-grid-link">
+<div class="quarto-grid-item card h-100 card-left">
+<div class="card-body post-contents">
+<h5 class="no-anchor card-title listing-title">
+Assign documentation section statuses
+</h5>
+<div class="card-text listing-description">
+Assign a completion status to individual sections of your model documentation that will be reflected in your Document Overview.
+</div>
+</div>
+</div>
+</a>
+</div>
+<div class="g-col-1" data-index="3" data-listing-date-sort="1711385588000" data-listing-file-modified-sort="1711385588621" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="715">
 <a href="../guide/collaborate-with-others.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -718,7 +732,7 @@ Use the real-time collaboration features to track changes, add comments, and acc
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-date-sort="1716002082000" data-listing-file-modified-sort="1716002082552" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="181">
+<div class="g-col-1" data-index="4" data-listing-date-sort="1716002082000" data-listing-file-modified-sort="1716002082552" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="181">
 <a href="../guide/view-documentation-activity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -732,7 +746,7 @@ Use the audit trail functionality in the ValidMind Platform UI to track or audit
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-listing-date-sort="1716002082000" data-listing-file-modified-sort="1716002082550" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="533">
+<div class="g-col-1" data-index="5" data-listing-date-sort="1716002082000" data-listing-file-modified-sort="1716002082550" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="533">
 <a href="../guide/submit-for-approval.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/listings.json
+++ b/site/_site/listings.json
@@ -232,6 +232,7 @@
     "items": [
       "/guide/view-documentation-guidelines.html",
       "/guide/work-with-content-blocks.html",
+      "/guide/assign-documentation-section-statuses.html",
       "/guide/collaborate-with-others.html",
       "/guide/view-documentation-activity.html",
       "/guide/submit-for-approval.html"

--- a/site/_site/search.json
+++ b/site/_site/search.json
@@ -3848,7 +3848,7 @@
     "href": "guide/working-with-model-documentation.html#whats-next",
     "title": "Working with model documentation",
     "section": "What’s next",
-    "text": "What’s next\n\n\n\n\n\n\n\nView documentation guidelines\n\n\n\n\n\n\n\n\n\n\n\n\n\nWork with content blocks\n\n\n\n\n\n\n\n\n\n\n\n\n\nCollaborate with others\n\n\n\n\n\n\n\n\n\n\n\n\n\nView documentation activity\n\n\n\n\n\n\n\n\n\n\n\n\n\nSubmit for approval\n\n\n\n\n\n\n\n\n\n\nNo matching items",
+    "text": "What’s next\n\n\n\n\n\n\n\nView documentation guidelines\n\n\n\n\n\n\n\n\n\n\n\n\n\nWork with content blocks\n\n\n\n\n\n\n\n\n\n\n\n\n\nAssign documentation section statuses\n\n\n\n\n\n\n\n\n\n\n\n\n\nCollaborate with others\n\n\n\n\n\n\n\n\n\n\n\n\n\nView documentation activity\n\n\n\n\n\n\n\n\n\n\n\n\n\nSubmit for approval\n\n\n\n\n\n\n\n\n\n\nNo matching items",
     "crumbs": [
       "Guides",
       "Working with model documentation"

--- a/site/guide/working-with-model-documentation.qmd
+++ b/site/guide/working-with-model-documentation.qmd
@@ -10,7 +10,7 @@ listing:
     contents:
       - view-documentation-guidelines.qmd
       - work-with-content-blocks.qmd
-      - documentation-section-statuses.qmd
+      - assign-documentation-section-statuses.qmd
       - collaborate-with-others.qmd
       - view-documentation-activity.qmd
       - submit-for-approval.qmd
@@ -70,7 +70,7 @@ This section describes how to work with model documentation in the {{< var vm_pl
 
    - Any [unresolved conversations](collaborate-with-others.qmd#commenting)
    - The number of [model findings](work-with-model-findings.qmd)
-   - The [completion status](documentation-section-statuses.qmd) for your model's documentation
+   - The [completion status](assign-documentation-section-statuses.qmd) for your model's documentation
 
 #### Unresolved conversations
 


### PR DESCRIPTION
## Internal Notes for Reviewers
> For sc-4030, added a `Assign documentation section statuses` page.

### Assign documentation section statuses
- Net new page: `documentation-section-statuses.qmd`
- Added page to `_quarto.yml` under "Assign section statuses"
<img width="1840" alt="Screenshot 2024-05-21 at 12 18 56 PM" src="https://github.com/validmind/documentation/assets/164545837/9750afc5-70dc-40a7-ad37-a97061a405f3">

### Working with model documentation
- Updated the contents to include "Assign documentation section statuses" so it shows up in the `What's next` section
- Modified the instructions in the `Get started` section to reflect current UX, including a call-out for documentation summaries at the top of the overview page

| Old | New |
|---|---|
|<img width="795" alt="Screenshot 2024-05-21 at 12 19 44 PM" src="https://github.com/validmind/documentation/assets/164545837/da34141b-939a-4f3c-80b8-ce9618d8e8c0">|<img width="796" alt="Screenshot 2024-05-21 at 12 20 02 PM" src="https://github.com/validmind/documentation/assets/164545837/aa282e74-bdff-4ade-9cdc-8556ab0f7b30">|



