### PR TITLE
Added some references for loading model predictions w/o available model

### DIFF
--- a/site/developer/model-documentation/generate-model-documentation.qmd
+++ b/site/developer/model-documentation/generate-model-documentation.qmd
@@ -16,7 +16,7 @@ graph LR
 ```
 <br> 
 
-1. **Develop your model** — In your existing developer environment, build one or more candidate models that need to be validated. This step includes all the usual activities you already follow as a model developer. 
+1. **Develop your model**[^1] — In your existing developer environment, build one or more candidate models that need to be validated. This step includes all the usual activities you already follow as a model developer. 
 
 2. **Generate model documentation** — With the {{< var validmind.developer >}}, generate automated model documentation and run validation tests. This step includes making use of the automation and testing functionality provided by the {{< var vm.developer >}} and uploading the output to the {{< var vm.platform >}}. You can iteratively regenerate the documentation as you work though the next step of refining your documentation.
 
@@ -118,3 +118,11 @@ Next, go to **In the {{< var validmind.platform >}}, Step 5**.  {{< fa arrow-rig
          - For existing blocks: Select from available texts from content provider
 
 6. [Submit your model documentation for review](/guide/model-documentation/submit-for-approval.qmd).
+
+
+<!-- FOOTNOTES -->
+
+[^1]: 
+
+   **No available model?**<br>
+   You can still run tests and log documentation with ValidMind as long as you're able to [load the model predictions](/faq/faq-documentation.qmd). 

--- a/site/developer/model-documentation/generate-model-documentation.qmd
+++ b/site/developer/model-documentation/generate-model-documentation.qmd
@@ -125,4 +125,4 @@ Next, go to **In the {{< var validmind.platform >}}, Step 5**.  {{< fa arrow-rig
 [^1]: 
 
    **No available model?**<br>
-   You can still run tests and log documentation with ValidMind as long as you're able to [load the model predictions](/faq/faq-documentation.qmd). 
+   You can still run tests and log documentation with ValidMind as long as you're able to [load the model predictions](/faq/faq-documentation.qmd#can-i-run-tests-and-log-documentation-without-having-a-model-available). 

--- a/site/faq/faq-documentation.qmd
+++ b/site/faq/faq-documentation.qmd
@@ -3,6 +3,26 @@ title: "Documentation"
 date: last-modified
 ---
 
+## Can I run tests and log documentation without having a model available?
+
+If you do not have a model ready, or your model can't be loaded directly, or you only have access to model predictions, you can still run tests and log documentation with ValidMind as long as you're able to load the model predictions.
+
+- Use [`assign_predictions()`](https://docs.validmind.ai/validmind/validmind/vm_models.html#VMDataset.assign_predictions) to load predictions from a separate file or a dataset with predictions.
+- Call [`init_model()`](https://docs.validmind.ai/validmind/validmind.html#init_model) but instead of a trained model instance, pass an `input_id` and model metadata. [`ModelMetadata()`](https://docs.validmind.ai/validmind/validmind/tests/model_validation/ModelMetadata.html#ModelMetadata) will use the provided metadata instead of trying to calculate it from the model's library. 
+
+    For example: 
+
+    ```python
+    external_model = vm.init_model(
+    input_id="spark_ml_model",
+    metadata={...}
+    )
+    ```
+
+::: {.callout title="If neither a trained model instance nor metadata is provided, `init_model()` will return an error.  "}
+However, tests that need a trained model will not work with "empty" models.
+:::
+
 ## Can documentation templates be configured per model use case or to match our existing templates?
 
 ValidMind's platform allows you to configure multiple templates based on documentation requirements for each model use case. During the model registration process, the platform automatically selects the template based on the provided model use case information.


### PR DESCRIPTION
## Internal Notes for Reviewers

> For sc-6033, I added a quick reference to the Documentation FAQ and linked to it in `/developer/model-documentation/generate-model-documentation.qmd`

### Generate model documentation

| Old | New |
|---|---|
| <img width="1626" alt="Screenshot 2024-08-21 at 12 10 17 PM" src="https://github.com/user-attachments/assets/eada5880-4ec6-4ceb-bf25-370746874a10"> | <img width="1525" alt="Screenshot 2024-08-21 at 12 04 43 PM" src="https://github.com/user-attachments/assets/973007cf-e2b8-418d-b02f-6bee9863eef9">|

### Documentation FAQ

| Old | New |
|---|---|
| <img width="1668" alt="Screenshot 2024-08-21 at 12 10 07 PM" src="https://github.com/user-attachments/assets/974c7bc0-e048-49c9-8c24-f77e0bc172df"> | <img width="1713" alt="Screenshot 2024-08-21 at 12 04 22 PM" src="https://github.com/user-attachments/assets/c7edd96f-7136-49b4-91d4-897ff8e36634">|

@cachafla Fearless leader pls to check for accuracy 🫡 