### PR TITLE
Fiddled with callout & link padding, edited README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ site
 Core files you manipulate live under `site` in these key directories that more or less correlate to the sections of the docs site reachable via the top navigation bar:
 
 - `about` 
-- `developer-framework` 
+- `developer` 
 - `faq` 
 - `get-started` 
 - `guide`  

--- a/site/styles.css
+++ b/site/styles.css
@@ -30,7 +30,7 @@ a {
 
 a:hover {
   text-decoration: underline 2px solid black;
-  text-underline-offset: 6px;
+  /* text-underline-offset: 6px; */
 }
 
 a.footnote-ref:hover, a.anchorjs-link:hover {
@@ -128,6 +128,11 @@ div.callout.callout {
   border: 1px solid #DE257E;
   border-left-width: 5px;
   background: #B5B5B510;
+}
+
+.callout-title-container {
+  /* color: #DE257E; */
+  margin-bottom: 10px;
 }
 
 .card {


### PR DESCRIPTION
## Internal Notes for Reviewers

> sc-5449

### Added some padding to callout titles 
| Old | New |
|---|---|
| <img width="934" alt="Screenshot 2024-07-15 at 11 08 50 AM" src="https://github.com/user-attachments/assets/8c504da1-e76b-4136-ba24-1d5f03bea3e3">| <img width="973" alt="Screenshot 2024-07-15 at 11 08 45 AM" src="https://github.com/user-attachments/assets/aabbe7c2-254c-4575-9b58-bbad543a4111">|
|<img width="952" alt="Screenshot 2024-07-15 at 11 08 54 AM" src="https://github.com/user-attachments/assets/ad4e8c94-13aa-46f2-b388-d7151677076f"> |<img width="950" alt="Screenshot 2024-07-15 at 11 08 58 AM" src="https://github.com/user-attachments/assets/d03d786e-85d8-44ff-a615-0dc1e3cd2744">|

### Updated README
I noticed today during the demo that `developer-framework` folder in the directory reference should actually just be `developer`, so I fixed that.

### Adjusted link underline padding
I removed the additional padding for the link underlines as I actually realised that with the thickened underline it looks better (and more cohesive) closer to the text (and a bit artsy, too).

| Old | New |
|---|---|
|![old](https://github.com/user-attachments/assets/5875aacc-2c83-44b9-a1c2-926b118baaa2) | ![new](https://github.com/user-attachments/assets/4e297712-415a-4c3a-81dd-e75be49ad2f2)|