### PR TITLE
Demo JupyterHub OAuth issue

### DIFF
--- a/site/_site/training/training-for-model-developers.html
+++ b/site/_site/training/training-for-model-developers.html
@@ -426,10 +426,11 @@ Log into ValidMind
 <section>
 <section id="youre-in-lets-show-you-around." class="title-slide slide level1 center">
 <h1>You’re in —&nbsp;let’s show you around.</h1>
-<!-- ## {background-iframe="https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/tutorials/intro_for_model_developers.ipynb" background-interactive="yes" data-preload="yes"}  -->
+
 </section>
-<section id="section" class="slide level2" data-background-iframe="../notebooks/tutorials/intro_for_model_developers_EXECUTED.html" data-background-interactive="yes" data-preload="yes">
+<section id="section" class="slide level2" data-background-iframe="https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/tutorials/intro_for_model_developers.ipynb" data-background-interactive="yes" data-preload="yes">
 <h2></h2>
+<!-- ## {background-iframe="../notebooks/tutorials/intro_for_model_developers_EXECUTED.html" background-interactive="yes" data-preload="yes"}  -->
 <!-- Avoid overlapping with UI elements by moving instructions into footer -->
 <div class="absolute w-100 f3 tc pl4 pr4 bg-near-white ba b--dark-pink bw1 br3 near-black shadow-5" style="left: 0px; bottom: 15px; right: 50px; ">
 <p><strong>This introductory notebook includes sample code and how-to information, all in one place.</strong></p>

--- a/site/training/training-for-model-developers.qmd
+++ b/site/training/training-for-model-developers.qmd
@@ -74,9 +74,9 @@ To try out this training module, you need to have been [onboarded](training-over
 
 # You're in — let's show you around.
 
-<!-- ## {background-iframe="https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/tutorials/intro_for_model_developers.ipynb" background-interactive="yes" data-preload="yes"}  -->
+## {background-iframe="https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/tutorials/intro_for_model_developers.ipynb" background-interactive="yes" data-preload="yes"} 
 
-## {background-iframe="../notebooks/tutorials/intro_for_model_developers_EXECUTED.html" background-interactive="yes" data-preload="yes"} 
+<!-- ## {background-iframe="../notebooks/tutorials/intro_for_model_developers_EXECUTED.html" background-interactive="yes" data-preload="yes"}  -->
 
 <!-- Avoid overlapping with UI elements by moving instructions into footer -->
 :::: {.absolute bottom=15 left=0 right=50 .w-100 .f3 .tc .pl4 .pr4 .bg-near-white .ba .b--dark-pink .bw1 .br3 .near-black .shadow-5}


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR demos the OAuth issue we're having — deployed to the docs-demo site:

1. Log into JupyterHub: https://docs-demo.vm.validmind.ai/training/training-for-model-developers.html#/can-you-log-in
2. Go forward two slides: https://docs-demo.vm.validmind.ai/training/training-for-model-developers.html#/section

Relates to https://app.shortcut.com/validmind/story/4946/fix-oauth-error-in-jupyterhub-for-training-modules

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

3. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->