### PR TITLE
PR#232 Additional fixes

### DIFF
--- a/site/_site/about/contributing/style-guide/style-guide.html
+++ b/site/_site/about/contributing/style-guide/style-guide.html
@@ -516,7 +516,7 @@ window.Quarto = {
 <p>The following guidelines are meant to reflect these above principles, and ensure that all of our communications adhere to our vision:</p>
 <div id="listing-style-guide" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-2">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957116" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="6" data-listing-word-count-sort="1061">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646835" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="6" data-listing-word-count-sort="1061">
 <a href="../../../about/contributing/style-guide/voice-and-tone.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -530,7 +530,7 @@ While we work closely with technology, the ValidMind voice prefers a <strong>hum
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957115" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1745">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646835" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1745">
 <a href="../../../about/contributing/style-guide/conventions.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/about/glossary/glossary.html
+++ b/site/_site/about/glossary/glossary.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-06-18">
+<meta name="dcterms.date" content="2024-06-11">
 
 <title>Glossary – ValidMind</title>
 <style>
@@ -444,7 +444,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">June 18, 2024</p>
+      <p class="date">June 11, 2024</p>
     </div>
   </div>
   

--- a/site/_site/about/overview.html
+++ b/site/_site/about/overview.html
@@ -563,7 +563,7 @@ Content & Workflow management to track models and manage risks, governance, and 
 <h2 class="anchored" data-anchor-id="section">ValidMind AI risk platform</h2>
 <div id="listing-validmind-features" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-2">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957117" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="825">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646836" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="825">
 <a href="../about/overview-model-documentation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -577,7 +577,7 @@ The ValidMind Developer Framework streamlines the process of documenting various
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957118" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="8" data-listing-word-count-sort="1469">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646837" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="8" data-listing-word-count-sort="1469">
 <a href="../about/overview-model-risk-management.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/developer/get-started-developer-framework.html
+++ b/site/_site/developer/get-started-developer-framework.html
@@ -1913,7 +1913,7 @@ A collection of tests which are run together to generate model documentation end
 <p>After you <a href="https://app.prod.validmind.ai"><strong>sign up</strong></a> for ValidMind to get access, try one our getting started guide:</p>
 <div id="listing-developer-getting-started" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1719948866253" data-listing-reading-time-sort="10" data-listing-word-count-sort="1928">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949859" data-listing-reading-time-sort="10" data-listing-word-count-sort="1928">
 <a href="../notebooks/quickstart_customer_churn_full_suite.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1927,7 +1927,7 @@ Welcome! Let’s get you started with the basic process of documenting models wi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720036957198" data-listing-reading-time-sort="27" data-listing-word-count-sort="5344">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949859" data-listing-reading-time-sort="27" data-listing-word-count-sort="5344">
 <a href="../notebooks/tutorials/intro_for_model_developers.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1952,7 +1952,7 @@ No matching items
 <p>ValidMind provides many built-in tests and test suites which make it easy for developers to automate their model documentation. Start by running a pre-made test, then modify it, and finally create your own test:</p>
 <div id="listing-developer-how-to-beginner" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1719948866263" data-listing-reading-time-sort="9" data-listing-word-count-sort="1796">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949845" data-listing-reading-time-sort="9" data-listing-word-count-sort="1796">
 <a href="../notebooks/how_to/run_tests/1_run_dataset_based_tests.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1966,7 +1966,7 @@ Use the ValidMind Developer Framework’s <code>run_test</code> function to run 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1719948866253" data-listing-reading-time-sort="14" data-listing-word-count-sort="2776">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949841" data-listing-reading-time-sort="14" data-listing-word-count-sort="2776">
 <a href="../notebooks/code_samples/custom_tests/implement_custom_tests.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1992,7 +1992,7 @@ No matching items
 <p>Our code samples showcase the capabilities of the ValidMind Developer Framework. Examples that you can build on and adapt for your own use cases include:</p>
 <div id="listing-developer-code-samples" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1719948866258" data-listing-reading-time-sort="8" data-listing-word-count-sort="1418">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949840" data-listing-reading-time-sort="8" data-listing-word-count-sort="1418">
 <a href="../notebooks/code_samples/NLP_and_LLM/prompt_validation_demo.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/developer/model-testing/test-descriptions.html
+++ b/site/_site/developer/model-testing/test-descriptions.html
@@ -1811,7 +1811,7 @@ window.Quarto = {
 <div id="tabset-1-1" class="tab-pane active" role="tabpanel" aria-labelledby="tabset-1-1-tab">
 <div id="listing-data-validation" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1719948867687" data-listing-reading-time-sort="2" data-listing-word-count-sort="307">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949862" data-listing-reading-time-sort="2" data-listing-word-count-sort="307">
 <a href="../../tests/data_validation/ACFandPACFPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1825,7 +1825,7 @@ Analyzes time series data using Autocorrelation Function (ACF) and Partial Autoc
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1719948867688" data-listing-reading-time-sort="2" data-listing-word-count-sort="266">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949862" data-listing-reading-time-sort="2" data-listing-word-count-sort="266">
 <a href="../../tests/data_validation/ADF.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1839,7 +1839,7 @@ Assesses the stationarity of a time series dataset using the Augmented Dickey-Fu
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1719948867697" data-listing-reading-time-sort="2" data-listing-word-count-sort="366">
+<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720030949862" data-listing-reading-time-sort="2" data-listing-word-count-sort="366">
 <a href="../../tests/data_validation/ANOVAOneWayTable.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1853,7 +1853,7 @@ Applies one-way ANOVA (Analysis of Variance) to identify statistically significa
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1719948867687" data-listing-reading-time-sort="2" data-listing-word-count-sort="347">
+<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720030949862" data-listing-reading-time-sort="2" data-listing-word-count-sort="347">
 <a href="../../tests/data_validation/AutoAR.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1867,7 +1867,7 @@ Automatically identifies the optimal Autoregressive (AR) order for a time series
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1719948867695" data-listing-reading-time-sort="2" data-listing-word-count-sort="397">
+<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720030949863" data-listing-reading-time-sort="2" data-listing-word-count-sort="397">
 <a href="../../tests/data_validation/AutoMA.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1881,7 +1881,7 @@ Automatically selects the optimal Moving Average (MA) order for each variable in
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1719948867685" data-listing-reading-time-sort="2" data-listing-word-count-sort="365">
+<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720030949863" data-listing-reading-time-sort="2" data-listing-word-count-sort="365">
 <a href="../../tests/data_validation/AutoSeasonality.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1895,7 +1895,7 @@ Automatically identifies and quantifies optimal seasonality in time series data 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1719948867691" data-listing-reading-time-sort="2" data-listing-word-count-sort="353">
+<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1720030949863" data-listing-reading-time-sort="2" data-listing-word-count-sort="353">
 <a href="../../tests/data_validation/AutoStationarity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1909,7 +1909,7 @@ Automates Augmented Dickey-Fuller test to assess stationarity across multiple ti
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="7" data-listing-file-modified-sort="1719948867692" data-listing-reading-time-sort="2" data-listing-word-count-sort="352">
+<div class="g-col-1" data-index="7" data-listing-file-modified-sort="1720030949863" data-listing-reading-time-sort="2" data-listing-word-count-sort="352">
 <a href="../../tests/data_validation/BivariateFeaturesBarPlots.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1923,7 +1923,7 @@ Generates visual bar plots to analyze the relationship between paired features w
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="8" data-listing-file-modified-sort="1719948867687" data-listing-reading-time-sort="2" data-listing-word-count-sort="301">
+<div class="g-col-1" data-index="8" data-listing-file-modified-sort="1720030949863" data-listing-reading-time-sort="2" data-listing-word-count-sort="301">
 <a href="../../tests/data_validation/BivariateHistograms.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1937,7 +1937,7 @@ Generates bivariate histograms for paired features, aiding in visual inspection 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="9" data-listing-file-modified-sort="1719948867685" data-listing-reading-time-sort="2" data-listing-word-count-sort="346">
+<div class="g-col-1" data-index="9" data-listing-file-modified-sort="1720030949863" data-listing-reading-time-sort="2" data-listing-word-count-sort="346">
 <a href="../../tests/data_validation/BivariateScatterPlots.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1951,7 +1951,7 @@ Generates bivariate scatterplots to visually inspect relationships between pairs
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="10" data-listing-file-modified-sort="1719948867697" data-listing-reading-time-sort="2" data-listing-word-count-sort="349">
+<div class="g-col-1" data-index="10" data-listing-file-modified-sort="1720030949864" data-listing-reading-time-sort="2" data-listing-word-count-sort="349">
 <a href="../../tests/data_validation/ChiSquaredFeaturesTable.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1965,7 +1965,7 @@ Executes Chi-Squared test for each categorical feature against a target column t
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="11" data-listing-file-modified-sort="1719948867688" data-listing-reading-time-sort="2" data-listing-word-count-sort="369">
+<div class="g-col-1" data-index="11" data-listing-file-modified-sort="1720030949864" data-listing-reading-time-sort="2" data-listing-word-count-sort="369">
 <a href="../../tests/data_validation/ClassImbalance.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1979,7 +1979,7 @@ Evaluates and quantifies class distribution imbalance in a dataset used by a mac
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="12" data-listing-file-modified-sort="1719948867694" data-listing-reading-time-sort="2" data-listing-word-count-sort="281">
+<div class="g-col-1" data-index="12" data-listing-file-modified-sort="1720030949870" data-listing-reading-time-sort="2" data-listing-word-count-sort="281">
 <a href="../../tests/data_validation/nlp/CommonWords.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1993,7 +1993,7 @@ Identifies and visualizes the 40 most frequent non-stopwords in a specified text
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="13" data-listing-file-modified-sort="1719948867688" data-listing-reading-time-sort="2" data-listing-word-count-sort="307">
+<div class="g-col-1" data-index="13" data-listing-file-modified-sort="1720030949864" data-listing-reading-time-sort="2" data-listing-word-count-sort="307">
 <a href="../../tests/data_validation/DFGLSArch.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2007,7 +2007,7 @@ Executes Dickey-Fuller GLS metric to determine order of integration and check st
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="14" data-listing-file-modified-sort="1719948867694" data-listing-reading-time-sort="3" data-listing-word-count-sort="421">
+<div class="g-col-1" data-index="14" data-listing-file-modified-sort="1720030949864" data-listing-reading-time-sort="3" data-listing-word-count-sort="421">
 <a href="../../tests/data_validation/DatasetDescription.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2021,7 +2021,7 @@ Provides comprehensive analysis and statistical summaries of each field in a mac
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="15" data-listing-file-modified-sort="1719948867686" data-listing-reading-time-sort="2" data-listing-word-count-sort="303">
+<div class="g-col-1" data-index="15" data-listing-file-modified-sort="1720030949865" data-listing-reading-time-sort="2" data-listing-word-count-sort="303">
 <a href="../../tests/data_validation/DatasetSplit.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2035,7 +2035,7 @@ Evaluates and visualizes the distribution proportions among training, testing, a
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="16" data-listing-file-modified-sort="1719948867691" data-listing-reading-time-sort="2" data-listing-word-count-sort="346">
+<div class="g-col-1" data-index="16" data-listing-file-modified-sort="1720030949865" data-listing-reading-time-sort="2" data-listing-word-count-sort="346">
 <a href="../../tests/data_validation/DescriptiveStatistics.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2049,7 +2049,7 @@ Performs a detailed descriptive statistical analysis of both numerical and categ
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="17" data-listing-file-modified-sort="1719948867695" data-listing-reading-time-sort="2" data-listing-word-count-sort="307">
+<div class="g-col-1" data-index="17" data-listing-file-modified-sort="1720030949865" data-listing-reading-time-sort="2" data-listing-word-count-sort="307">
 <a href="../../tests/data_validation/Duplicates.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2063,7 +2063,7 @@ Tests dataset for duplicate entries, ensuring model reliability via data quality
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="18" data-listing-file-modified-sort="1719948867685" data-listing-reading-time-sort="2" data-listing-word-count-sort="331">
+<div class="g-col-1" data-index="18" data-listing-file-modified-sort="1720030949865" data-listing-reading-time-sort="2" data-listing-word-count-sort="331">
 <a href="../../tests/data_validation/EngleGrangerCoint.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2077,7 +2077,7 @@ Validates co-integration in pairs of time series data using the Engle-Granger te
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="19" data-listing-file-modified-sort="1719948867696" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
+<div class="g-col-1" data-index="19" data-listing-file-modified-sort="1720030949865" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
 <a href="../../tests/data_validation/FeatureTargetCorrelationPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2091,7 +2091,7 @@ Visualizes the correlation between input features and model’s target output in
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="20" data-listing-file-modified-sort="1719948867693" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
+<div class="g-col-1" data-index="20" data-listing-file-modified-sort="1720030949870" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
 <a href="../../tests/data_validation/nlp/Hashtags.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2105,7 +2105,7 @@ Assesses hashtag frequency in a text column, highlighting usage trends and poten
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="21" data-listing-file-modified-sort="1719948867686" data-listing-reading-time-sort="2" data-listing-word-count-sort="349">
+<div class="g-col-1" data-index="21" data-listing-file-modified-sort="1720030949865" data-listing-reading-time-sort="2" data-listing-word-count-sort="349">
 <a href="../../tests/data_validation/HeatmapFeatureCorrelations.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2119,7 +2119,7 @@ Creates a heatmap to visually represent correlation patterns between pairs of nu
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="22" data-listing-file-modified-sort="1719948867697" data-listing-reading-time-sort="2" data-listing-word-count-sort="286">
+<div class="g-col-1" data-index="22" data-listing-file-modified-sort="1720030949866" data-listing-reading-time-sort="2" data-listing-word-count-sort="286">
 <a href="../../tests/data_validation/HighCardinality.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2133,7 +2133,7 @@ Assesses the number of unique values in categorical columns to detect high cardi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="23" data-listing-file-modified-sort="1719948867687" data-listing-reading-time-sort="2" data-listing-word-count-sort="311">
+<div class="g-col-1" data-index="23" data-listing-file-modified-sort="1720030949866" data-listing-reading-time-sort="2" data-listing-word-count-sort="311">
 <a href="../../tests/data_validation/HighPearsonCorrelation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2147,7 +2147,7 @@ Identifies highly correlated feature pairs in a dataset suggesting feature redun
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="24" data-listing-file-modified-sort="1719948867688" data-listing-reading-time-sort="2" data-listing-word-count-sort="394">
+<div class="g-col-1" data-index="24" data-listing-file-modified-sort="1720030949866" data-listing-reading-time-sort="2" data-listing-word-count-sort="394">
 <a href="../../tests/data_validation/IQROutliersBarPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2161,7 +2161,7 @@ Visualizes outlier distribution across percentiles in numerical data using Inter
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="25" data-listing-file-modified-sort="1719948867692" data-listing-reading-time-sort="2" data-listing-word-count-sort="384">
+<div class="g-col-1" data-index="25" data-listing-file-modified-sort="1720030949866" data-listing-reading-time-sort="2" data-listing-word-count-sort="384">
 <a href="../../tests/data_validation/IQROutliersTable.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2175,7 +2175,7 @@ Determines and summarizes outliers in numerical features using Interquartile Ran
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="26" data-listing-file-modified-sort="1719948867698" data-listing-reading-time-sort="2" data-listing-word-count-sort="284">
+<div class="g-col-1" data-index="26" data-listing-file-modified-sort="1720030949866" data-listing-reading-time-sort="2" data-listing-word-count-sort="284">
 <a href="../../tests/data_validation/IsolationForestOutliers.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2189,7 +2189,7 @@ Detects outliers in a dataset using the Isolation Forest algorithm and visualize
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="27" data-listing-file-modified-sort="1719948867685" data-listing-reading-time-sort="2" data-listing-word-count-sort="280">
+<div class="g-col-1" data-index="27" data-listing-file-modified-sort="1720030949866" data-listing-reading-time-sort="2" data-listing-word-count-sort="280">
 <a href="../../tests/data_validation/KPSS.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2203,7 +2203,7 @@ Executes KPSS unit root test to validate stationarity of time-series data in mac
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="28" data-listing-file-modified-sort="1719948867689" data-listing-reading-time-sort="2" data-listing-word-count-sort="308">
+<div class="g-col-1" data-index="28" data-listing-file-modified-sort="1720030949867" data-listing-reading-time-sort="2" data-listing-word-count-sort="308">
 <a href="../../tests/data_validation/LaggedCorrelationHeatmap.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2217,7 +2217,7 @@ Assesses and visualizes correlation between target variable and lagged independe
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="29" data-listing-file-modified-sort="1720036957228" data-listing-reading-time-sort="1" data-listing-word-count-sort="107">
+<div class="g-col-1" data-index="29" data-listing-file-modified-sort="1720030949870" data-listing-reading-time-sort="1" data-listing-word-count-sort="107">
 <a href="../../tests/data_validation/nlp/LanguageDetection.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2231,7 +2231,7 @@ Detects the language of each text entry in a dataset and visualizes the distribu
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="30" data-listing-file-modified-sort="1719948867693" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
+<div class="g-col-1" data-index="30" data-listing-file-modified-sort="1720030949870" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
 <a href="../../tests/data_validation/nlp/Mentions.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2245,7 +2245,7 @@ Calculates and visualizes frequencies of ‘@’ prefixed mentions in a text-bas
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="31" data-listing-file-modified-sort="1719948867697" data-listing-reading-time-sort="2" data-listing-word-count-sort="308">
+<div class="g-col-1" data-index="31" data-listing-file-modified-sort="1720030949867" data-listing-reading-time-sort="2" data-listing-word-count-sort="308">
 <a href="../../tests/data_validation/MissingValues.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2259,7 +2259,7 @@ Evaluates dataset quality by ensuring missing value ratio across all features do
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="32" data-listing-file-modified-sort="1719948867695" data-listing-reading-time-sort="2" data-listing-word-count-sort="354">
+<div class="g-col-1" data-index="32" data-listing-file-modified-sort="1720030949867" data-listing-reading-time-sort="2" data-listing-word-count-sort="354">
 <a href="../../tests/data_validation/MissingValuesBarPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2273,7 +2273,7 @@ Creates a bar plot showcasing the percentage of missing values in each column of
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="33" data-listing-file-modified-sort="1719948867692" data-listing-reading-time-sort="2" data-listing-word-count-sort="326">
+<div class="g-col-1" data-index="33" data-listing-file-modified-sort="1720030949867" data-listing-reading-time-sort="2" data-listing-word-count-sort="326">
 <a href="../../tests/data_validation/MissingValuesRisk.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2287,7 +2287,7 @@ Assesses and quantifies the risk related to missing values in a dataset used for
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="34" data-listing-file-modified-sort="1719948867696" data-listing-reading-time-sort="2" data-listing-word-count-sort="338">
+<div class="g-col-1" data-index="34" data-listing-file-modified-sort="1720030949867" data-listing-reading-time-sort="2" data-listing-word-count-sort="338">
 <a href="../../tests/data_validation/PearsonCorrelationMatrix.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2301,7 +2301,7 @@ Evaluates linear dependency between numerical variables in a dataset via a Pears
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="35" data-listing-file-modified-sort="1719948867696" data-listing-reading-time-sort="2" data-listing-word-count-sort="269">
+<div class="g-col-1" data-index="35" data-listing-file-modified-sort="1720030949867" data-listing-reading-time-sort="2" data-listing-word-count-sort="269">
 <a href="../../tests/data_validation/PhillipsPerronArch.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2315,7 +2315,7 @@ Executes Phillips-Perron test to assess the stationarity of time series data in 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="36" data-listing-file-modified-sort="1720036957228" data-listing-reading-time-sort="1" data-listing-word-count-sort="66">
+<div class="g-col-1" data-index="36" data-listing-file-modified-sort="1720030949871" data-listing-reading-time-sort="1" data-listing-word-count-sort="66">
 <a href="../../tests/data_validation/nlp/PolarityAndSubjectivity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2329,7 +2329,7 @@ Analyzes the polarity and subjectivity of text data within a dataset.
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="37" data-listing-file-modified-sort="1719948867693" data-listing-reading-time-sort="2" data-listing-word-count-sort="268">
+<div class="g-col-1" data-index="37" data-listing-file-modified-sort="1720030949871" data-listing-reading-time-sort="2" data-listing-word-count-sort="268">
 <a href="../../tests/data_validation/nlp/Punctuations.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2343,7 +2343,7 @@ Analyzes and visualizes the frequency distribution of punctuation usage in a giv
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="38" data-listing-file-modified-sort="1719948867695" data-listing-reading-time-sort="2" data-listing-word-count-sort="391">
+<div class="g-col-1" data-index="38" data-listing-file-modified-sort="1720030949867" data-listing-reading-time-sort="2" data-listing-word-count-sort="391">
 <a href="../../tests/data_validation/RollingStatsPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2357,7 +2357,7 @@ This test evaluates the stationarity of time series data by plotting its rolling
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="39" data-listing-file-modified-sort="1719948867690" data-listing-reading-time-sort="2" data-listing-word-count-sort="361">
+<div class="g-col-1" data-index="39" data-listing-file-modified-sort="1720030949867" data-listing-reading-time-sort="2" data-listing-word-count-sort="361">
 <a href="../../tests/data_validation/ScatterPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2371,7 +2371,7 @@ Creates a scatter plot matrix to visually analyze feature relationships, pattern
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="40" data-listing-file-modified-sort="1719948867689" data-listing-reading-time-sort="2" data-listing-word-count-sort="289">
+<div class="g-col-1" data-index="40" data-listing-file-modified-sort="1720030949867" data-listing-reading-time-sort="2" data-listing-word-count-sort="289">
 <a href="../../tests/data_validation/SeasonalDecompose.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2385,7 +2385,7 @@ Decomposes dataset features into observed, trend, seasonal, and residual compone
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="41" data-listing-file-modified-sort="1720036957228" data-listing-reading-time-sort="1" data-listing-word-count-sort="80">
+<div class="g-col-1" data-index="41" data-listing-file-modified-sort="1720030949871" data-listing-reading-time-sort="1" data-listing-word-count-sort="80">
 <a href="../../tests/data_validation/nlp/Sentiment.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2399,7 +2399,7 @@ Analyzes the sentiment of text data within a dataset using the VADER sentiment a
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="42" data-listing-file-modified-sort="1719948867691" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
+<div class="g-col-1" data-index="42" data-listing-file-modified-sort="1720030949868" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
 <a href="../../tests/data_validation/Skewness.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2413,7 +2413,7 @@ Evaluates the skewness of numerical data in a machine learning model and checks 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="43" data-listing-file-modified-sort="1719948867687" data-listing-reading-time-sort="2" data-listing-word-count-sort="297">
+<div class="g-col-1" data-index="43" data-listing-file-modified-sort="1720030949868" data-listing-reading-time-sort="2" data-listing-word-count-sort="297">
 <a href="../../tests/data_validation/SpreadPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2427,7 +2427,7 @@ Visualizes the spread relationship between pairs of time-series variables in a d
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="44" data-listing-file-modified-sort="1719948867693" data-listing-reading-time-sort="2" data-listing-word-count-sort="389">
+<div class="g-col-1" data-index="44" data-listing-file-modified-sort="1720030949871" data-listing-reading-time-sort="2" data-listing-word-count-sort="389">
 <a href="../../tests/data_validation/nlp/StopWords.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2441,7 +2441,7 @@ Evaluates and visualizes the frequency of English stop words in a text dataset a
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="45" data-listing-file-modified-sort="1719948867691" data-listing-reading-time-sort="2" data-listing-word-count-sort="266">
+<div class="g-col-1" data-index="45" data-listing-file-modified-sort="1720030949868" data-listing-reading-time-sort="2" data-listing-word-count-sort="266">
 <a href="../../tests/data_validation/TabularCategoricalBarPlots.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2455,7 +2455,7 @@ Generates and visualizes bar plots for each category in categorical features to 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="46" data-listing-file-modified-sort="1719948867689" data-listing-reading-time-sort="2" data-listing-word-count-sort="308">
+<div class="g-col-1" data-index="46" data-listing-file-modified-sort="1720030949868" data-listing-reading-time-sort="2" data-listing-word-count-sort="308">
 <a href="../../tests/data_validation/TabularDateTimeHistograms.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2469,7 +2469,7 @@ Generates histograms to provide graphical insight into the distribution of time 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="47" data-listing-file-modified-sort="1719948867695" data-listing-reading-time-sort="2" data-listing-word-count-sort="355">
+<div class="g-col-1" data-index="47" data-listing-file-modified-sort="1720030949868" data-listing-reading-time-sort="2" data-listing-word-count-sort="355">
 <a href="../../tests/data_validation/TabularDescriptionTables.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2483,7 +2483,7 @@ Summarizes key descriptive statistics for numerical, categorical, and datetime v
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="48" data-listing-file-modified-sort="1719948867698" data-listing-reading-time-sort="2" data-listing-word-count-sort="303">
+<div class="g-col-1" data-index="48" data-listing-file-modified-sort="1720030949868" data-listing-reading-time-sort="2" data-listing-word-count-sort="303">
 <a href="../../tests/data_validation/TabularNumericalHistograms.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2497,7 +2497,7 @@ Generates histograms for each numerical feature in a dataset to provide visual i
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="49" data-listing-file-modified-sort="1719948867697" data-listing-reading-time-sort="2" data-listing-word-count-sort="300">
+<div class="g-col-1" data-index="49" data-listing-file-modified-sort="1720030949869" data-listing-reading-time-sort="2" data-listing-word-count-sort="300">
 <a href="../../tests/data_validation/TargetRateBarPlots.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2511,7 +2511,7 @@ Generates bar plots visualizing the default rates of categorical features for a 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="50" data-listing-file-modified-sort="1719948867693" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
+<div class="g-col-1" data-index="50" data-listing-file-modified-sort="1720030949871" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
 <a href="../../tests/data_validation/nlp/TextDescription.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2525,7 +2525,7 @@ Performs comprehensive textual analysis on a dataset using NLTK, evaluating vari
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="51" data-listing-file-modified-sort="1720036957227" data-listing-reading-time-sort="2" data-listing-word-count-sort="235">
+<div class="g-col-1" data-index="51" data-listing-file-modified-sort="1720030949869" data-listing-reading-time-sort="2" data-listing-word-count-sort="235">
 <a href="../../tests/data_validation/TimeSeriesDescription.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2539,7 +2539,7 @@ Generates a detailed analysis for the provided time series dataset.
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="52" data-listing-file-modified-sort="1720036957227" data-listing-reading-time-sort="2" data-listing-word-count-sort="223">
+<div class="g-col-1" data-index="52" data-listing-file-modified-sort="1720030949869" data-listing-reading-time-sort="2" data-listing-word-count-sort="223">
 <a href="../../tests/data_validation/TimeSeriesDescriptiveStatistics.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2553,7 +2553,7 @@ Generates a detailed table of descriptive statistics for the provided time serie
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="53" data-listing-file-modified-sort="1719948867686" data-listing-reading-time-sort="2" data-listing-word-count-sort="343">
+<div class="g-col-1" data-index="53" data-listing-file-modified-sort="1720030949869" data-listing-reading-time-sort="2" data-listing-word-count-sort="343">
 <a href="../../tests/data_validation/TimeSeriesFrequency.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2567,7 +2567,7 @@ Evaluates consistency of time series data frequency and generates a frequency pl
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="54" data-listing-file-modified-sort="1720036957228" data-listing-reading-time-sort="2" data-listing-word-count-sort="344">
+<div class="g-col-1" data-index="54" data-listing-file-modified-sort="1720030949869" data-listing-reading-time-sort="2" data-listing-word-count-sort="344">
 <a href="../../tests/data_validation/TimeSeriesHistogram.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2581,7 +2581,7 @@ Visualizes distribution of time-series data using histograms and Kernel Density 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="55" data-listing-file-modified-sort="1719948867685" data-listing-reading-time-sort="2" data-listing-word-count-sort="320">
+<div class="g-col-1" data-index="55" data-listing-file-modified-sort="1720030949869" data-listing-reading-time-sort="2" data-listing-word-count-sort="320">
 <a href="../../tests/data_validation/TimeSeriesLinePlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2595,7 +2595,7 @@ Generates and analyses time-series data through line plots revealing trends, pat
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="56" data-listing-file-modified-sort="1719948867690" data-listing-reading-time-sort="2" data-listing-word-count-sort="380">
+<div class="g-col-1" data-index="56" data-listing-file-modified-sort="1720030949869" data-listing-reading-time-sort="2" data-listing-word-count-sort="380">
 <a href="../../tests/data_validation/TimeSeriesMissingValues.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2609,7 +2609,7 @@ Validates time-series data quality by confirming the count of missing values is 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="57" data-listing-file-modified-sort="1719948867690" data-listing-reading-time-sort="2" data-listing-word-count-sort="380">
+<div class="g-col-1" data-index="57" data-listing-file-modified-sort="1720030949869" data-listing-reading-time-sort="2" data-listing-word-count-sort="380">
 <a href="../../tests/data_validation/TimeSeriesOutliers.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2623,7 +2623,7 @@ Identifies and visualizes outliers in time-series data using z-score method.
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="58" data-listing-file-modified-sort="1719948867696" data-listing-reading-time-sort="3" data-listing-word-count-sort="443">
+<div class="g-col-1" data-index="58" data-listing-file-modified-sort="1720030949869" data-listing-reading-time-sort="3" data-listing-word-count-sort="443">
 <a href="../../tests/data_validation/TooManyZeroValues.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2637,7 +2637,7 @@ Identifies numerical columns in a dataset that contain an excessive number of ze
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="59" data-listing-file-modified-sort="1720036957228" data-listing-reading-time-sort="1" data-listing-word-count-sort="80">
+<div class="g-col-1" data-index="59" data-listing-file-modified-sort="1720030949871" data-listing-reading-time-sort="1" data-listing-word-count-sort="80">
 <a href="../../tests/data_validation/nlp/Toxicity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2651,7 +2651,7 @@ Analyzes the toxicity of text data within a dataset using a pre-trained toxicity
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="60" data-listing-file-modified-sort="1719948867696" data-listing-reading-time-sort="2" data-listing-word-count-sort="330">
+<div class="g-col-1" data-index="60" data-listing-file-modified-sort="1720030949870" data-listing-reading-time-sort="2" data-listing-word-count-sort="330">
 <a href="../../tests/data_validation/UniqueRows.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2665,7 +2665,7 @@ Verifies the diversity of the dataset by ensuring that the count of unique rows 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="61" data-listing-file-modified-sort="1719948867690" data-listing-reading-time-sort="2" data-listing-word-count-sort="368">
+<div class="g-col-1" data-index="61" data-listing-file-modified-sort="1720030949870" data-listing-reading-time-sort="2" data-listing-word-count-sort="368">
 <a href="../../tests/data_validation/WOEBinPlots.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2679,7 +2679,7 @@ Generates visualizations of Weight of Evidence (WoE) and Information Value (IV) 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="62" data-listing-file-modified-sort="1719948867686" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
+<div class="g-col-1" data-index="62" data-listing-file-modified-sort="1720030949870" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
 <a href="../../tests/data_validation/WOEBinTable.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2693,7 +2693,7 @@ Calculates and assesses the Weight of Evidence (WoE) and Information Value (IV) 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="63" data-listing-file-modified-sort="1719948867694" data-listing-reading-time-sort="2" data-listing-word-count-sort="299">
+<div class="g-col-1" data-index="63" data-listing-file-modified-sort="1720030949870" data-listing-reading-time-sort="2" data-listing-word-count-sort="299">
 <a href="../../tests/data_validation/ZivotAndrewsArch.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2716,7 +2716,7 @@ No matching items
 <div id="tabset-1-2" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-2-tab">
 <div id="listing-model-validation" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1719948867675" data-listing-reading-time-sort="2" data-listing-word-count-sort="301">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949878" data-listing-reading-time-sort="2" data-listing-word-count-sort="301">
 <a href="../../tests/model_validation/sklearn/AdjustedMutualInformation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2730,7 +2730,7 @@ Evaluates clustering model performance by measuring mutual information between t
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1719948867674" data-listing-reading-time-sort="2" data-listing-word-count-sort="285">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949879" data-listing-reading-time-sort="2" data-listing-word-count-sort="285">
 <a href="../../tests/model_validation/sklearn/AdjustedRandIndex.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2744,7 +2744,7 @@ Measures the similarity between two data clusters using the Adjusted Rand Index 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720036957232" data-listing-reading-time-sort="2" data-listing-word-count-sort="335">
+<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720030949877" data-listing-reading-time-sort="2" data-listing-word-count-sort="335">
 <a href="../../tests/model_validation/ragas/AnswerCorrectness.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2758,7 +2758,7 @@ Evaluates the correctness of answers in a dataset with respect to the provided g
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720036957232" data-listing-reading-time-sort="2" data-listing-word-count-sort="287">
+<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720030949877" data-listing-reading-time-sort="2" data-listing-word-count-sort="287">
 <a href="../../tests/model_validation/ragas/AnswerRelevance.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2772,7 +2772,7 @@ Assesses how pertinent the generated answer is to the given prompt.
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720036957232" data-listing-reading-time-sort="2" data-listing-word-count-sort="244">
+<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720030949877" data-listing-reading-time-sort="2" data-listing-word-count-sort="244">
 <a href="../../tests/model_validation/ragas/AnswerSimilarity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2786,7 +2786,7 @@ Calculates the semantic similarity between generated answers and ground truths
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720036957233" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
+<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720030949877" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
 <a href="../../tests/model_validation/ragas/AspectCritique.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2800,7 +2800,7 @@ Evaluates generations against the following aspects: harmfulness, maliciousness,
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1719948867681" data-listing-reading-time-sort="2" data-listing-word-count-sort="389">
+<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1720030949885" data-listing-reading-time-sort="2" data-listing-word-count-sort="389">
 <a href="../../tests/model_validation/statsmodels/AutoARIMA.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2814,7 +2814,7 @@ Evaluates ARIMA models for time-series forecasting, ranking them using Bayesian 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="7" data-listing-file-modified-sort="1720036957229" data-listing-reading-time-sort="2" data-listing-word-count-sort="343">
+<div class="g-col-1" data-index="7" data-listing-file-modified-sort="1720030949872" data-listing-reading-time-sort="2" data-listing-word-count-sort="343">
 <a href="../../tests/model_validation/BertScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2828,7 +2828,7 @@ Evaluates the quality of machine-generated text using BERTScore metrics and visu
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="8" data-listing-file-modified-sort="1720036957229" data-listing-reading-time-sort="2" data-listing-word-count-sort="368">
+<div class="g-col-1" data-index="8" data-listing-file-modified-sort="1720030949872" data-listing-reading-time-sort="2" data-listing-word-count-sort="368">
 <a href="../../tests/model_validation/BleuScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2842,7 +2842,7 @@ Evaluates the quality of machine-generated text using BLEU metrics and visualize
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="9" data-listing-file-modified-sort="1719948867683" data-listing-reading-time-sort="2" data-listing-word-count-sort="316">
+<div class="g-col-1" data-index="9" data-listing-file-modified-sort="1720030949886" data-listing-reading-time-sort="2" data-listing-word-count-sort="316">
 <a href="../../tests/model_validation/statsmodels/BoxPierce.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2856,7 +2856,7 @@ Detects autocorrelation in time-series data through the Box-Pierce test to valid
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="10" data-listing-file-modified-sort="1719948867677" data-listing-reading-time-sort="2" data-listing-word-count-sort="322">
+<div class="g-col-1" data-index="10" data-listing-file-modified-sort="1720030949879" data-listing-reading-time-sort="2" data-listing-word-count-sort="322">
 <a href="../../tests/model_validation/sklearn/ClassifierPerformance.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2870,7 +2870,7 @@ Evaluates performance of binary or multiclass classification models using precis
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="11" data-listing-file-modified-sort="1719948867676" data-listing-reading-time-sort="2" data-listing-word-count-sort="386">
+<div class="g-col-1" data-index="11" data-listing-file-modified-sort="1720030949879" data-listing-reading-time-sort="2" data-listing-word-count-sort="386">
 <a href="../../tests/model_validation/sklearn/ClusterCosineSimilarity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2884,7 +2884,7 @@ Measures the intra-cluster similarity of a clustering model using cosine similar
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="12" data-listing-file-modified-sort="1719948867666" data-listing-reading-time-sort="2" data-listing-word-count-sort="332">
+<div class="g-col-1" data-index="12" data-listing-file-modified-sort="1720030949875" data-listing-reading-time-sort="2" data-listing-word-count-sort="332">
 <a href="../../tests/model_validation/embeddings/ClusterDistribution.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2898,7 +2898,7 @@ Assesses the distribution of text embeddings across clusters produced by a model
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="13" data-listing-file-modified-sort="1719948867671" data-listing-reading-time-sort="2" data-listing-word-count-sort="353">
+<div class="g-col-1" data-index="13" data-listing-file-modified-sort="1720030949879" data-listing-reading-time-sort="2" data-listing-word-count-sort="353">
 <a href="../../tests/model_validation/sklearn/ClusterPerformance.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2912,7 +2912,7 @@ Evaluates and compares a clustering model’s performance on training and testin
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="14" data-listing-file-modified-sort="1719948867676" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
+<div class="g-col-1" data-index="14" data-listing-file-modified-sort="1720030949880" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
 <a href="../../tests/model_validation/sklearn/ClusterPerformanceMetrics.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2926,7 +2926,7 @@ Evaluates the performance of clustering machine learning models using multiple e
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="15" data-listing-file-modified-sort="1719948867667" data-listing-reading-time-sort="2" data-listing-word-count-sort="298">
+<div class="g-col-1" data-index="15" data-listing-file-modified-sort="1720030949872" data-listing-reading-time-sort="2" data-listing-word-count-sort="298">
 <a href="../../tests/model_validation/ClusterSizeDistribution.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2940,7 +2940,7 @@ Compares and visualizes the distribution of cluster sizes in model predictions a
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="16" data-listing-file-modified-sort="1719948867673" data-listing-reading-time-sort="2" data-listing-word-count-sort="255">
+<div class="g-col-1" data-index="16" data-listing-file-modified-sort="1720030949880" data-listing-reading-time-sort="2" data-listing-word-count-sort="255">
 <a href="../../tests/model_validation/sklearn/CompletenessScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2954,7 +2954,7 @@ Evaluates a clustering model’s capacity to categorize instances from a single 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="17" data-listing-file-modified-sort="1719948867674" data-listing-reading-time-sort="2" data-listing-word-count-sort="382">
+<div class="g-col-1" data-index="17" data-listing-file-modified-sort="1720030949880" data-listing-reading-time-sort="2" data-listing-word-count-sort="382">
 <a href="../../tests/model_validation/sklearn/ConfusionMatrix.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2968,7 +2968,7 @@ Evaluates and visually represents the classification ML model’s predictive per
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="18" data-listing-file-modified-sort="1720036957233" data-listing-reading-time-sort="2" data-listing-word-count-sort="298">
+<div class="g-col-1" data-index="18" data-listing-file-modified-sort="1720030949878" data-listing-reading-time-sort="2" data-listing-word-count-sort="298">
 <a href="../../tests/model_validation/ragas/ContextEntityRecall.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2982,7 +2982,7 @@ Evaluates the context entity recall for dataset entries and visualizes the resul
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="19" data-listing-file-modified-sort="1720036957233" data-listing-reading-time-sort="2" data-listing-word-count-sort="245">
+<div class="g-col-1" data-index="19" data-listing-file-modified-sort="1720030949878" data-listing-reading-time-sort="2" data-listing-word-count-sort="245">
 <a href="../../tests/model_validation/ragas/ContextPrecision.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2996,7 +2996,7 @@ Context Precision is a metric that evaluates whether all of the ground-truth rel
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="20" data-listing-file-modified-sort="1720036957233" data-listing-reading-time-sort="2" data-listing-word-count-sort="254">
+<div class="g-col-1" data-index="20" data-listing-file-modified-sort="1720030949878" data-listing-reading-time-sort="2" data-listing-word-count-sort="254">
 <a href="../../tests/model_validation/ragas/ContextRecall.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3010,7 +3010,7 @@ Context recall measures the extent to which the retrieved context aligns with th
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="21" data-listing-file-modified-sort="1720036957233" data-listing-reading-time-sort="2" data-listing-word-count-sort="221">
+<div class="g-col-1" data-index="21" data-listing-file-modified-sort="1720030949878" data-listing-reading-time-sort="2" data-listing-word-count-sort="221">
 <a href="../../tests/model_validation/ragas/ContextRelevancy.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3024,7 +3024,7 @@ Evaluates the context relevancy metric for entries in a dataset and visualizes t
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="22" data-listing-file-modified-sort="1720036957229" data-listing-reading-time-sort="2" data-listing-word-count-sort="379">
+<div class="g-col-1" data-index="22" data-listing-file-modified-sort="1720030949873" data-listing-reading-time-sort="2" data-listing-word-count-sort="379">
 <a href="../../tests/model_validation/ContextualRecall.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3038,7 +3038,7 @@ Evaluates a Natural Language Generation model’s ability to generate contextual
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="23" data-listing-file-modified-sort="1720036957231" data-listing-reading-time-sort="2" data-listing-word-count-sort="349">
+<div class="g-col-1" data-index="23" data-listing-file-modified-sort="1720030949875" data-listing-reading-time-sort="2" data-listing-word-count-sort="349">
 <a href="../../tests/model_validation/embeddings/CosineSimilarityComparison.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3052,7 +3052,7 @@ Computes pairwise cosine similarities between model embeddings and visualizes th
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="24" data-listing-file-modified-sort="1719948867667" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
+<div class="g-col-1" data-index="24" data-listing-file-modified-sort="1720030949875" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
 <a href="../../tests/model_validation/embeddings/CosineSimilarityDistribution.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3066,7 +3066,7 @@ Assesses the similarity between predicted text embeddings from a model using a C
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="25" data-listing-file-modified-sort="1720036957231" data-listing-reading-time-sort="2" data-listing-word-count-sort="290">
+<div class="g-col-1" data-index="25" data-listing-file-modified-sort="1720030949875" data-listing-reading-time-sort="2" data-listing-word-count-sort="290">
 <a href="../../tests/model_validation/embeddings/CosineSimilarityHeatmap.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3080,7 +3080,7 @@ Generates an interactive heatmap to visualize the cosine similarities among embe
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="26" data-listing-file-modified-sort="1719948867680" data-listing-reading-time-sort="2" data-listing-word-count-sort="337">
+<div class="g-col-1" data-index="26" data-listing-file-modified-sort="1720030949886" data-listing-reading-time-sort="2" data-listing-word-count-sort="337">
 <a href="../../tests/model_validation/statsmodels/CumulativePredictionProbabilities.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3094,7 +3094,7 @@ Visualizes cumulative probabilities of positive and negative classes for both tr
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="27" data-listing-file-modified-sort="1719948867665" data-listing-reading-time-sort="2" data-listing-word-count-sort="305">
+<div class="g-col-1" data-index="27" data-listing-file-modified-sort="1720030949876" data-listing-reading-time-sort="2" data-listing-word-count-sort="305">
 <a href="../../tests/model_validation/embeddings/DescriptiveAnalytics.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3108,7 +3108,7 @@ Evaluates statistical properties of text embeddings in an ML model via mean, med
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="28" data-listing-file-modified-sort="1719948867681" data-listing-reading-time-sort="2" data-listing-word-count-sort="252">
+<div class="g-col-1" data-index="28" data-listing-file-modified-sort="1720030949886" data-listing-reading-time-sort="2" data-listing-word-count-sort="252">
 <a href="../../tests/model_validation/statsmodels/DurbinWatsonTest.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3122,7 +3122,7 @@ Assesses autocorrelation in time series data features using the Durbin-Watson st
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="29" data-listing-file-modified-sort="1719948867666" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
+<div class="g-col-1" data-index="29" data-listing-file-modified-sort="1720030949876" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
 <a href="../../tests/model_validation/embeddings/EmbeddingsVisualization2D.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3136,7 +3136,7 @@ Visualizes 2D representation of text embeddings generated by a model using t-SNE
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="30" data-listing-file-modified-sort="1720036957231" data-listing-reading-time-sort="2" data-listing-word-count-sort="304">
+<div class="g-col-1" data-index="30" data-listing-file-modified-sort="1720030949876" data-listing-reading-time-sort="2" data-listing-word-count-sort="304">
 <a href="../../tests/model_validation/embeddings/EuclideanDistanceComparison.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3150,7 +3150,7 @@ Computes pairwise Euclidean distances between model embeddings and visualizes th
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="31" data-listing-file-modified-sort="1720036957232" data-listing-reading-time-sort="2" data-listing-word-count-sort="256">
+<div class="g-col-1" data-index="31" data-listing-file-modified-sort="1720030949876" data-listing-reading-time-sort="2" data-listing-word-count-sort="256">
 <a href="../../tests/model_validation/embeddings/EuclideanDistanceHeatmap.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3164,7 +3164,7 @@ Generates an interactive heatmap to visualize the Euclidean distances among embe
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="32" data-listing-file-modified-sort="1720036957233" data-listing-reading-time-sort="2" data-listing-word-count-sort="286">
+<div class="g-col-1" data-index="32" data-listing-file-modified-sort="1720030949878" data-listing-reading-time-sort="2" data-listing-word-count-sort="286">
 <a href="../../tests/model_validation/ragas/Faithfulness.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3178,7 +3178,7 @@ Evaluates the faithfulness of the generated answers with respect to retrieved co
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="33" data-listing-file-modified-sort="1720036957234" data-listing-reading-time-sort="1" data-listing-word-count-sort="178">
+<div class="g-col-1" data-index="33" data-listing-file-modified-sort="1720030949880" data-listing-reading-time-sort="1" data-listing-word-count-sort="178">
 <a href="../../tests/model_validation/sklearn/FeatureImportanceComparison.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3192,7 +3192,7 @@ Compare feature importance scores for each model and generate a summary table wi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="34" data-listing-file-modified-sort="1719948867678" data-listing-reading-time-sort="2" data-listing-word-count-sort="277">
+<div class="g-col-1" data-index="34" data-listing-file-modified-sort="1720030949873" data-listing-reading-time-sort="2" data-listing-word-count-sort="277">
 <a href="../../tests/model_validation/FeaturesAUC.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3206,7 +3206,7 @@ Evaluates the discriminatory power of each individual feature within a binary cl
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="35" data-listing-file-modified-sort="1719948867678" data-listing-reading-time-sort="2" data-listing-word-count-sort="298">
+<div class="g-col-1" data-index="35" data-listing-file-modified-sort="1720030949881" data-listing-reading-time-sort="2" data-listing-word-count-sort="298">
 <a href="../../tests/model_validation/sklearn/FowlkesMallowsScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3220,7 +3220,7 @@ Evaluates the similarity between predicted and actual cluster assignments in a m
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="36" data-listing-file-modified-sort="1719948867682" data-listing-reading-time-sort="2" data-listing-word-count-sort="397">
+<div class="g-col-1" data-index="36" data-listing-file-modified-sort="1720030949887" data-listing-reading-time-sort="2" data-listing-word-count-sort="397">
 <a href="../../tests/model_validation/statsmodels/GINITable.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3234,7 +3234,7 @@ Evaluates classification model performance using AUC, GINI, and KS metrics for t
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="37" data-listing-file-modified-sort="1719948867673" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
+<div class="g-col-1" data-index="37" data-listing-file-modified-sort="1720030949881" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
 <a href="../../tests/model_validation/sklearn/HomogeneityScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3248,7 +3248,7 @@ Assesses clustering homogeneity by comparing true and predicted labels, scoring 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="38" data-listing-file-modified-sort="1719948867672" data-listing-reading-time-sort="2" data-listing-word-count-sort="348">
+<div class="g-col-1" data-index="38" data-listing-file-modified-sort="1720030949881" data-listing-reading-time-sort="2" data-listing-word-count-sort="348">
 <a href="../../tests/model_validation/sklearn/HyperParametersTuning.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3262,7 +3262,7 @@ Exerts exhaustive grid search to identify optimal hyperparameters for the model,
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="39" data-listing-file-modified-sort="1719948867684" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
+<div class="g-col-1" data-index="39" data-listing-file-modified-sort="1720030949887" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
 <a href="../../tests/model_validation/statsmodels/JarqueBera.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3276,7 +3276,7 @@ Assesses normality of dataset features in an ML model using the Jarque-Bera test
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="40" data-listing-file-modified-sort="1719948867672" data-listing-reading-time-sort="2" data-listing-word-count-sort="384">
+<div class="g-col-1" data-index="40" data-listing-file-modified-sort="1720030949881" data-listing-reading-time-sort="2" data-listing-word-count-sort="384">
 <a href="../../tests/model_validation/sklearn/KMeansClustersOptimization.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3290,7 +3290,7 @@ Optimizes the number of clusters in K-means models using Elbow and Silhouette me
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="41" data-listing-file-modified-sort="1719948867684" data-listing-reading-time-sort="2" data-listing-word-count-sort="305">
+<div class="g-col-1" data-index="41" data-listing-file-modified-sort="1720030949887" data-listing-reading-time-sort="2" data-listing-word-count-sort="305">
 <a href="../../tests/model_validation/statsmodels/KolmogorovSmirnov.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3304,7 +3304,7 @@ Executes a feature-wise Kolmogorov-Smirnov test to evaluate alignment with norma
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="42" data-listing-file-modified-sort="1719948867684" data-listing-reading-time-sort="2" data-listing-word-count-sort="286">
+<div class="g-col-1" data-index="42" data-listing-file-modified-sort="1720030949887" data-listing-reading-time-sort="2" data-listing-word-count-sort="286">
 <a href="../../tests/model_validation/statsmodels/LJungBox.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3318,7 +3318,7 @@ Assesses autocorrelations in dataset features by performing a Ljung-Box test on 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="43" data-listing-file-modified-sort="1719948867680" data-listing-reading-time-sort="2" data-listing-word-count-sort="390">
+<div class="g-col-1" data-index="43" data-listing-file-modified-sort="1720030949887" data-listing-reading-time-sort="2" data-listing-word-count-sort="390">
 <a href="../../tests/model_validation/statsmodels/Lilliefors.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3332,7 +3332,7 @@ Assesses the normality of feature distributions in an ML model’s training data
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="44" data-listing-file-modified-sort="1720036957229" data-listing-reading-time-sort="2" data-listing-word-count-sort="354">
+<div class="g-col-1" data-index="44" data-listing-file-modified-sort="1720030949873" data-listing-reading-time-sort="2" data-listing-word-count-sort="354">
 <a href="../../tests/model_validation/MeteorScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3346,7 +3346,7 @@ Computes and visualizes the METEOR score for each text generation instance, asse
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="45" data-listing-file-modified-sort="1719948867672" data-listing-reading-time-sort="2" data-listing-word-count-sort="305">
+<div class="g-col-1" data-index="45" data-listing-file-modified-sort="1720030949881" data-listing-reading-time-sort="2" data-listing-word-count-sort="305">
 <a href="../../tests/model_validation/sklearn/MinimumAccuracy.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3360,7 +3360,7 @@ Checks if the model’s prediction accuracy meets or surpasses a specified thres
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="46" data-listing-file-modified-sort="1719948867675" data-listing-reading-time-sort="2" data-listing-word-count-sort="310">
+<div class="g-col-1" data-index="46" data-listing-file-modified-sort="1720030949881" data-listing-reading-time-sort="2" data-listing-word-count-sort="310">
 <a href="../../tests/model_validation/sklearn/MinimumF1Score.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3374,7 +3374,7 @@ Evaluates if the model’s F1 score on the validation set meets a predefined min
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="47" data-listing-file-modified-sort="1719948867677" data-listing-reading-time-sort="2" data-listing-word-count-sort="314">
+<div class="g-col-1" data-index="47" data-listing-file-modified-sort="1720030949881" data-listing-reading-time-sort="2" data-listing-word-count-sort="314">
 <a href="../../tests/model_validation/sklearn/MinimumROCAUCScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3388,7 +3388,7 @@ Validates model by checking if the ROC AUC score meets or surpasses a specified 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="48" data-listing-file-modified-sort="1719948867663" data-listing-reading-time-sort="2" data-listing-word-count-sort="271">
+<div class="g-col-1" data-index="48" data-listing-file-modified-sort="1720030949873" data-listing-reading-time-sort="2" data-listing-word-count-sort="271">
 <a href="../../tests/model_validation/ModelMetadata.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3402,7 +3402,7 @@ Extracts and summarizes critical metadata from a machine learning model instance
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="49" data-listing-file-modified-sort="1720036957229" data-listing-reading-time-sort="1" data-listing-word-count-sort="158">
+<div class="g-col-1" data-index="49" data-listing-file-modified-sort="1720030949873" data-listing-reading-time-sort="1" data-listing-word-count-sort="158">
 <a href="../../tests/model_validation/ModelMetadataComparison.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3416,7 +3416,7 @@ Compare metadata of different models and generate a summary table with the resul
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="50" data-listing-file-modified-sort="1720036957230" data-listing-reading-time-sort="1" data-listing-word-count-sort="169">
+<div class="g-col-1" data-index="50" data-listing-file-modified-sort="1720030949874" data-listing-reading-time-sort="1" data-listing-word-count-sort="169">
 <a href="../../tests/model_validation/ModelPredictionResiduals.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3430,7 +3430,7 @@ Plot the residuals and histograms for each model, and generate a summary table w
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="51" data-listing-file-modified-sort="1719948867671" data-listing-reading-time-sort="2" data-listing-word-count-sort="317">
+<div class="g-col-1" data-index="51" data-listing-file-modified-sort="1720030949881" data-listing-reading-time-sort="2" data-listing-word-count-sort="317">
 <a href="../../tests/model_validation/sklearn/ModelsPerformanceComparison.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3444,7 +3444,7 @@ Evaluates and compares the performance of multiple Machine Learning models using
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="52" data-listing-file-modified-sort="1719948867676" data-listing-reading-time-sort="2" data-listing-word-count-sort="372">
+<div class="g-col-1" data-index="52" data-listing-file-modified-sort="1720030949882" data-listing-reading-time-sort="2" data-listing-word-count-sort="372">
 <a href="../../tests/model_validation/sklearn/OverfitDiagnosis.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3458,7 +3458,7 @@ Detects and visualizes overfit regions in an ML model by comparing performance o
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="53" data-listing-file-modified-sort="1720036957232" data-listing-reading-time-sort="2" data-listing-word-count-sort="275">
+<div class="g-col-1" data-index="53" data-listing-file-modified-sort="1720030949876" data-listing-reading-time-sort="2" data-listing-word-count-sort="275">
 <a href="../../tests/model_validation/embeddings/PCAComponentsPairwisePlots.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3472,7 +3472,7 @@ Generates scatter plots for pairwise combinations of principal component analysi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="54" data-listing-file-modified-sort="1719948867676" data-listing-reading-time-sort="2" data-listing-word-count-sort="289">
+<div class="g-col-1" data-index="54" data-listing-file-modified-sort="1720030949882" data-listing-reading-time-sort="2" data-listing-word-count-sort="289">
 <a href="../../tests/model_validation/sklearn/PermutationFeatureImportance.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3486,7 +3486,7 @@ Assesses the significance of each feature in a model by evaluating the impact on
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="55" data-listing-file-modified-sort="1719948867672" data-listing-reading-time-sort="3" data-listing-word-count-sort="454">
+<div class="g-col-1" data-index="55" data-listing-file-modified-sort="1720030949882" data-listing-reading-time-sort="3" data-listing-word-count-sort="454">
 <a href="../../tests/model_validation/sklearn/PopulationStabilityIndex.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3500,7 +3500,7 @@ Evaluates the Population Stability Index (PSI) to quantify the stability of an M
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="56" data-listing-file-modified-sort="1719948867677" data-listing-reading-time-sort="2" data-listing-word-count-sort="277">
+<div class="g-col-1" data-index="56" data-listing-file-modified-sort="1720030949883" data-listing-reading-time-sort="2" data-listing-word-count-sort="277">
 <a href="../../tests/model_validation/sklearn/PrecisionRecallCurve.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3514,7 +3514,7 @@ Evaluates the precision-recall trade-off for binary classification models and vi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="57" data-listing-file-modified-sort="1719948867681" data-listing-reading-time-sort="2" data-listing-word-count-sort="390">
+<div class="g-col-1" data-index="57" data-listing-file-modified-sort="1720030949887" data-listing-reading-time-sort="2" data-listing-word-count-sort="390">
 <a href="../../tests/model_validation/statsmodels/PredictionProbabilitiesHistogram.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3528,7 +3528,7 @@ Generates and visualizes histograms of the Probability of Default predictions fo
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="58" data-listing-file-modified-sort="1719948867671" data-listing-reading-time-sort="2" data-listing-word-count-sort="387">
+<div class="g-col-1" data-index="58" data-listing-file-modified-sort="1720030949883" data-listing-reading-time-sort="2" data-listing-word-count-sort="387">
 <a href="../../tests/model_validation/sklearn/ROCCurve.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3542,7 +3542,7 @@ Evaluates binary classification model performance by generating and plotting the
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="59" data-listing-file-modified-sort="1720036957230" data-listing-reading-time-sort="2" data-listing-word-count-sort="264">
+<div class="g-col-1" data-index="59" data-listing-file-modified-sort="1720030949874" data-listing-reading-time-sort="2" data-listing-word-count-sort="264">
 <a href="../../tests/model_validation/RegardScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3556,7 +3556,7 @@ Computes and visualizes the regard score for each text instance, assessing senti
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="60" data-listing-file-modified-sort="1719948867683" data-listing-reading-time-sort="2" data-listing-word-count-sort="337">
+<div class="g-col-1" data-index="60" data-listing-file-modified-sort="1720030949887" data-listing-reading-time-sort="2" data-listing-word-count-sort="337">
 <a href="../../tests/model_validation/statsmodels/RegressionCoeffsPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3570,7 +3570,7 @@ Visualizes regression coefficients with 95% confidence intervals to assess predi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="61" data-listing-file-modified-sort="1719948867670" data-listing-reading-time-sort="2" data-listing-word-count-sort="340">
+<div class="g-col-1" data-index="61" data-listing-file-modified-sort="1720030949883" data-listing-reading-time-sort="2" data-listing-word-count-sort="340">
 <a href="../../tests/model_validation/sklearn/RegressionErrors.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3584,7 +3584,7 @@ RegressionErrors
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="62" data-listing-file-modified-sort="1720036957234" data-listing-reading-time-sort="1" data-listing-word-count-sort="177">
+<div class="g-col-1" data-index="62" data-listing-file-modified-sort="1720030949883" data-listing-reading-time-sort="1" data-listing-word-count-sort="177">
 <a href="../../tests/model_validation/sklearn/RegressionErrorsComparison.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3598,7 +3598,7 @@ Compare regression error metrics for each model and generate a summary table wit
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="63" data-listing-file-modified-sort="1719948867681" data-listing-reading-time-sort="2" data-listing-word-count-sort="303">
+<div class="g-col-1" data-index="63" data-listing-file-modified-sort="1720030949888" data-listing-reading-time-sort="2" data-listing-word-count-sort="303">
 <a href="../../tests/model_validation/statsmodels/RegressionFeatureSignificance.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3612,7 +3612,7 @@ Assesses and visualizes the statistical significance of features in a set of reg
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="64" data-listing-file-modified-sort="1719948867682" data-listing-reading-time-sort="2" data-listing-word-count-sort="340">
+<div class="g-col-1" data-index="64" data-listing-file-modified-sort="1720030949888" data-listing-reading-time-sort="2" data-listing-word-count-sort="340">
 <a href="../../tests/model_validation/statsmodels/RegressionModelForecastPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3626,7 +3626,7 @@ Generates plots to visually compare the forecasted outcomes of one or more regre
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="65" data-listing-file-modified-sort="1719948867682" data-listing-reading-time-sort="2" data-listing-word-count-sort="371">
+<div class="g-col-1" data-index="65" data-listing-file-modified-sort="1720030949888" data-listing-reading-time-sort="2" data-listing-word-count-sort="371">
 <a href="../../tests/model_validation/statsmodels/RegressionModelForecastPlotLevels.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3640,7 +3640,7 @@ Compares and visualizes forecasted and actual values of regression models on bot
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="66" data-listing-file-modified-sort="1719948867683" data-listing-reading-time-sort="2" data-listing-word-count-sort="353">
+<div class="g-col-1" data-index="66" data-listing-file-modified-sort="1720030949888" data-listing-reading-time-sort="2" data-listing-word-count-sort="353">
 <a href="../../tests/model_validation/statsmodels/RegressionModelSensitivityPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3654,7 +3654,7 @@ Tests the sensitivity of a regression model to variations in independent variabl
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="67" data-listing-file-modified-sort="1719948867681" data-listing-reading-time-sort="2" data-listing-word-count-sort="299">
+<div class="g-col-1" data-index="67" data-listing-file-modified-sort="1720030949888" data-listing-reading-time-sort="2" data-listing-word-count-sort="299">
 <a href="../../tests/model_validation/statsmodels/RegressionModelSummary.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3668,7 +3668,7 @@ Evaluates regression model performance using metrics including R-Squared, Adjust
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="68" data-listing-file-modified-sort="1719948867683" data-listing-reading-time-sort="2" data-listing-word-count-sort="251">
+<div class="g-col-1" data-index="68" data-listing-file-modified-sort="1720030949888" data-listing-reading-time-sort="2" data-listing-word-count-sort="251">
 <a href="../../tests/model_validation/statsmodels/RegressionModelsCoeffs.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3682,7 +3682,7 @@ Compares feature importance by evaluating and contrasting coefficients of differ
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="69" data-listing-file-modified-sort="1719948867675" data-listing-reading-time-sort="2" data-listing-word-count-sort="337">
+<div class="g-col-1" data-index="69" data-listing-file-modified-sort="1720030949884" data-listing-reading-time-sort="2" data-listing-word-count-sort="337">
 <a href="../../tests/model_validation/sklearn/RegressionModelsPerformanceComparison.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3696,7 +3696,7 @@ Compares and evaluates the performance of multiple regression models using five 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="70" data-listing-file-modified-sort="1719948867682" data-listing-reading-time-sort="2" data-listing-word-count-sort="239">
+<div class="g-col-1" data-index="70" data-listing-file-modified-sort="1720030949888" data-listing-reading-time-sort="2" data-listing-word-count-sort="239">
 <a href="../../tests/model_validation/statsmodels/RegressionPermutationFeatureImportance.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3710,7 +3710,7 @@ Assesses the significance of each feature in a model by evaluating the impact on
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="71" data-listing-file-modified-sort="1719948867671" data-listing-reading-time-sort="2" data-listing-word-count-sort="331">
+<div class="g-col-1" data-index="71" data-listing-file-modified-sort="1720030949884" data-listing-reading-time-sort="2" data-listing-word-count-sort="331">
 <a href="../../tests/model_validation/sklearn/RegressionR2Square.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3724,7 +3724,7 @@ RegressionR2Square
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="72" data-listing-file-modified-sort="1720036957234" data-listing-reading-time-sort="1" data-listing-word-count-sort="179">
+<div class="g-col-1" data-index="72" data-listing-file-modified-sort="1720030949884" data-listing-reading-time-sort="1" data-listing-word-count-sort="179">
 <a href="../../tests/model_validation/sklearn/RegressionR2SquareComparison.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3738,7 +3738,7 @@ Compare R-Squared and Adjusted R-Squared values for each model and generate a su
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="73" data-listing-file-modified-sort="1719948867679" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
+<div class="g-col-1" data-index="73" data-listing-file-modified-sort="1720030949874" data-listing-reading-time-sort="2" data-listing-word-count-sort="291">
 <a href="../../tests/model_validation/RegressionResidualsPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3752,7 +3752,7 @@ Evaluates regression model performance using residual distribution and actual vs
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="74" data-listing-file-modified-sort="1719948867674" data-listing-reading-time-sort="2" data-listing-word-count-sort="353">
+<div class="g-col-1" data-index="74" data-listing-file-modified-sort="1720030949884" data-listing-reading-time-sort="2" data-listing-word-count-sort="353">
 <a href="../../tests/model_validation/sklearn/RobustnessDiagnosis.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3766,7 +3766,7 @@ Evaluates the robustness of a machine learning model by injecting Gaussian noise
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="75" data-listing-file-modified-sort="1720036957230" data-listing-reading-time-sort="2" data-listing-word-count-sort="397">
+<div class="g-col-1" data-index="75" data-listing-file-modified-sort="1720030949874" data-listing-reading-time-sort="2" data-listing-word-count-sort="397">
 <a href="../../tests/model_validation/RougeScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3780,7 +3780,7 @@ Evaluates the quality of machine-generated text using ROUGE metrics and visualiz
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="76" data-listing-file-modified-sort="1719948867682" data-listing-reading-time-sort="2" data-listing-word-count-sort="382">
+<div class="g-col-1" data-index="76" data-listing-file-modified-sort="1720030949889" data-listing-reading-time-sort="2" data-listing-word-count-sort="382">
 <a href="../../tests/model_validation/statsmodels/RunsTest.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3794,7 +3794,7 @@ Executes Runs Test on ML model to detect non-random patterns in output data sequ
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="77" data-listing-file-modified-sort="1719948867674" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
+<div class="g-col-1" data-index="77" data-listing-file-modified-sort="1720030949884" data-listing-reading-time-sort="2" data-listing-word-count-sort="336">
 <a href="../../tests/model_validation/sklearn/SHAPGlobalImportance.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3808,7 +3808,7 @@ Evaluates and visualizes global feature importance using SHAP values for model e
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="78" data-listing-file-modified-sort="1719948867683" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
+<div class="g-col-1" data-index="78" data-listing-file-modified-sort="1720030949889" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
 <a href="../../tests/model_validation/statsmodels/ScorecardHistogram.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3822,7 +3822,7 @@ Creates histograms of credit scores, from both default and non-default instances
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="79" data-listing-file-modified-sort="1719948867684" data-listing-reading-time-sort="2" data-listing-word-count-sort="308">
+<div class="g-col-1" data-index="79" data-listing-file-modified-sort="1720030949889" data-listing-reading-time-sort="2" data-listing-word-count-sort="308">
 <a href="../../tests/model_validation/statsmodels/ShapiroWilk.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3836,7 +3836,7 @@ Evaluates feature-wise normality of training data using the Shapiro-Wilk test.
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="80" data-listing-file-modified-sort="1719948867674" data-listing-reading-time-sort="2" data-listing-word-count-sort="361">
+<div class="g-col-1" data-index="80" data-listing-file-modified-sort="1720030949884" data-listing-reading-time-sort="2" data-listing-word-count-sort="361">
 <a href="../../tests/model_validation/sklearn/SilhouettePlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3850,7 +3850,7 @@ Calculates and visualizes Silhouette Score, assessing degree of data point suita
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="81" data-listing-file-modified-sort="1720036957232" data-listing-reading-time-sort="1" data-listing-word-count-sort="32">
+<div class="g-col-1" data-index="81" data-listing-file-modified-sort="1720030949876" data-listing-reading-time-sort="1" data-listing-word-count-sort="32">
 <a href="../../tests/model_validation/embeddings/StabilityAnalysis.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3864,7 +3864,7 @@ Base class for embeddings stability analysis tests
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="82" data-listing-file-modified-sort="1719948867665" data-listing-reading-time-sort="2" data-listing-word-count-sort="332">
+<div class="g-col-1" data-index="82" data-listing-file-modified-sort="1720030949876" data-listing-reading-time-sort="2" data-listing-word-count-sort="332">
 <a href="../../tests/model_validation/embeddings/StabilityAnalysisKeyword.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3878,7 +3878,7 @@ Evaluate robustness of embeddings models to keyword swaps on the test dataset
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="83" data-listing-file-modified-sort="1719948867667" data-listing-reading-time-sort="2" data-listing-word-count-sort="375">
+<div class="g-col-1" data-index="83" data-listing-file-modified-sort="1720030949876" data-listing-reading-time-sort="2" data-listing-word-count-sort="375">
 <a href="../../tests/model_validation/embeddings/StabilityAnalysisRandomNoise.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3892,7 +3892,7 @@ Evaluate robustness of embeddings models to random noise introduced by using a <
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="84" data-listing-file-modified-sort="1719948867665" data-listing-reading-time-sort="2" data-listing-word-count-sort="380">
+<div class="g-col-1" data-index="84" data-listing-file-modified-sort="1720030949876" data-listing-reading-time-sort="2" data-listing-word-count-sort="380">
 <a href="../../tests/model_validation/embeddings/StabilityAnalysisSynonyms.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3906,7 +3906,7 @@ Evaluates the stability of text embeddings models when words in test data are re
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="85" data-listing-file-modified-sort="1719948867664" data-listing-reading-time-sort="2" data-listing-word-count-sort="350">
+<div class="g-col-1" data-index="85" data-listing-file-modified-sort="1720030949877" data-listing-reading-time-sort="2" data-listing-word-count-sort="350">
 <a href="../../tests/model_validation/embeddings/StabilityAnalysisTranslation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3920,7 +3920,7 @@ Evaluate robustness of embeddings models to noise introduced by translating the 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="86" data-listing-file-modified-sort="1720036957232" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
+<div class="g-col-1" data-index="86" data-listing-file-modified-sort="1720030949877" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
 <a href="../../tests/model_validation/embeddings/TSNEComponentsPairwisePlots.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3934,7 +3934,7 @@ Plots individual scatter plots for pairwise combinations of t-SNE components of 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="87" data-listing-file-modified-sort="1720036957230" data-listing-reading-time-sort="2" data-listing-word-count-sort="206">
+<div class="g-col-1" data-index="87" data-listing-file-modified-sort="1720030949874" data-listing-reading-time-sort="2" data-listing-word-count-sort="206">
 <a href="../../tests/model_validation/TimeSeriesPredictionWithCI.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3948,7 +3948,7 @@ Plot actual vs predicted values for a time series with confidence intervals and 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="88" data-listing-file-modified-sort="1720036957230" data-listing-reading-time-sort="1" data-listing-word-count-sort="159">
+<div class="g-col-1" data-index="88" data-listing-file-modified-sort="1720030949874" data-listing-reading-time-sort="1" data-listing-word-count-sort="159">
 <a href="../../tests/model_validation/TimeSeriesPredictionsPlot.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3962,7 +3962,7 @@ Plot actual vs predicted values for time series data and generate a visual compa
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="89" data-listing-file-modified-sort="1720036957230" data-listing-reading-time-sort="1" data-listing-word-count-sort="193">
+<div class="g-col-1" data-index="89" data-listing-file-modified-sort="1720030949874" data-listing-reading-time-sort="1" data-listing-word-count-sort="193">
 <a href="../../tests/model_validation/TimeSeriesR2SquareBySegments.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3976,7 +3976,7 @@ Plot R-Squared values for each model over specified time segments and generate a
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="90" data-listing-file-modified-sort="1720036957230" data-listing-reading-time-sort="2" data-listing-word-count-sort="246">
+<div class="g-col-1" data-index="90" data-listing-file-modified-sort="1720030949875" data-listing-reading-time-sort="2" data-listing-word-count-sort="246">
 <a href="../../tests/model_validation/TokenDisparity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -3990,7 +3990,7 @@ Evaluates the token disparity between reference and generated texts, visualizing
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="91" data-listing-file-modified-sort="1720036957231" data-listing-reading-time-sort="2" data-listing-word-count-sort="248">
+<div class="g-col-1" data-index="91" data-listing-file-modified-sort="1720030949875" data-listing-reading-time-sort="2" data-listing-word-count-sort="248">
 <a href="../../tests/model_validation/ToxicityScore.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4004,7 +4004,7 @@ Computes and visualizes the toxicity score for input text, true text, and predic
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="92" data-listing-file-modified-sort="1719948867673" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
+<div class="g-col-1" data-index="92" data-listing-file-modified-sort="1720030949884" data-listing-reading-time-sort="2" data-listing-word-count-sort="329">
 <a href="../../tests/model_validation/sklearn/TrainingTestDegradation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4018,7 +4018,7 @@ Tests if model performance degradation between training and test datasets exceed
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="93" data-listing-file-modified-sort="1719948867675" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
+<div class="g-col-1" data-index="93" data-listing-file-modified-sort="1720030949885" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
 <a href="../../tests/model_validation/sklearn/VMeasure.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4032,7 +4032,7 @@ Evaluates homogeneity and completeness of a clustering model using the V Measure
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="94" data-listing-file-modified-sort="1719948867673" data-listing-reading-time-sort="2" data-listing-word-count-sort="393">
+<div class="g-col-1" data-index="94" data-listing-file-modified-sort="1720030949885" data-listing-reading-time-sort="2" data-listing-word-count-sort="393">
 <a href="../../tests/model_validation/sklearn/WeakspotsDiagnosis.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4055,7 +4055,7 @@ No matching items
 <div id="tabset-1-3" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-3-tab">
 <div id="listing-prompt-validation" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1719948867663" data-listing-reading-time-sort="2" data-listing-word-count-sort="379">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949889" data-listing-reading-time-sort="2" data-listing-word-count-sort="379">
 <a href="../../tests/prompt_validation/Bias.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4069,7 +4069,7 @@ Evaluates bias in a Large Language Model based on the order and distribution of 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1719948867663" data-listing-reading-time-sort="2" data-listing-word-count-sort="269">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949889" data-listing-reading-time-sort="2" data-listing-word-count-sort="269">
 <a href="../../tests/prompt_validation/Clarity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4083,7 +4083,7 @@ Evaluates and scores the clarity of prompts in a Large Language Model based on s
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1719948867663" data-listing-reading-time-sort="2" data-listing-word-count-sort="238">
+<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720030949889" data-listing-reading-time-sort="2" data-listing-word-count-sort="238">
 <a href="../../tests/prompt_validation/Conciseness.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4097,7 +4097,7 @@ Analyzes and grades the conciseness of prompts provided to a Large Language Mode
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1719948867662" data-listing-reading-time-sort="2" data-listing-word-count-sort="264">
+<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720030949889" data-listing-reading-time-sort="2" data-listing-word-count-sort="264">
 <a href="../../tests/prompt_validation/Delimitation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4111,7 +4111,7 @@ Evaluates the proper use of delimiters in prompts provided to Large Language Mod
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1719948867662" data-listing-reading-time-sort="2" data-listing-word-count-sort="303">
+<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720030949889" data-listing-reading-time-sort="2" data-listing-word-count-sort="303">
 <a href="../../tests/prompt_validation/NegativeInstruction.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4125,7 +4125,7 @@ Evaluates and grades the use of affirmative, proactive language over negative in
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1719948867662" data-listing-reading-time-sort="2" data-listing-word-count-sort="255">
+<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720030949889" data-listing-reading-time-sort="2" data-listing-word-count-sort="255">
 <a href="../../tests/prompt_validation/Robustness.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -4139,7 +4139,7 @@ Assesses the robustness of prompts provided to a Large Language Model under vary
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1719948867663" data-listing-reading-time-sort="2" data-listing-word-count-sort="261">
+<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1720030949890" data-listing-reading-time-sort="2" data-listing-word-count-sort="261">
 <a href="../../tests/prompt_validation/Specificity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/developer/model-testing/testing-overview.html
+++ b/site/_site/developer/model-testing/testing-overview.html
@@ -1923,7 +1923,7 @@ A collection of tests which are run together to generate model documentation end
 <p>Start by running a pre-made test, then modify it, and finally create your own test:</p>
 <div id="listing-tests-beginner" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1719948866263" data-listing-reading-time-sort="9" data-listing-word-count-sort="1796">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949845" data-listing-reading-time-sort="9" data-listing-word-count-sort="1796">
 <a href="../../notebooks/how_to/run_tests/1_run_dataset_based_tests.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1937,7 +1937,7 @@ Use the ValidMind Developer Framework’s <code>run_test</code> function to run 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1719948866253" data-listing-reading-time-sort="14" data-listing-word-count-sort="2776">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949841" data-listing-reading-time-sort="14" data-listing-word-count-sort="2776">
 <a href="../../notebooks/code_samples/custom_tests/implement_custom_tests.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1962,7 +1962,7 @@ No matching items
 <p>Next, find available tests and test suites using the developer framework or the interactive test sandbox:</p>
 <div id="listing-tests-explore" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720036957195" data-listing-reading-time-sort="4" data-listing-word-count-sort="741">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949844" data-listing-reading-time-sort="4" data-listing-word-count-sort="741">
 <a href="../../notebooks/how_to/explore_tests.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1976,7 +1976,7 @@ View and learn more about the tests available in the ValidMind Developer Framewo
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1719948866263" data-listing-reading-time-sort="5" data-listing-word-count-sort="965">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949843" data-listing-reading-time-sort="5" data-listing-word-count-sort="965">
 <a href="../../notebooks/how_to/explore_test_suites.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1990,7 +1990,7 @@ Explore the the test suites and tests that are available in the ValidMind Develo
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957121" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="48">
+<div class="g-col-1" data-index="2" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646840" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="48">
 <a href="../../developer/model-testing/test-sandbox.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2015,7 +2015,7 @@ No matching items
 <p>Building on previous sections, add your own test provider, set up datasets, run tests on individual sections in your model documentation, and more:</p>
 <div id="listing-tests-intermediate" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1719948866253" data-listing-reading-time-sort="13" data-listing-word-count-sort="2551">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949841" data-listing-reading-time-sort="13" data-listing-word-count-sort="2551">
 <a href="../../notebooks/code_samples/custom_tests/integrate_external_test_providers.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2029,7 +2029,7 @@ Register a custom test provider with the ValidMind Developer Framework to run yo
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1719948866263" data-listing-reading-time-sort="7" data-listing-word-count-sort="1305">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949843" data-listing-reading-time-sort="7" data-listing-word-count-sort="1305">
 <a href="../../notebooks/how_to/configure_dataset_features.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2043,7 +2043,7 @@ When initializing a ValidMind dataset object, you can pass in a list of features
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1719948866263" data-listing-reading-time-sort="8" data-listing-word-count-sort="1452">
+<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720030949845" data-listing-reading-time-sort="8" data-listing-word-count-sort="1452">
 <a href="../../notebooks/how_to/run_documentation_sections.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2057,7 +2057,7 @@ For targeted testing, you can run tests on individual sections or specific group
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1719948866263" data-listing-reading-time-sort="9" data-listing-word-count-sort="1761">
+<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720030949845" data-listing-reading-time-sort="9" data-listing-word-count-sort="1761">
 <a href="../../notebooks/how_to/run_documentation_tests_with_config.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2071,7 +2071,7 @@ When running documentation tests, you can configure inputs and parameters for in
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1719948866264" data-listing-reading-time-sort="8" data-listing-word-count-sort="1584">
+<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720030949845" data-listing-reading-time-sort="8" data-listing-word-count-sort="1584">
 <a href="../../notebooks/how_to/run_tests_that_require_multiple_datasets.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2085,7 +2085,7 @@ To support running tests that require more than one dataset, ValidMind provides 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1719948866262" data-listing-reading-time-sort="15" data-listing-word-count-sort="2824">
+<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720030949846" data-listing-reading-time-sort="15" data-listing-word-count-sort="2824">
 <a href="../../notebooks/how_to/run_unit_metrics.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2110,7 +2110,7 @@ No matching items
 <p>Need more? Try some of the advanced features provided by the developer framework:</p>
 <div id="listing-tests-advanced" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1719948866264" data-listing-reading-time-sort="10" data-listing-word-count-sort="1846">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949843" data-listing-reading-time-sort="10" data-listing-word-count-sort="1846">
 <a href="../../notebooks/how_to/document_multiple_results_for_the_same_test.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2124,7 +2124,7 @@ Documentation templates facilitate the presentation of multiple unique test resu
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1719948866262" data-listing-reading-time-sort="10" data-listing-word-count-sort="1903">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949844" data-listing-reading-time-sort="10" data-listing-word-count-sort="1903">
 <a href="../../notebooks/how_to/load_datasets_predictions.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/developer/samples-jupyter-notebooks.html
+++ b/site/_site/developer/samples-jupyter-notebooks.html
@@ -1804,7 +1804,7 @@ A free Jupyter notebook environment that runs in the cloud. There, you can work 
 
 <div class="quarto-listing quarto-listing-container-grid" id="listing-listing">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720036957194" data-listing-reading-time-sort="9" data-listing-word-count-sort="1742">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720030949840" data-listing-reading-time-sort="9" data-listing-word-count-sort="1742">
 <a href="../notebooks/code_samples/NLP_and_LLM/llm_summarization_demo.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1821,7 +1821,7 @@ Document a LLM-based text summarization model of news using the CNN DailyMail sa
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1719948866254" data-listing-reading-time-sort="16" data-listing-word-count-sort="3018">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720030949842" data-listing-reading-time-sort="16" data-listing-word-count-sort="3018">
 <a href="../notebooks/code_samples/customization/customizing_tests_with_output_templates.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1838,7 +1838,7 @@ Run individual tests and tests for experimentation and when exploring and buildi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1719948866258" data-listing-reading-time-sort="7" data-listing-word-count-sort="1202">
+<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720030949842" data-listing-reading-time-sort="7" data-listing-word-count-sort="1202">
 <a href="../notebooks/code_samples/regression/quickstart_regression_full_suite.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1855,7 +1855,7 @@ Use the California Housing Price Prediction sample dataset from Sklearn to train
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1719948866258" data-listing-reading-time-sort="11" data-listing-word-count-sort="2094">
+<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720030949842" data-listing-reading-time-sort="11" data-listing-word-count-sort="2094">
 <a href="../notebooks/code_samples/time_series/quickstart_time_series_full_suite.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1872,7 +1872,7 @@ Use the FRED sample dataset to train a simple time series model and document tha
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1719948866259" data-listing-reading-time-sort="16" data-listing-word-count-sort="3035">
+<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720030949840" data-listing-reading-time-sort="16" data-listing-word-count-sort="3035">
 <a href="../notebooks/code_samples/credit_risk/application_scorecard_demo.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1889,7 +1889,7 @@ Build and document an <em>application scorecard model</em> with the ValidMind De
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1719948866253" data-listing-reading-time-sort="14" data-listing-word-count-sort="2776">
+<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720030949841" data-listing-reading-time-sort="14" data-listing-word-count-sort="2776">
 <a href="../notebooks/code_samples/custom_tests/implement_custom_tests.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1906,7 +1906,7 @@ Custom tests extend the functionality of ValidMind, allowing you to document any
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1719948866253" data-listing-reading-time-sort="13" data-listing-word-count-sort="2551">
+<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1720030949841" data-listing-reading-time-sort="13" data-listing-word-count-sort="2551">
 <a href="../notebooks/code_samples/custom_tests/integrate_external_test_providers.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1923,7 +1923,7 @@ Register a custom test provider with the ValidMind Developer Framework to run yo
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="7" data-listing-file-modified-sort="1719948866258" data-listing-reading-time-sort="8" data-listing-word-count-sort="1418">
+<div class="g-col-1" data-index="7" data-listing-file-modified-sort="1720030949840" data-listing-reading-time-sort="8" data-listing-word-count-sort="1418">
 <a href="../notebooks/code_samples/NLP_and_LLM/prompt_validation_demo.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1940,7 +1940,7 @@ Run and document prompt validation tests for a large language model (LLM) specia
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="8" data-listing-file-modified-sort="1719948866258" data-listing-reading-time-sort="16" data-listing-word-count-sort="3035">
+<div class="g-col-1" data-index="8" data-listing-file-modified-sort="1720030949840" data-listing-reading-time-sort="16" data-listing-word-count-sort="3035">
 <a href="../notebooks/code_samples/NLP_and_LLM/rag_documentation_demo.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1957,7 +1957,7 @@ In this notebook, we are going to implement a simple RAG Model for automating th
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="9" data-listing-file-modified-sort="1719948866255" data-listing-reading-time-sort="4" data-listing-word-count-sort="781">
+<div class="g-col-1" data-index="9" data-listing-file-modified-sort="1720030949839" data-listing-reading-time-sort="4" data-listing-word-count-sort="781">
 <a href="../notebooks/code_samples/NLP_and_LLM/hugging_face_integration_demo.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1974,7 +1974,7 @@ Document a natural language processing (NLP) model using the ValidMind Developer
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="10" data-listing-file-modified-sort="1719948866255" data-listing-reading-time-sort="4" data-listing-word-count-sort="776">
+<div class="g-col-1" data-index="10" data-listing-file-modified-sort="1720030949837" data-listing-reading-time-sort="4" data-listing-word-count-sort="776">
 <a href="../notebooks/code_samples/NLP_and_LLM/foundation_models_integration_demo.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1991,7 +1991,7 @@ Document a large language model (LLM) specialized in sentiment analysis for fina
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="11" data-listing-file-modified-sort="1719948866254" data-listing-reading-time-sort="4" data-listing-word-count-sort="730">
+<div class="g-col-1" data-index="11" data-listing-file-modified-sort="1720030949840" data-listing-reading-time-sort="4" data-listing-word-count-sort="730">
 <a href="../notebooks/code_samples/NLP_and_LLM/hugging_face_summarization_demo.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -2008,7 +2008,7 @@ Document a natural language processing (NLP) model using ValidMind to summarize 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="12" data-listing-file-modified-sort="1719948866258" data-listing-reading-time-sort="4" data-listing-word-count-sort="652">
+<div class="g-col-1" data-index="12" data-listing-file-modified-sort="1720030949837" data-listing-reading-time-sort="4" data-listing-word-count-sort="652">
 <a href="../notebooks/code_samples/NLP_and_LLM/foundation_models_summarization_demo.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/faq/faq-documentation.html
+++ b/site/_site/faq/faq-documentation.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-06-12">
+<meta name="dcterms.date" content="2024-06-26">
 
 <title>Documentation – ValidMind</title>
 <style>
@@ -308,7 +308,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">June 12, 2024</p>
+      <p class="date">June 26, 2024</p>
     </div>
   </div>
   

--- a/site/_site/faq/faq-integrations.html
+++ b/site/_site/faq/faq-integrations.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-06-12">
+<meta name="dcterms.date" content="2024-06-26">
 
 <title>Integrations and support – ValidMind</title>
 <style>
@@ -311,7 +311,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">June 12, 2024</p>
+      <p class="date">June 26, 2024</p>
     </div>
   </div>
   

--- a/site/_site/faq/faq-inventory.html
+++ b/site/_site/faq/faq-inventory.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-06-12">
+<meta name="dcterms.date" content="2024-06-26">
 
 <title>Model Inventory – ValidMind</title>
 <style>
@@ -307,7 +307,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">June 12, 2024</p>
+      <p class="date">June 26, 2024</p>
     </div>
   </div>
   

--- a/site/_site/faq/faq-models.html
+++ b/site/_site/faq/faq-models.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-06-12">
+<meta name="dcterms.date" content="2024-06-26">
 
 <title>Model registration – ValidMind</title>
 <style>
@@ -307,7 +307,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">June 12, 2024</p>
+      <p class="date">June 26, 2024</p>
     </div>
   </div>
   

--- a/site/_site/faq/faq-testing.html
+++ b/site/_site/faq/faq-testing.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-06-12">
+<meta name="dcterms.date" content="2024-06-26">
 
 <title>Testing – ValidMind</title>
 <style>
@@ -307,7 +307,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">June 12, 2024</p>
+      <p class="date">June 26, 2024</p>
     </div>
   </div>
   

--- a/site/_site/faq/faq-workflows.html
+++ b/site/_site/faq/faq-workflows.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-06-12">
+<meta name="dcterms.date" content="2024-06-26">
 
 <title>Workflows – ValidMind</title>
 <style>
@@ -307,7 +307,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">June 12, 2024</p>
+      <p class="date">June 26, 2024</p>
     </div>
   </div>
   

--- a/site/_site/get-started/get-started.html
+++ b/site/_site/get-started/get-started.html
@@ -545,7 +545,7 @@ Select a documentation template when registering a new inventory model to start 
 </dd>
 <dt><strong>Initial validation</strong></dt>
 <dd>
-Triggers a new <a href="#documentation-workflow">documentation workflow</a> to yield a model that will be ready for production deployment after its documentation and validation reports have been approved.
+Triggers a new <a href="../guide/model-workflows/working-with-model-workflows.html">documentation workflow</a> to yield a model that will be ready for production deployment after its documentation and validation reports have been approved.
 </dd>
 <dt><strong>Validation approval</strong></dt>
 <dd>

--- a/site/_site/guide/configuration/onboarding-users.html
+++ b/site/_site/guide/configuration/onboarding-users.html
@@ -674,7 +674,7 @@ The Customer Admin role has extensive control over the entire platform. This rol
 <h2 class="anchored" data-anchor-id="whats-next">What’s next</h2>
 <div id="listing-whats-next-listing" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957136" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="253">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720028963000" data-listing-file-modified-sort="1720028963649" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="253">
 <a href="../../guide/configuration/manage-users.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -688,7 +688,7 @@ Ensure smooth operations and maintain secure access controls by managing users. 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720036957135" data-listing-reading-time-sort="2" data-listing-word-count-sort="320">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720027646856" data-listing-reading-time-sort="2" data-listing-word-count-sort="320">
 <a href="../../guide/configuration/manage-groups.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -702,7 +702,7 @@ Invite new users and assign users to specific groups to maintain access control 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720036957135" data-listing-reading-time-sort="1" data-listing-word-count-sort="165">
+<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720028963649" data-listing-reading-time-sort="1" data-listing-word-count-sort="165">
 <a href="../../guide/configuration/manage-roles.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -716,7 +716,7 @@ Managing roles is crucial for maintaining a secure and well-organized environmen
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957135" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="160">
+<div class="g-col-1" data-index="3" data-listing-date-sort="1720028963000" data-listing-file-modified-sort="1720028963649" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="160">
 <a href="../../guide/configuration/manage-permissions.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/guides.html
+++ b/site/_site/guide/guides.html
@@ -853,7 +853,7 @@ A collection of tests which are run together to generate model documentation end
 <p>To onboard your organization, teams or business units, and users onto the ValidMind platform:</p>
 <div id="listing-guides-onboarding" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957136" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="187">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646857" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="187">
 <a href="../guide/configuration/set-up-your-organization.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -867,7 +867,7 @@ This task involves managing organizations within ValidMind, allowing for effecti
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957136" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="326">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646857" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="326">
 <a href="../guide/configuration/onboarding-users.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -881,7 +881,7 @@ User setup involves controlling and organizing who has access to the ValidMind p
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957135" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="816">
+<div class="g-col-1" data-index="2" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646856" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="816">
 <a href="../guide/configuration/configure-aws-privatelink.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -906,7 +906,7 @@ No matching items
 <p>Use workflows to match your organizational needs for overseeing model development, validation, or implementation activities:</p>
 <div id="listing-guides-model-workflows" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957187" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="590">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720044001000" data-listing-file-modified-sort="1720044001918" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="590">
 <a href="../guide/model-workflows/working-with-model-workflows.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -931,7 +931,7 @@ No matching items
 <p>To configure the model inventory to your organization’s requirements and to register new models:</p>
 <div id="listing-guides-model-inventory" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957174" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="167">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720044001000" data-listing-file-modified-sort="1720044001918" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="164">
 <a href="../guide/model-inventory/working-with-model-inventory.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -945,7 +945,7 @@ Use the model inventory within the ValidMind Platform UI to easily track compreh
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957174" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="344">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720028963000" data-listing-file-modified-sort="1720028963653" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="344">
 <a href="../guide/model-inventory/manage-inventory-custom-fields.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -970,7 +970,7 @@ No matching items
 <p>To document and test your models in your own model development environment:</p>
 <div id="listing-guides-developer-framework" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957120" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="465">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646840" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="465">
 <a href="../developer/get-started-developer-framework.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -984,7 +984,7 @@ The ValidMind Developer Framework helps you streamline model documentation by au
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957121" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="249">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646840" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="249">
 <a href="../developer/samples-jupyter-notebooks.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1006,7 +1006,7 @@ No matching items
 <p>To work with documentation, documentation templates, and model documentation in the platform UI, and to collaborate with model validators:</p>
 <div id="listing-guides-model-documentation" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957161" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="26">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646880" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="26">
 <a href="../guide/model-documentation/working-with-documentation-templates.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1020,7 +1020,7 @@ Documentation templates offer a standardized approach to creating consistent and
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957161" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="350">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646880" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="350">
 <a href="../guide/model-documentation/working-with-model-documentation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1034,7 +1034,7 @@ After you upload initial model documentation through the developer framework, us
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957149" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="385">
+<div class="g-col-1" data-index="2" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028556" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="385">
 <a href="../guide/model-documentation/export-documentation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1059,7 +1059,7 @@ No matching items
 <p>To set up approvals, prepare validation reports, collaborate with model developers, link evidence to your reports, or work with model documentation findings:</p>
 <div id="listing-guides-model-validation" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957179" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="325">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028582" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="325">
 <a href="../guide/model-validation/preparing-validation-reports.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1073,7 +1073,7 @@ As part of preparing validation reports, you can view the guidelines, collaborat
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957180" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="819">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720044001000" data-listing-file-modified-sort="1720044001918" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="813">
 <a href="../guide/model-validation/work-with-model-findings.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1087,7 +1087,7 @@ Model findings are detailed observations identified during the model validation 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957180" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="567">
+<div class="g-col-1" data-index="2" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646898" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="567">
 <a href="../guide/model-validation/view-reports.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -1101,7 +1101,7 @@ Reports provide quick insights into your model validation efforts, detailing cri
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957149" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="385">
+<div class="g-col-1" data-index="3" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028556" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="385">
 <a href="../guide/model-documentation/export-documentation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/model-documentation/working-with-documentation-templates.html
+++ b/site/_site/guide/model-documentation/working-with-documentation-templates.html
@@ -607,7 +607,7 @@ window.Quarto = {
 <p>Documentation templates offer a standardized approach to creating consistent and comprehensive model documentation and validation reports. You customize these templates to fit your specific project needs.</p>
 <div id="listing-documentation-project-templates" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957160" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="169">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646879" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="169">
 <a href="../../guide/model-documentation/view-documentation-templates.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -621,7 +621,7 @@ Learn how to view the structure and configuration of existing documentation temp
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957138" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="27" data-listing-word-count-sort="5327">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646859" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="27" data-listing-word-count-sort="5327">
 <a href="../../guide/model-documentation/customize-documentation-templates.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -635,7 +635,7 @@ The ValidMind AI risk platform offers robust and fully customizable templates fo
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957156" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="602">
+<div class="g-col-1" data-index="2" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028562" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="602">
 <a href="../../guide/model-documentation/swap-documentation-templates.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/model-documentation/working-with-model-documentation.html
+++ b/site/_site/guide/model-documentation/working-with-model-documentation.html
@@ -727,7 +727,7 @@ Focuses on the model’s ongoing monitoring plan, implementation, and governance
 <h2 class="anchored" data-anchor-id="whats-next">What’s next</h2>
 <div id="listing-model-documentation-listing" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957160" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="251">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028565" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="251">
 <a href="../../guide/model-documentation/view-documentation-guidelines.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -741,7 +741,7 @@ View the guidelines for model documentation associated with a template to ensure
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957160" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="752">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028565" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="752">
 <a href="../../guide/model-documentation/work-with-content-blocks.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -755,7 +755,7 @@ Make edits to your model documentation or validation reports by adding or removi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957138" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="162">
+<div class="g-col-1" data-index="2" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028546" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="162">
 <a href="../../guide/model-documentation/assign-documentation-section-statuses.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -769,7 +769,7 @@ Assign a completion status to individual sections of your model documentation th
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957138" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="502">
+<div class="g-col-1" data-index="3" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646859" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="502">
 <a href="../../guide/model-documentation/collaborate-with-others.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -783,7 +783,7 @@ Use the real-time collaboration features to track changes, add comments, and acc
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957160" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="129">
+<div class="g-col-1" data-index="4" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028565" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="129">
 <a href="../../guide/model-documentation/view-documentation-activity.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -797,7 +797,7 @@ Use the audit trail functionality in the ValidMind Platform UI to track or audit
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="5" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957156" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="229">
+<div class="g-col-1" data-index="5" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646875" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="229">
 <a href="../../guide/model-documentation/submit-for-approval.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/model-inventory/customize-model-inventory-layout.html
+++ b/site/_site/guide/model-inventory/customize-model-inventory-layout.html
@@ -562,7 +562,7 @@ cookieconsent.run({
 <p>There are models registered in the model inventory<sup>1</sup>.</p>
 
 <div class="no-row-height column-margin column-container"><div class="">
-<p><sup>1</sup> Learn how to <a href="../../guide/model-inventory/register-models-in-inventory.html">register models in the inventory</a>.</p>
+<p><sup>1</sup> <a href="../../guide/model-inventory/register-models-in-inventory.html">Register models in the inventory</a></p>
 </div></div></section>
 <section id="steps" class="level2">
 <h2 class="anchored" data-anchor-id="steps">Steps</h2>

--- a/site/_site/guide/model-inventory/working-with-model-inventory.html
+++ b/site/_site/guide/model-inventory/working-with-model-inventory.html
@@ -618,7 +618,7 @@ window.Quarto = {
 <p>There are models registered in the model inventory<sup>1</sup>.</p>
 
 <div class="no-row-height column-margin column-container"><div class="">
-<p><sup>1</sup> Learn how to <a href="../../guide/model-inventory/register-models-in-inventory.html">register models in the inventory</a>.</p>
+<p><sup>1</sup> <a href="../../guide/model-inventory/register-models-in-inventory.html">Register models in the inventory</a></p>
 </div></div></section>
 <section id="search-filter-and-sort-models" class="level2">
 <h2 class="anchored" data-anchor-id="search-filter-and-sort-models">Search, filter, and sort models</h2>
@@ -647,7 +647,7 @@ window.Quarto = {
 <h2 class="anchored" data-anchor-id="whats-next">What’s next</h2>
 <div id="listing-whats-next-listing" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957174" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="207">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646893" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="207">
 <a href="../../guide/model-inventory/register-models-in-inventory.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -661,7 +661,7 @@ To be able to document models using ValidMind’s model documentation and valida
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720036957161" data-listing-reading-time-sort="1" data-listing-word-count-sort="153">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720044001917" data-listing-reading-time-sort="1" data-listing-word-count-sort="150">
 <a href="../../guide/model-inventory/customize-model-inventory-layout.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -675,7 +675,7 @@ Configure the information that displays on the model inventory, and swap between
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957161" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="202">
+<div class="g-col-1" data-index="2" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028566" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="202">
 <a href="../../guide/model-inventory/edit-model-inventory-fields.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/model-validation/preparing-validation-reports.html
+++ b/site/_site/guide/model-validation/preparing-validation-reports.html
@@ -699,7 +699,7 @@ A periodic report assessing the model’s performance and compliance over time, 
 <h2 class="anchored" data-anchor-id="whats-next">What’s next</h2>
 <div id="listing-validation-reports-listing" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957180" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="239">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720029028000" data-listing-file-modified-sort="1720029028582" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="239">
 <a href="../../guide/model-validation/view-validation-guidelines.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -713,7 +713,7 @@ View the guidelines for validation reports associated with a template to ensure 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957179" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="194">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646897" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="194">
 <a href="../../guide/model-validation/review-model-documentation.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -727,7 +727,7 @@ You review the model documentation provided by a model developer as part of the 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957176" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="177">
+<div class="g-col-1" data-index="2" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646894" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="177">
 <a href="../../guide/model-validation/assess-compliance.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/guide/model-validation/work-with-model-findings.html
+++ b/site/_site/guide/model-validation/work-with-model-findings.html
@@ -624,7 +624,7 @@ cookieconsent.run({
 <p>You can now either log a finding on this overview page, or via a specific documentation section. Both methods will allow you to associate a finding with a documentation section.</p>
 
 <div class="no-row-height column-margin column-container"><div class="">
-<p><sup>4</sup> Learn how to <a href="../../guide/model-inventory/working-with-model-inventory.html">work with the model inventory</a>.</p>
+<p><sup>4</sup> <a href="../../guide/model-inventory/working-with-model-inventory.html">Work with the model inventory</a></p>
 </div></div><section id="add-finding-via-overview" class="level4">
 <h4 class="anchored" data-anchor-id="add-finding-via-overview">Add finding via overview</h4>
 <p>To log a finding from the documentation overview:</p>
@@ -686,7 +686,7 @@ cookieconsent.run({
 </ol>
 
 <div class="no-row-height column-margin column-container"><div class="">
-<p><sup>5</sup> Learn how to <a href="#filter-project-findings">filter project findings</a>.</p>
+<p><sup>5</sup> <a href="#filter-project-findings">Filter project findings</a></p>
 </div></div><p>Most updates are applied immediately but you must click <strong>Save</strong> to make changes to the finding description and proposed remediation plan effective.</p>
 <!---
 ## Troubleshooting

--- a/site/_site/guide/model-workflows/working-with-model-workflows.html
+++ b/site/_site/guide/model-workflows/working-with-model-workflows.html
@@ -708,8 +708,8 @@ Roles and action visbility
 <section id="whats-next" class="level2">
 <h2 class="anchored" data-anchor-id="whats-next">What’s next</h2>
 <div id="listing-model-workflows-listing" class="quarto-listing quarto-listing-container-grid">
-<div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957184" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
+<div class="list grid quarto-listing-cols-2">
+<div class="g-col-1" data-index="0" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646901" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="292">
 <a href="../../guide/model-workflows/customize-resource-statuses.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -723,7 +723,7 @@ Statuses are manipulated via workflow transitions and are used to track the prog
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-date-sort="1720036957000" data-listing-file-modified-sort="1720036957185" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="7" data-listing-word-count-sort="1309">
+<div class="g-col-1" data-index="1" data-listing-date-sort="1720027646000" data-listing-file-modified-sort="1720027646903" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="7" data-listing-word-count-sort="1309">
 <a href="../../guide/model-workflows/set-up-model-workflows.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/releases/2023/2023-oct-25/highlights.html
+++ b/site/_site/releases/2023/2023-oct-25/highlights.html
@@ -534,7 +534,7 @@ This notebook serves as a guide for modifying configuration and parameters withi
 <section id="remove-blocks-from-documentation" class="level4">
 <h4 class="anchored" data-anchor-id="remove-blocks-from-documentation">Remove blocks from documentation</h4>
 <p>You can now remove blocks of text or test-related content from model documentation in the editor of the platform UI. This new feature gives you more control over your documentation and enables you to remove content that is no longer needed.</p>
-<p><img src="../../../guide/remove-test-driven-block.gif" class="img-fluid" style="width:50.0%"></p>
+<p><img src="../../../guide/model-documentation/remove-test-driven-block.gif" class="img-fluid" style="width:50.0%"></p>
 <p>To remove text blocks and test-driven blocks from model documentation, you first select the block you want to remove and click <i class="fa-solid fa-trash-can" aria-label="trash-can"></i>, either in the text-block’s toolbar or in the test-driven’s block single-button toolbar:</p>
 <p><a href="../../../guide/model-documentation/work-with-content-blocks.html#remove-content-blocks">Try it …</a></p>
 <!--- NR I don't think we have any user-facing docs for this feature ... 

--- a/site/_site/releases/2023/2023-releases.html
+++ b/site/_site/releases/2023/2023-releases.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-06-17">
+<meta name="dcterms.date" content="2024-06-26">
 
 <title>2023 Releases – ValidMind</title>
 <style>
@@ -486,7 +486,7 @@ window.Quarto = {
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">June 17, 2024</p>
+      <p class="date">June 26, 2024</p>
     </div>
   </div>
   
@@ -500,7 +500,7 @@ window.Quarto = {
 
 <div id="listing-2023-releases" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720036957198" data-listing-reading-time-sort="2" data-listing-word-count-sort="245">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720027646910" data-listing-reading-time-sort="2" data-listing-word-count-sort="245">
 <a href="../../releases/2023/2023-dec-13/highlights.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -514,7 +514,7 @@ This release includes bug fixes for the ValidMind Platform UI and reduces the ex
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720036957198" data-listing-reading-time-sort="3" data-listing-word-count-sort="545">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720028963656" data-listing-reading-time-sort="3" data-listing-word-count-sort="545">
 <a href="../../releases/2023/2023-nov-09/highlights.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -528,7 +528,7 @@ This release introduces support for several new models, a new user onboarding gu
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720036957199" data-listing-reading-time-sort="6" data-listing-word-count-sort="1001">
+<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720044001919" data-listing-reading-time-sort="6" data-listing-word-count-sort="1001">
 <a href="../../releases/2023/2023-oct-25/highlights.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -542,7 +542,7 @@ We’ve introduced a new guide for modifying configurations and parameters withi
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720036957200" data-listing-reading-time-sort="7" data-listing-word-count-sort="1317">
+<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720027646912" data-listing-reading-time-sort="7" data-listing-word-count-sort="1317">
 <a href="../../releases/2023/2023-sep-27/highlights.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -556,7 +556,7 @@ In this release, we’ve added support for large language models (LLMs) to enhan
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720036957198" data-listing-reading-time-sort="3" data-listing-word-count-sort="510">
+<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720027646910" data-listing-reading-time-sort="3" data-listing-word-count-sort="510">
 <a href="../../releases/2023/2023-aug-15/highlights.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -570,7 +570,7 @@ This release includes a number of improvements for the developer experience when
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720036957201" data-listing-reading-time-sort="5" data-listing-word-count-sort="849">
+<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720027646913" data-listing-reading-time-sort="5" data-listing-word-count-sort="849">
 <a href="../../releases/2023/release-notes-2023-jul-24.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -584,7 +584,7 @@ This release improves the developer experience within the ValidMind Developer Fr
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1720036957201" data-listing-reading-time-sort="3" data-listing-word-count-sort="511">
+<div class="g-col-1" data-index="6" data-listing-file-modified-sort="1720027646913" data-listing-reading-time-sort="3" data-listing-word-count-sort="511">
 <a href="../../releases/2023/release-notes-2023-jun-22.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -598,7 +598,7 @@ This release includes a number of major enhancements to the ValidMind Developer 
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="7" data-listing-file-modified-sort="1720036957201" data-listing-reading-time-sort="2" data-listing-word-count-sort="275">
+<div class="g-col-1" data-index="7" data-listing-file-modified-sort="1720027646914" data-listing-reading-time-sort="2" data-listing-word-count-sort="275">
 <a href="../../releases/2023/release-notes-2023-may-30.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/releases/2024-jan-18/highlights.html
+++ b/site/_site/releases/2024-jan-18/highlights.html
@@ -533,7 +533,7 @@ cookieconsent.run({
 <li>View existing group members</li>
 <li>Add or remove group members</li>
 </ul>
-<p>Try it in the platform UI: <a href="../../settings/groups">Groups</a></p>
+<p>Try it in the platform UI: <a href="https://app.prod.validmind.ai/settings/groups">Groups</a></p>
 </section>
 <section id="template-management" class="level4">
 <h4 class="anchored" data-anchor-id="template-management">Template management</h4>

--- a/site/_site/releases/2024-mar-27/highlights.html
+++ b/site/_site/releases/2024-mar-27/highlights.html
@@ -595,7 +595,7 @@ Your browser does not support the video tag.
 Your browser does not support the video tag.
 </video>
 <p><br></p>
-<p>Try it: <a href="https://app.dev.vm.validmind.ai/settings/groups">Groups</a></p>
+<p>Try it: <a href="https://app.prod.validmind.ai/settings/groups">Groups</a></p>
 <p>We also made improvements to how the invitation history gets displayed when you add new users to your organization:</p>
 <ul>
 <li>Added an <strong>Invite History</strong> table to show accepted invitations</li>
@@ -603,7 +603,7 @@ Your browser does not support the video tag.
 </ul>
 <p>Combined, these changes make it easier to see both pending and accepted invitations for new users joining your organization:</p>
 <p><img src="user-invite-history.png" class="img-fluid" style="width:80.0%" alt="A screenshot that highlights the user invitation history, showing both pending and accepted invitations to join your organization."></p>
-<p>Try it: <a href="https://app.dev.vm.validmind.ai/settings/invitation">Invite New Users</a></p>
+<p>Try it: <a href="https://app.prod.validmind.ai/settings/invitation">Invite New Users</a></p>
 </section>
 </section>
 </section>

--- a/site/_site/releases/2024-releases.html
+++ b/site/_site/releases/2024-releases.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2024-06-17">
+<meta name="dcterms.date" content="2024-06-26">
 
 <title>2024 Releases – ValidMind</title>
 <style>
@@ -282,7 +282,7 @@ window.Quarto = {
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">June 17, 2024</p>
+      <p class="date">June 26, 2024</p>
     </div>
   </div>
   
@@ -296,7 +296,7 @@ window.Quarto = {
 
 <div id="listing-2024-releases" class="quarto-listing quarto-listing-container-grid">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720036957204" data-listing-reading-time-sort="1" data-listing-word-count-sort="86">
+<div class="g-col-1" data-index="0" data-listing-file-modified-sort="1720027646917" data-listing-reading-time-sort="1" data-listing-word-count-sort="86">
 <a href="../releases/2024-jun-10/release-notes.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -310,7 +310,7 @@ Within the ValidMind Platform UI, you can now edit the names of your business un
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720036957225" data-listing-reading-time-sort="17" data-listing-word-count-sort="3281">
+<div class="g-col-1" data-index="1" data-listing-file-modified-sort="1720027646938" data-listing-reading-time-sort="17" data-listing-word-count-sort="3281">
 <a href="../releases/2024-may-22/release-notes.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -324,7 +324,7 @@ Our new end-to-end notebook gives you a full introduction to the ValidMind Devel
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720036957204" data-listing-reading-time-sort="11" data-listing-word-count-sort="2141">
+<div class="g-col-1" data-index="2" data-listing-file-modified-sort="1720044001920" data-listing-reading-time-sort="11" data-listing-word-count-sort="2147">
 <a href="../releases/2024-mar-27/highlights.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -338,7 +338,7 @@ This extensive release brings many improvements ValidMind, from the display of n
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720036957203" data-listing-reading-time-sort="10" data-listing-word-count-sort="1831">
+<div class="g-col-1" data-index="3" data-listing-file-modified-sort="1720028963656" data-listing-reading-time-sort="10" data-listing-word-count-sort="1831">
 <a href="../releases/2024-feb-14/highlights.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -352,7 +352,7 @@ We’ve improved the ValidMind user experience, from more supportive documentati
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720036957204" data-listing-reading-time-sort="7" data-listing-word-count-sort="1400">
+<div class="g-col-1" data-index="4" data-listing-file-modified-sort="1720027646917" data-listing-reading-time-sort="7" data-listing-word-count-sort="1400">
 <a href="../releases/2024-jan-26/highlights.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">
@@ -366,7 +366,7 @@ This release includes numerous improvements to the developer framework, includin
 </div>
 </a>
 </div>
-<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720036957204" data-listing-reading-time-sort="6" data-listing-word-count-sort="1130">
+<div class="g-col-1" data-index="5" data-listing-file-modified-sort="1720044001919" data-listing-reading-time-sort="6" data-listing-word-count-sort="1133">
 <a href="../releases/2024-jan-18/highlights.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="card-body post-contents">

--- a/site/_site/search.json
+++ b/site/_site/search.json
@@ -4355,7 +4355,7 @@
     "href": "guide/model-inventory/customize-model-inventory-layout.html#prerequisites",
     "title": "Customize model inventory layout",
     "section": "Prerequisites",
-    "text": "Prerequisites\nThere are models registered in the model inventory1.\n\n\n1 Learn how to register models in the inventory.",
+    "text": "Prerequisites\nThere are models registered in the model inventory1.\n\n\n1 Register models in the inventory",
     "crumbs": [
       "Guides",
       "Working with the model inventory",
@@ -5672,7 +5672,7 @@
     "href": "guide/model-validation/work-with-model-findings.html#add-project-findings",
     "title": "Work with model findings",
     "section": "Add project findings",
-    "text": "Add project findings\n\nLog in to the ValidMind Platform UI.\nIn the left sidebar, click Model Inventory4.\nSelect a model by clicking on it or find your model by applying a filter or searching for it.\nIn the left sidebar that appears for your model, click Documentation.\n\nYou can now either log a finding on this overview page, or via a specific documentation section. Both methods will allow you to associate a finding with a documentation section.\n\n\n4 Learn how to work with the model inventory.\n\nAdd finding via overview\nTo log a finding from the documentation overview:\n\nOn your model’s Documentation page, click Add Finding.\nOn the Add Model Finding page that opens, provide information for:\n\nTitle\nRisk area\nOwner\nSeverity\nDue date\nDocumentation section\nDescription\n\nAt a minimum, you must provide the required information indicated by *.\nWhen you are done, click Save to submit the finding.\n\n\n\nAdd finding via section\nWhile working within a section of your documentation, you can easily log a finding associated with that section without leaving the page:\n\nClick on ValidMind Insights™ to expand the insight panel.\nFor the section you want to add a Finding for, click  Add Finding beneath the Documentation Guidelines.\nOn the Add Model Finding page that opens, provide information for:\n\nTitle\nRisk area\nOwner\nSeverity\nDue date\nDocumentation section\nDescription\n\nAt a minimum, you must provide the required information indicated indicated by *. The documentation section will be auto-populated with the section you are working from — you are able to select another section if desired.\nWhen you are done, click Save to submit the finding.",
+    "text": "Add project findings\n\nLog in to the ValidMind Platform UI.\nIn the left sidebar, click Model Inventory4.\nSelect a model by clicking on it or find your model by applying a filter or searching for it.\nIn the left sidebar that appears for your model, click Documentation.\n\nYou can now either log a finding on this overview page, or via a specific documentation section. Both methods will allow you to associate a finding with a documentation section.\n\n\n4 Work with the model inventory\n\nAdd finding via overview\nTo log a finding from the documentation overview:\n\nOn your model’s Documentation page, click Add Finding.\nOn the Add Model Finding page that opens, provide information for:\n\nTitle\nRisk area\nOwner\nSeverity\nDue date\nDocumentation section\nDescription\n\nAt a minimum, you must provide the required information indicated by *.\nWhen you are done, click Save to submit the finding.\n\n\n\nAdd finding via section\nWhile working within a section of your documentation, you can easily log a finding associated with that section without leaving the page:\n\nClick on ValidMind Insights™ to expand the insight panel.\nFor the section you want to add a Finding for, click  Add Finding beneath the Documentation Guidelines.\nOn the Add Model Finding page that opens, provide information for:\n\nTitle\nRisk area\nOwner\nSeverity\nDue date\nDocumentation section\nDescription\n\nAt a minimum, you must provide the required information indicated indicated by *. The documentation section will be auto-populated with the section you are working from — you are able to select another section if desired.\nWhen you are done, click Save to submit the finding.",
     "crumbs": [
       "Guides",
       "Work with model findings"
@@ -5683,7 +5683,7 @@
     "href": "guide/model-validation/work-with-model-findings.html#update-project-findings",
     "title": "Work with model findings",
     "section": "Update project findings",
-    "text": "Update project findings\nAs project findings get resolved or require other changes during the model validation process, you can update them:\n\nLog in to the ValidMind Platform UI.\nIn the left sidebar, click Model Findings.\nOn the page that opens, click on the finding you want to update or apply a filter to locate the correct finding first5.\nOn the page that opens, make your updates to the finding. You can make updates to:\n\nDescription\nProposed remediation plan\nStatus\nSeverity\nRisk area\nDue date\nAssignee\nDocumentation section\n\n\n\n\n5 Learn how to filter project findings.\nMost updates are applied immediately but you must click Save to make changes to the finding description and proposed remediation plan effective.",
+    "text": "Update project findings\nAs project findings get resolved or require other changes during the model validation process, you can update them:\n\nLog in to the ValidMind Platform UI.\nIn the left sidebar, click Model Findings.\nOn the page that opens, click on the finding you want to update or apply a filter to locate the correct finding first5.\nOn the page that opens, make your updates to the finding. You can make updates to:\n\nDescription\nProposed remediation plan\nStatus\nSeverity\nRisk area\nDue date\nAssignee\nDocumentation section\n\n\n\n\n5 Filter project findings\nMost updates are applied immediately but you must click Save to make changes to the finding description and proposed remediation plan effective.",
     "crumbs": [
       "Guides",
       "Work with model findings"
@@ -6114,7 +6114,7 @@
     "href": "guide/model-inventory/working-with-model-inventory.html#prerequisites",
     "title": "Working with the model inventory",
     "section": "Prerequisites",
-    "text": "Prerequisites\nThere are models registered in the model inventory1.\n\n\n1 Learn how to register models in the inventory.",
+    "text": "Prerequisites\nThere are models registered in the model inventory1.\n\n\n1 Register models in the inventory",
     "crumbs": [
       "Guides",
       "Working with the model inventory"

--- a/site/_site/validmind/validmind.html
+++ b/site/_site/validmind/validmind.html
@@ -150,7 +150,7 @@ and to upload to the ValidMind Platform.</p>
                 <section id="__version__">
                     <div class="attr variable">
             <span class="name">__version__</span>        =
-<span class="default_value">&#39;2.4.0&#39;</span>
+<span class="default_value">&#39;2.4.3&#39;</span>
 
         
     </div>
@@ -196,7 +196,7 @@ Defaults to None.</li>
                     <div class="attr function">
             
         <span class="def">def</span>
-        <span class="name">init</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="n">project</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">api_key</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">api_secret</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">api_host</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span></span><span class="return-annotation">):</span></span>
+        <span class="name">init</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="n">project</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">api_key</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">api_secret</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">api_host</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">model</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span></span><span class="return-annotation">):</span></span>
 
         
     </div>
@@ -211,7 +211,8 @@ retrieve them from the environment variables <code>VM_API_KEY</code> and <code>V
 <h6 id="arguments">Arguments:</h6>
 
 <ul>
-<li><strong>project (str):</strong>  The project CUID</li>
+<li><strong>project (str, optional):</strong>  The project CUID. Alias for model. Defaults to None.</li>
+<li><strong>model (str, optional):</strong>  The model CUID. Defaults to None.</li>
 <li><strong>api_key (str, optional):</strong>  The API key. Defaults to None.</li>
 <li><strong>api_secret (str, optional):</strong>  The API secret. Defaults to None.</li>
 <li><strong>api_host (str, optional):</strong>  The API host. Defaults to None.</li>

--- a/site/_site/validmind/validmind/tests/data_validation/TabularDescriptionTables.html
+++ b/site/_site/validmind/validmind/tests/data_validation/TabularDescriptionTables.html
@@ -32,37 +32,25 @@
             <h3>High Level API</h3>
                 <ul class="memberlist">
             <li>
-                    <a class="class" href="#TabularDescriptionTables">TabularDescriptionTables</a>
-                            <ul class="memberlist">
-                        <li>
-                                <a class="function" href="#TabularDescriptionTables.__init__">TabularDescriptionTables</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#TabularDescriptionTables.get_summary_statistics_numerical">get_summary_statistics_numerical</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#TabularDescriptionTables.get_summary_statistics_categorical">get_summary_statistics_categorical</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#TabularDescriptionTables.get_summary_statistics_datetime">get_summary_statistics_datetime</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#TabularDescriptionTables.summary">summary</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#TabularDescriptionTables.get_categorical_columns">get_categorical_columns</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#TabularDescriptionTables.get_numerical_columns">get_numerical_columns</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#TabularDescriptionTables.get_datetime_columns">get_datetime_columns</a>
-                        </li>
-                        <li>
-                                <a class="function" href="#TabularDescriptionTables.run">run</a>
-                        </li>
-                </ul>
-
+                    <a class="function" href="#TabularDescriptionTables">TabularDescriptionTables</a>
+            </li>
+            <li>
+                    <a class="function" href="#get_summary_statistics_numerical">get_summary_statistics_numerical</a>
+            </li>
+            <li>
+                    <a class="function" href="#get_summary_statistics_categorical">get_summary_statistics_categorical</a>
+            </li>
+            <li>
+                    <a class="function" href="#get_summary_statistics_datetime">get_summary_statistics_datetime</a>
+            </li>
+            <li>
+                    <a class="function" href="#get_categorical_columns">get_categorical_columns</a>
+            </li>
+            <li>
+                    <a class="function" href="#get_numerical_columns">get_numerical_columns</a>
+            </li>
+            <li>
+                    <a class="function" href="#get_datetime_columns">get_datetime_columns</a>
             </li>
     </ul>
 
@@ -87,11 +75,12 @@
                 
             </section>
                 <section id="TabularDescriptionTables">
-                    <div class="attr class">
-                    <div class="decorator">@dataclass</div>
+                    <div class="attr function">
+                    <div class="decorator">@tags(&#39;tabular_data&#39;)</div>
+        <div class="decorator">@tasks(&#39;classification&#39;, &#39;regression&#39;)</div>
 
-    <span class="def">class</span>
-    <span class="name">TabularDescriptionTables</span><wbr>(<span class="base">validmind.vm_models.test.metric.Metric</span>):
+        <span class="def">def</span>
+        <span class="name">TabularDescriptionTables</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">dataset</span></span><span class="return-annotation">):</span></span>
 
         
     </div>
@@ -151,152 +140,84 @@ chosen algorithm.</li>
 </div>
 
 
-                            <div id="TabularDescriptionTables.__init__" class="classattr">
-                                <div class="attr function">
-            
-        <span class="name">TabularDescriptionTables</span><span class="signature pdoc-code multiline">(<span class="param">	<span class="n">context</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">validmind</span><span class="o">.</span><span class="n">vm_models</span><span class="o">.</span><span class="n">test_context</span><span class="o">.</span><span class="n">TestContext</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">inputs</span><span class="p">:</span> <span class="n">Optional</span><span class="p">[</span><span class="n">validmind</span><span class="o">.</span><span class="n">vm_models</span><span class="o">.</span><span class="n">test_context</span><span class="o">.</span><span class="n">TestInput</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">tasks</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">tags</span><span class="p">:</span> <span class="n">List</span><span class="p">[</span><span class="nb">str</span><span class="p">]</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">_ref_id</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">_section_id</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">test_id</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">result</span><span class="p">:</span> <span class="n">validmind</span><span class="o">.</span><span class="n">vm_models</span><span class="o">.</span><span class="n">test</span><span class="o">.</span><span class="n">result_wrapper</span><span class="o">.</span><span class="n">MetricResultWrapper</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">params</span><span class="p">:</span> <span class="nb">dict</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">output_template</span><span class="p">:</span> <span class="nb">str</span> <span class="o">=</span> <span class="kc">None</span>,</span><span class="param">	<span class="n">generate_description</span><span class="p">:</span> <span class="nb">bool</span> <span class="o">=</span> <span class="kc">True</span></span>)</span>
-
-        
-    </div>
-    <a class="headerlink" href="#TabularDescriptionTables.__init__"></a>
-    
-    
-
-                            </div>
-                            <div id="TabularDescriptionTables.get_summary_statistics_numerical" class="classattr">
-                                <div class="attr function">
+                </section>
+                <section id="get_summary_statistics_numerical">
+                    <div class="attr function">
             
         <span class="def">def</span>
-        <span class="name">get_summary_statistics_numerical</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">numerical_fields</span></span><span class="return-annotation">):</span></span>
+        <span class="name">get_summary_statistics_numerical</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">dataset</span>, </span><span class="param"><span class="n">numerical_fields</span></span><span class="return-annotation">):</span></span>
 
         
     </div>
-    <a class="headerlink" href="#TabularDescriptionTables.get_summary_statistics_numerical"></a>
+    <a class="headerlink" href="#get_summary_statistics_numerical"></a>
     
     
 
-                            </div>
-                            <div id="TabularDescriptionTables.get_summary_statistics_categorical" class="classattr">
-                                <div class="attr function">
+                </section>
+                <section id="get_summary_statistics_categorical">
+                    <div class="attr function">
             
         <span class="def">def</span>
-        <span class="name">get_summary_statistics_categorical</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">categorical_fields</span></span><span class="return-annotation">):</span></span>
+        <span class="name">get_summary_statistics_categorical</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">dataset</span>, </span><span class="param"><span class="n">categorical_fields</span></span><span class="return-annotation">):</span></span>
 
         
     </div>
-    <a class="headerlink" href="#TabularDescriptionTables.get_summary_statistics_categorical"></a>
+    <a class="headerlink" href="#get_summary_statistics_categorical"></a>
     
     
 
-                            </div>
-                            <div id="TabularDescriptionTables.get_summary_statistics_datetime" class="classattr">
-                                <div class="attr function">
+                </section>
+                <section id="get_summary_statistics_datetime">
+                    <div class="attr function">
             
         <span class="def">def</span>
-        <span class="name">get_summary_statistics_datetime</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">datetime_fields</span></span><span class="return-annotation">):</span></span>
+        <span class="name">get_summary_statistics_datetime</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">dataset</span>, </span><span class="param"><span class="n">datetime_fields</span></span><span class="return-annotation">):</span></span>
 
         
     </div>
-    <a class="headerlink" href="#TabularDescriptionTables.get_summary_statistics_datetime"></a>
+    <a class="headerlink" href="#get_summary_statistics_datetime"></a>
     
     
 
-                            </div>
-                            <div id="TabularDescriptionTables.summary" class="classattr">
-                                <div class="attr function">
+                </section>
+                <section id="get_categorical_columns">
+                    <div class="attr function">
             
         <span class="def">def</span>
-        <span class="name">summary</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span>, </span><span class="param"><span class="n">metric_value</span></span><span class="return-annotation">):</span></span>
+        <span class="name">get_categorical_columns</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">dataset</span></span><span class="return-annotation">):</span></span>
 
         
     </div>
-    <a class="headerlink" href="#TabularDescriptionTables.summary"></a>
+    <a class="headerlink" href="#get_categorical_columns"></a>
     
-            <div class="docstring"><p>Return the metric summary. Should be overridden by subclasses. Defaults to None.
-The metric summary allows renderers (e.g. Word and ValidMind UI) to display a
-short summary of the metric results.</p>
+    
 
-<p>We return None here because the metric summary is optional.</p>
-</div>
-
-
-                            </div>
-                            <div id="TabularDescriptionTables.get_categorical_columns" class="classattr">
-                                <div class="attr function">
+                </section>
+                <section id="get_numerical_columns">
+                    <div class="attr function">
             
         <span class="def">def</span>
-        <span class="name">get_categorical_columns</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">):</span></span>
+        <span class="name">get_numerical_columns</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">dataset</span></span><span class="return-annotation">):</span></span>
 
         
     </div>
-    <a class="headerlink" href="#TabularDescriptionTables.get_categorical_columns"></a>
+    <a class="headerlink" href="#get_numerical_columns"></a>
     
     
 
-                            </div>
-                            <div id="TabularDescriptionTables.get_numerical_columns" class="classattr">
-                                <div class="attr function">
+                </section>
+                <section id="get_datetime_columns">
+                    <div class="attr function">
             
         <span class="def">def</span>
-        <span class="name">get_numerical_columns</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">):</span></span>
+        <span class="name">get_datetime_columns</span><span class="signature pdoc-code condensed">(<span class="param"><span class="n">dataset</span></span><span class="return-annotation">):</span></span>
 
         
     </div>
-    <a class="headerlink" href="#TabularDescriptionTables.get_numerical_columns"></a>
+    <a class="headerlink" href="#get_datetime_columns"></a>
     
     
 
-                            </div>
-                            <div id="TabularDescriptionTables.get_datetime_columns" class="classattr">
-                                <div class="attr function">
-            
-        <span class="def">def</span>
-        <span class="name">get_datetime_columns</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">):</span></span>
-
-        
-    </div>
-    <a class="headerlink" href="#TabularDescriptionTables.get_datetime_columns"></a>
-    
-    
-
-                            </div>
-                            <div id="TabularDescriptionTables.run" class="classattr">
-                                <div class="attr function">
-            
-        <span class="def">def</span>
-        <span class="name">run</span><span class="signature pdoc-code condensed">(<span class="param"><span class="bp">self</span></span><span class="return-annotation">):</span></span>
-
-        
-    </div>
-    <a class="headerlink" href="#TabularDescriptionTables.run"></a>
-    
-            <div class="docstring"><p>Run the calculation and cache its results</p>
-</div>
-
-
-                            </div>
-                            <div class="inherited">
-                                <h5>Inherited Members</h5>
-                                <dl>
-                                    <div><dt>validmind.vm_models.test.metric.Metric</dt>
-                                <dd id="TabularDescriptionTables.cache_results" class="function">cache_results</dd>
-
-            </div>
-            <div><dt>validmind.vm_models.test.test.Test</dt>
-                                <dd id="TabularDescriptionTables.description" class="function">description</dd>
-                <dd id="TabularDescriptionTables.log" class="function">log</dd>
-
-            </div>
-            <div><dt>validmind.vm_models.test_context.TestUtils</dt>
-                                <dd id="TabularDescriptionTables.get_accessed_inputs" class="function">get_accessed_inputs</dd>
-                <dd id="TabularDescriptionTables.dataset" class="variable">dataset</dd>
-                <dd id="TabularDescriptionTables.model" class="variable">model</dd>
-                <dd id="TabularDescriptionTables.models" class="variable">models</dd>
-                <dd id="TabularDescriptionTables.validate_inputs" class="function">validate_inputs</dd>
-
-            </div>
-                                </dl>
-                            </div>
                 </section>
     </main>
 <script>

--- a/site/get-started/get-started.qmd
+++ b/site/get-started/get-started.qmd
@@ -65,7 +65,7 @@ New model registration
 : Select a documentation template when registering a new inventory model to start your model documentation. You then use the model inventory to manage the metadata associated with the model, including all compliance and regulatory attributes. 
 
 **Initial validation**
-: Triggers a new [documentation workflow](#documentation-workflow) to yield a model that will be ready for production deployment after its documentation and validation reports have been approved. 
+: Triggers a new [documentation workflow](/guide/model-workflows/working-with-model-workflows.qmd) to yield a model that will be ready for production deployment after its documentation and validation reports have been approved. 
 
 **Validation approval**
 : Perform validation of the model to ensure that it meets the needs for which it was designed. You can also connect to third-party systems to send events when a model has been approved for production.

--- a/site/guide/model-inventory/customize-model-inventory-layout.qmd
+++ b/site/guide/model-inventory/customize-model-inventory-layout.qmd
@@ -13,7 +13,7 @@ Changes are automatically saved to your account and will not affect other users.
 There are models registered in the model inventory^1^.
 
 ::: {.column-margin}
-^1^ Learn how to [register models in the inventory](register-models-in-inventory.qmd).
+^1^ [Register models in the inventory](register-models-in-inventory.qmd)
 :::
 
 ## Steps

--- a/site/guide/model-inventory/working-with-model-inventory.qmd
+++ b/site/guide/model-inventory/working-with-model-inventory.qmd
@@ -18,7 +18,7 @@ Use the model inventory within the {{< var vm_platform >}} to easily track compr
 There are models registered in the model inventory^1^.
 
 ::: {.column-margin}
-^1^ Learn how to [register models in the inventory](register-models-in-inventory.qmd).
+^1^ [Register models in the inventory](register-models-in-inventory.qmd)
 :::
 
 ## Search, filter, and sort models

--- a/site/guide/model-validation/work-with-model-findings.qmd
+++ b/site/guide/model-validation/work-with-model-findings.qmd
@@ -79,7 +79,7 @@ Filters can be removed by clicking on the {{< fa xmark >}} next to them on the m
 {{< include _work-with-model-findings-add-findings.qmd >}}
 
 ::: {.column-margin}
-^4^ Learn how to [work with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd).
+^4^ [Work with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd)
 :::
 
 #### Add finding via overview
@@ -146,7 +146,7 @@ As project findings get resolved or require other changes during the model valid
    - Documentation section
 
 ::: {.column-margin}
-^5^ Learn how to [filter project findings](#filter-project-findings).
+^5^ [Filter project findings](#filter-project-findings)
 :::
 
 Most updates are applied immediately but you must click **Save** to make changes to the finding description and proposed remediation plan effective. 

--- a/site/guide/model-workflows/working-with-model-workflows.qmd
+++ b/site/guide/model-workflows/working-with-model-workflows.qmd
@@ -4,6 +4,7 @@ date: last-modified
 listing:
   - id: model-workflows-listing
     type: grid
+    grid-columns: 2
     max-description-length: 250
     sort: false
     fields: [title, description]

--- a/site/releases/2023/2023-oct-25/highlights.qmd
+++ b/site/releases/2023/2023-oct-25/highlights.qmd
@@ -62,7 +62,7 @@ This notebook serves as a guide for modifying configuration and parameters withi
 
 You can now remove blocks of text or test-related content from model documentation in the editor of the {{< var vm_ui >}}. This new feature gives you more control over your documentation and enables you to remove content that is no longer needed.
 
-![](/guide/remove-test-driven-block.gif){width=50%}
+![](/guide/model-documentation/remove-test-driven-block.gif){width=50%}
 
 To remove text blocks and test-driven blocks from model documentation, you first select the block you want to remove and click {{< fa trash-can >}}, either in the text-block's toolbar or in the test-driven's block single-button toolbar:
 

--- a/site/releases/2024-jan-18/highlights.qmd
+++ b/site/releases/2024-jan-18/highlights.qmd
@@ -66,7 +66,7 @@ These features enable you to:
 -   View existing group members
 -   Add or remove group members
 
-Try it in the {{< var vm_ui >}}: [Groups](/settings/groups)
+Try it in the {{< var vm_ui >}}: [Groups]({{< var vm_url >}}/settings/groups)
 
 #### Template management
 

--- a/site/releases/2024-mar-27/highlights.qmd
+++ b/site/releases/2024-mar-27/highlights.qmd
@@ -113,7 +113,7 @@ You can create new user groups under **Settings** > **Groups**:
   Your browser does not support the video tag.
 </video><br>
 
-Try it: [Groups](https://app.dev.vm.validmind.ai/settings/groups)
+Try it: [Groups]({{< var vm_url >}}/settings/groups)
 
 We also made improvements to how the invitation history gets displayed when you add new users to your organization:
 
@@ -124,7 +124,7 @@ Combined, these changes make it easier to see both pending and accepted invitati
 
 ![](user-invite-history.png){width=80% fig-alt="A screenshot that highlights the user invitation history, showing both pending and accepted invitations to join your organization."}
 
-Try it: [Invite New Users](https://app.dev.vm.validmind.ai/settings/invitation)
+Try it: [Invite New Users]({{< var vm_url >}}/settings/invitation)
 
 ## Enhancements
 


### PR DESCRIPTION
## Internal Notes for Reviewers

> For sc-4799, I published the site to `docs-demo` and stressed tested nearly everything:
> 
> - I clicked on EVERY link in the top-nav & side-nav
> - I clicked on EVERY inline link (including in all the releases and training), other than the ones in sourced `.ipynb` files as those will be taken care of instead in sc-5132. (**Placeholders are in effect:** e.g [Get started](https://docs-demo.vm.validmind.ai/guide/get-started.html))
> - I clicked on EVERY notebook and EVERY test description to make sure they loaded correctly
> - I clicked on EVERY entry in the developer reference

### Files fixed

#### `/get-started/get-started.qmd`
> This file had an empty link in "Initial validation" to a header that no longer existed, so I just swapped it in for our workflow docs:

| Old | New |
|---|---|
| ![Screenshot 2024-07-03 at 12 02 53 PM](https://github.com/validmind/documentation/assets/164545837/0f8acfbb-d87c-419e-84a5-f32d83912046) | ![Screenshot 2024-07-03 at 12 03 20 PM](https://github.com/validmind/documentation/assets/164545837/78822e00-abbb-47f0-886d-1bee7ff1be56) |

#### `/guide/model-workflows/working-with-model-workflows.qmd`
> Made the "What's next" cards into 2 columns: 

| Old | New |
|---|---|
| <img width="729" alt="Screenshot 2024-07-03 at 12 28 05 PM" src="https://github.com/validmind/documentation/assets/164545837/c8749d0f-95a3-41cd-b659-41de8b8c5a88"> | <img width="751" alt="Screenshot 2024-07-03 at 12 27 11 PM" src="https://github.com/validmind/documentation/assets/164545837/8997a620-d57f-4caf-90ed-6a0f6dbbdda4"> |

#### Simplified footenotes
> Simplified the margin footnotes on these pages:

| Page | Old | New |
|---|---|---|
| Working with the model inventory | <img width="1019" alt="Screenshot 2024-07-03 at 12 05 34 PM" src="https://github.com/validmind/documentation/assets/164545837/af0b4c44-1eeb-46cd-8301-ebb096663e44"> | <img width="1023" alt="Screenshot 2024-07-03 at 12 05 43 PM" src="https://github.com/validmind/documentation/assets/164545837/df238df5-b410-4a35-b4db-f975275d819d"> |
| Customize model inventory layout | <img width="1044" alt="Screenshot 2024-07-03 at 12 07 08 PM" src="https://github.com/validmind/documentation/assets/164545837/2dd6d614-851d-40b9-b67d-da7b800a269b"> | <img width="997" alt="Screenshot 2024-07-03 at 12 07 12 PM" src="https://github.com/validmind/documentation/assets/164545837/7f5605c0-e7ff-48c4-ac23-2b85174b3101"> |
| Work with model findings | <img width="532" alt="Screenshot 2024-07-03 at 12 09 02 PM" src="https://github.com/validmind/documentation/assets/164545837/236d4c02-88ba-47b1-8ca0-70a3988118cb"> | <img width="545" alt="Screenshot 2024-07-03 at 12 09 17 PM" src="https://github.com/validmind/documentation/assets/164545837/ae7b88a9-9654-40a1-ac22-9864d137aa99"> |

#### Broken links & images in releases
> This file had an empty link in "Initial validation" to a header that no longer existed, so I just swapped it in for our workflow docs:

| Release | Old | New |
|---|---|---|
| October 25, 2023 | <img width="988" alt="Screenshot 2024-07-03 at 12 11 48 PM" src="https://github.com/validmind/documentation/assets/164545837/75e65f93-ac01-4e94-ab41-55ee13047875"> | <img width="987" alt="Screenshot 2024-07-03 at 12 11 55 PM" src="https://github.com/validmind/documentation/assets/164545837/41132d39-c1fd-4d04-8f16-2378a74ff38c"> |
| March 27, 2024 | These for some reason [linked out to staging instead of prod](https://github.com/validmind/documentation/blob/c62310c9f51e4f50d40fcc1d4f4ff64b20590b47/site/releases/2024-mar-27/highlights.qmd#L116): `Try it: [Groups](https://app.dev.vm.validmind.ai/settings/groups)` & `Try it: [Invite New Users](https://app.dev.vm.validmind.ai/settings/invitation)` | `Try it: [Groups]({{< var vm_url >}}/settings/groups)` & `Try it: [Invite New Users]({{< var vm_url >}}/settings/invitation)` |
| January 18, 2024 | [This linked out to the docs instead of the UI](https://github.com/validmind/documentation/blob/c62310c9f51e4f50d40fcc1d4f4ff64b20590b47/site/releases/2024-jan-18/highlights.qmd#L69).  | `Try it in the {{< var vm_ui >}}: [Groups]({{< var vm_url >}}/settings/groups)` |

### `validmind.__version__`
> I am not sure if this page in the developer reference is meant to be blank? @nrichers: https://docs-demo.vm.validmind.ai/validmind/validmind/__version__.html

It's like that currently on the prod/live site as well.