### PR TITLE
Add basic Nutshell example for experimentation

### DIFF
--- a/site/_log-in.qmd
+++ b/site/_log-in.qmd
@@ -1,0 +1,2 @@
+##### {{< fa circle-exclamation >}} Before you begin
+Make sure you are [logged in to the ValidMind Platform UI](/link-to-login-page.qmd).

--- a/site/guide/configuration/managing-your-organization.qmd
+++ b/site/guide/configuration/managing-your-organization.qmd
@@ -11,6 +11,8 @@ listing:
     contents:
     - set-up-your-organization.qmd
     - configure-aws-privatelink.qmd
+filters:
+   - nutshell
 ---
 
 Access to the {{< var validmind_platform >}} is associated with an organization, which encompasses all your users, groups, and business units. As a user, you can belong to multiple organizations.
@@ -24,7 +26,8 @@ To perform these steps, you must have access to the {{< var vm_login >}}.
 You will only see the option to switch between organizations if you belong to more than one organization.
 :::
 
-1. Log in to the {{< var vm_login >}}.
+
+1. [:Log into ValidMind](/guide/step-1.qmd#x-invisible)
 
 2. Click **{{< fa gear >}} Settings**. 
 

--- a/site/guide/configuration/managing-your-organization.qmd
+++ b/site/guide/configuration/managing-your-organization.qmd
@@ -27,7 +27,7 @@ You will only see the option to switch between organizations if you belong to mo
 :::
 
 
-1. [:Log into ValidMind](/guide/step-1.qmd#x-invisible)
+1. [:Log in to ValidMind](/nutshell/login.qmd#x-step-1).
 
 2. Click **{{< fa gear >}} Settings**. 
 

--- a/site/guide/model-inventory/register-models-in-inventory.qmd
+++ b/site/guide/model-inventory/register-models-in-inventory.qmd
@@ -10,16 +10,16 @@ To be able to document models using ValidMind's model documentation and validati
 - You are the model owner.
 - You hold the `Developer` role.[^1] 
 
+{{< include /_log-in.qmd >}}
+
 ## Steps
 
-1. Log in to the {{< var vm_login >}}.
-
-2. Click **Model Inventory** in the left sidebar. 
+1. Click **Model Inventory** in the left sidebar. 
 <!--- **Need screenshot** --->
    
-3. Click **Register new model**.
+2. Click **Register new model**.
    
-4. Fill in the required information on the registration form:
+3. Fill in the required information on the registration form:
 
    - Provide a model name
    - Select the relevant business unit
@@ -29,7 +29,7 @@ To be able to document models using ValidMind's model documentation and validati
    - Select the preliminary risk tier for the model
    - If the model is a vendor model, toggle **Is Vendor Model**[^2] and provide the vendor name.
 
-5. Click **Register new model** to create a new entry in the model inventory.
+4. Click **Register new model** to create a new entry in the model inventory.
 
    You can now access the model details from the **Model Inventory** page.
 

--- a/site/guide/step-1.qmd
+++ b/site/guide/step-1.qmd
@@ -1,0 +1,12 @@
+## :x invisible
+
+<!-- Use `## :x header` to include an invisible section that can be linked to via nutshell  -->
+
+In a web browser, open one of the the URLs for the {{< var validmind_platform >}}:
+   
+| Name | Provider | Region | URL |
+|--|--|--|----------|
+| US1 | AWS | us-east-1 | [{{< var vm_url_us1 >}}]({{< var vm_url_us1 >}}) |
+| CA1 | AWS | ca-west-1 | [{{< var vm_url_ca1 >}}]({{< var vm_url_ca1 >}}) |
+   
+   If unsure which URL to use, we recommend US1 or consult your organization for data stewardship requirements. For instance, if your data must stay in Canada, use CA1.

--- a/site/nutshell/login.qmd
+++ b/site/nutshell/login.qmd
@@ -1,11 +1,11 @@
-## :x invisible
+## :x step-1
 
 <!-- Use `## :x header` to include an invisible section that can be linked to via nutshell  -->
 
 In a web browser, open one of the the URLs for the {{< var validmind_platform >}}:
    
-| Name | Provider | Region | URL |
-|--|--|--|----------|
+| Name    | Provider    | Region          | URL |
+|---|---|---|---|
 | US1 | AWS | us-east-1 | [{{< var vm_url_us1 >}}]({{< var vm_url_us1 >}}) |
 | CA1 | AWS | ca-west-1 | [{{< var vm_url_ca1 >}}]({{< var vm_url_ca1 >}}) |
    

--- a/site/styles.css
+++ b/site/styles.css
@@ -231,6 +231,11 @@ pre, pre.python, pre.bash, pre.yaml {
   opacity: 1;
 }
 
+.nutshell-expandable:hover {
+  color: #DE257E;
+  text-decoration: none;
+}
+
 .nutshell-bubble {
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   border-radius: 5px;
@@ -244,6 +249,10 @@ pre, pre.python, pre.bash, pre.yaml {
   width: 0em;
   height: 0em;
 }
+
+/* .nutshell-ball-up, .nutshell-ball-down {
+  visibility: hidden;
+} */
 
 /* section#footnotes {
   display: none !important;

--- a/site/styles.css
+++ b/site/styles.css
@@ -222,6 +222,29 @@ pre, pre.python, pre.bash, pre.yaml {
   text-underline-offset: 10px;
 }
 
+.nutshell-expandable {
+  color: #DE257E;
+  text-decoration: none;
+  /* border-bottom: dotted 1.5px; */
+  position: relative;
+  transition: opacity 0.1s ease-in-out;
+  opacity: 1;
+}
+
+.nutshell-bubble {
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+}
+
+.nutshell-bubble-from {
+  opacity: 0;
+}
+
+.nutshell-bubble-overflow-embed-button img {
+  width: 0em;
+  height: 0em;
+}
+
 /* section#footnotes {
   display: none !important;
 }


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR does exactly one thing: it provides a working Nutshell example that can be used to experiment with a better alternative for step 1 in task topics. @noosheenv @validbeck 

Includes:

- A `step-1.qmd` file with text for the Nutshell bubble (dependency on #251 to render variables, FYI)
- A modified `guide/configuration/managing-your-organization.qmd` task topic that demonstrates how to use the Nutshell bubble
- Some initial style modifications in `styles.css` (hide the text with the source, hide the icon, pink links, smaller bubble radius) — more is needed

Note that tables don't seem to render correctly. 

![2024-07-17_19-31-46 (1)](https://github.com/user-attachments/assets/bcdf5585-b944-4d99-a8b9-e0d631d4eb8d)

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->