### PR TITLE
Added `make install` to the Makefile to install dependencies

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -61,7 +61,7 @@ python-docs:
 
 test-descriptions:
 	@echo "\nUpdating test descriptions source ..."
-	@cd _source/developer-framework && poetry run python scripts/extract_descriptions.py validmind/tests
+	@cd _source/developer-framework && make install && poetry run python scripts/extract_descriptions.py validmind/tests
 	@cd ../../
 	@rm -rf $(DEST_DIR_TESTS)
 	@mkdir -p $(DEST_DIR_TESTS)


### PR DESCRIPTION
## Internal Notes for Reviewers
There was an issue with some dependencies not being installed within the cloned little folder of the developer-framework repo. 

By adding `make install` to the Makefile, dependencies are installed and the scripts can run normally.
<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->