### PR TITLE
Removed icon from .qmd title and added it to navigation link

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -48,7 +48,8 @@ website:
           file: developer/model-testing/testing-overview.qmd
         - text: "{{< fa microscope >}} Test Descriptions"
           file: developer/model-testing/test-descriptions.qmd
-        - developer/model-testing/test-sandbox.qmd
+        - text: "{{< fa toolbox >}} Test Sandbox (BETA)"
+          file: developer/model-testing/test-sandbox.qmd
         - text: "---"
         - text: "{{< fa code >}} CODE SAMPLES"
         - text: "{{< fa book-open-reader >}} All Code Samples · `LLM` · `NLP` · `Time Series` · `Etc.`"

--- a/site/developer/model-testing/test-sandbox.qmd
+++ b/site/developer/model-testing/test-sandbox.qmd
@@ -1,5 +1,5 @@
 ---
-title: "{{< fa toolbox >}} Test sandbox (BETA)"
+title: "Test sandbox (BETA)"
 date: last-modified
 ---
 


### PR DESCRIPTION
## Internal Notes for Reviewers

> For sc-5541, I discovered this is actually just a limitation of mobile popovers: https://stackoverflow.com/questions/64618889/fontawesome-icons-showing-on-desktop-but-not-on-mobile

- None of the alternative icon extensions offered by Quarto resolved this issue (they all used the `@font-family` css) 
- So I removed the icon from that page's title and modified the navigation link to match the other entries in the Developer Framework dropdown (and now everything is AOK on mobile)

| Page & navigation drop-down | Mobile view|
|---|---|
| <img width="1726" alt="Screenshot 2024-07-31 at 3 52 18 PM" src="https://github.com/user-attachments/assets/8f1f6427-76e1-48e1-b91d-ed65e383f6f8">| <img width="402" alt="Screenshot 2024-07-31 at 3 55 55 PM" src="https://github.com/user-attachments/assets/4679ead1-738f-44a5-827c-e4b9b3eb8e58"> |
