### PR TITLE
Fixing Makefile to not change nlp_and_llm to NLP_and_LLM

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -46,10 +46,6 @@ notebooks:
 	@if [ -f "$(DEST_DIR_NB)/code_samples/quickstart_customer_churn_full_suite.ipynb" ]; then mv $(DEST_DIR_NB)/code_samples/quickstart_customer_churn_full_suite.ipynb $(DEST_DIR_NB)/quickstart_customer_churn_full_suite.ipynb; fi
 	@echo "Zip up notebooks.zip ..."
 	@zip -r notebooks.zip $(DEST_DIR_NB) > /dev/null 2>&1
-    # This line fixes text casing in Quarto when notebooks are embedded via wildcard
-	@echo "Renaming code_samples/nlp_and_llm to fix Quarto sidebar ..."
-	@if [ -d "$(DEST_DIR_NB)/code_samples/nlp_and_llm" ]; then mv $(DEST_DIR_NB)/code_samples/nlp_and_llm $(DEST_DIR_NB)/code_samples/NLP_and_LLM; fi
-
 
 # Make Python library docs & copy them over
 python-docs:


### PR DESCRIPTION
## Internal Notes for Reviewers
Was trying to fix the folder name to `nlp_and_llm` and make it still display `NLP and LLM` but that was a sad sad rabbit hole. As per the recent comments on the associated story, I just fixed the file name by editing the Makefile.

The other files changed were just from running `make notebooks` for testing and from running `quarto render` as well.
<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->