### PR TITLE
Add PR previews

### DIFF
--- a/.github/workflows/delete-pr-preview.yaml
+++ b/.github/workflows/delete-pr-preview.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   delete-preview:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == false
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/delete-pr-preview.yaml
+++ b/.github/workflows/delete-pr-preview.yaml
@@ -14,12 +14,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Configure AWS credentials
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set default.region us-east-1
+        run: aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} && aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} && aws configure set default.region us-east-1
 
       - name: Delete PR preview
-        run: |
-          aws s3 rm s3://${{ vars.S3_BUCKET_DEMO }}/site/pr_previews/${{ github.head_ref }}/ --recursive
-          aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager > /dev/null
+        run: aws s3 rm s3://${{ vars.S3_BUCKET_DEMO }}/site/pr_previews/${{ github.head_ref }}/ --recursive && aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager > /dev/null

--- a/.github/workflows/delete-pr-preview.yaml
+++ b/.github/workflows/delete-pr-preview.yaml
@@ -1,0 +1,25 @@
+name: Delete PR preview
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-preview:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Configure AWS credentials
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws configure set default.region us-east-1
+
+      - name: Delete PR preview
+        run: |
+          aws s3 rm s3://${{ vars.S3_BUCKET_DEMO }}/site/pr_previews/${{ github.head_ref }}/ --recursive
+          aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager > /dev/null

--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       # Prod bucket is in us-east-1

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -2,7 +2,7 @@ name: Validate docs site (render, test, and deploy)
 
 on:
   pull_request:
-    types: [opened, synchronize, edited, ready_for_review]
+    types: [opened, synchronize, ready_for_review]
 
 permissions:
   issues: write

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -49,3 +49,15 @@ jobs:
 
     - name: Deploy PR preview
       run: aws s3 sync site/_site s3://${{ vars.S3_BUCKET_DEMO }}/site/pr_previews/${{ github.head_ref }} --delete && aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager
+
+    - name: Post comment with preview URL
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const url = `https://docs-demo.vm.validmind.ai/pr_previews/${{ github.head_ref }}/index.html`;
+          github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body: `A PR preview is available at: [Preview URL](${url})`
+          });

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, edited, ready_for_review]
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -63,5 +63,5 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
-            body: `A PR preview is available at: [Preview URL](${url})`
+            body: `A PR preview is available: [Preview URL](${url})`
           });

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -1,4 +1,4 @@
-name: Run quarto render
+name: Validate docs site
 
 on:
   pull_request:
@@ -25,7 +25,7 @@ jobs:
         wget ${{ env.DOWNLOAD_URL }} -O quarto-latest-linux-amd64.deb
         sudo dpkg -i quarto-latest-linux-amd64.deb
 
-    - name: Render Site
+    - name: Render site
       run: |
           cd ./site 
           quarto render &> render_errors.log || { 
@@ -34,7 +34,7 @@ jobs:
           exit 1;
           }
 
-    - name: Check for render errors 
+    - name: Check for warnings or errors 
       run: |
         if grep -q 'WARN:\|ERROR:' site/render_errors.log; then
           echo "Warnings or errors detected during Quarto render"
@@ -43,3 +43,10 @@ jobs:
         else
           echo "No warnings or errors detected during Quarto render"
         fi
+
+    - name: Configure AWS credentials
+      run: aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} && aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} && aws configure set default.region us-east-1
+
+    - name: Deploy PR preview
+      run: 
+        aws s3 sync site/_site s3://${{ vars.S3_BUCKET_DEMO }}/site/pr_previews/${{ github.head_ref }} --delete && aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -1,56 +1,51 @@
-name: Validate docs site
+name: Validate docs site (render, test, and deploy)
 
 on:
   pull_request:
     types: [opened, synchronize, edited, ready_for_review]
 
 jobs:
-  build:
+  validate:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
+    - name: Checkout repository
+      uses: actions/checkout@v2
 
-      - name: Get latest Quarto release URL
-        id: get-quarto-url
-        run: |
-          API_URL="https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest"
-          DOWNLOAD_URL=$(curl -s $API_URL | jq -r '.assets[] | select(.name | endswith("linux-amd64.deb")).browser_download_url')
-          echo "DOWNLOAD_URL=$DOWNLOAD_URL" >> $GITHUB_ENV
+    - name: Get latest Quarto release URL
+      id: get-quarto-url
+      run: |
+        API_URL="https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest"
+        DOWNLOAD_URL=$(curl -s $API_URL | jq -r '.assets[] | select(.name | endswith("linux-amd64.deb")).browser_download_url')
+        echo "DOWNLOAD_URL=$DOWNLOAD_URL" >> $GITHUB_ENV
 
-      - name: Download and install Quarto
-        run: |
-          wget ${{ env.DOWNLOAD_URL }} -O quarto-latest-linux-amd64.deb
-          sudo dpkg -i quarto-latest-linux-amd64.deb
+    - name: Download and install Quarto
+      run: |
+        wget ${{ env.DOWNLOAD_URL }} -O quarto-latest-linux-amd64.deb
+        sudo dpkg -i quarto-latest-linux-amd64.deb
 
-      - name: Render site
-        run: |
-          cd ./site
+    - name: Render site
+      run: |
+          cd ./site 
           quarto render &> render_errors.log || { 
-            echo "Quarto render failed immediately"
-            cat render_errors.log
-            exit 1
+          echo "Quarto render failed immediately";
+          cat render_errors.log;
+          exit 1;
           }
 
-      - name: Check for warnings or errors
-        run: |
-          if grep -q 'WARN:\|ERROR:' site/render_errors.log; then
-            echo "Warnings or errors detected during Quarto render"
-            cat site/render_errors.log
-            exit 1
-          else
-            echo "No warnings or errors detected during Quarto render"
-          fi
+    - name: Test for warnings or errors 
+      run: |
+        if grep -q 'WARN:\|ERROR:' site/render_errors.log; then
+          echo "Warnings or errors detected during Quarto render"
+          cat site/render_errors.log
+          exit 1
+        else
+          echo "No warnings or errors detected during Quarto render"
+        fi
 
-      - name: Configure AWS credentials
-        run: |
-          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws configure set default.region us-east-1
+    - name: Configure AWS credentials
+      run: aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} && aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} && aws configure set default.region us-east-1
 
-      - name: Deploy PR preview
-        run: |
-          aws s3 sync site/_site s3://${{ vars.S3_BUCKET_DEMO }}/site/pr_previews/${{ github.head_ref }} --delete
-          aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager
+    - name: Deploy PR preview
+      run: aws s3 sync site/_site s3://${{ vars.S3_BUCKET_DEMO }}/site/pr_previews/${{ github.head_ref }} --delete && aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -10,43 +10,47 @@ jobs:
     if: github.event.pull_request.draft == false
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Get latest Quarto release URL
-      id: get-quarto-url
-      run: |
-        API_URL="https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest"
-        DOWNLOAD_URL=$(curl -s $API_URL | jq -r '.assets[] | select(.name | endswith("linux-amd64.deb")).browser_download_url')
-        echo "DOWNLOAD_URL=$DOWNLOAD_URL" >> $GITHUB_ENV
+      - name: Get latest Quarto release URL
+        id: get-quarto-url
+        run: |
+          API_URL="https://api.github.com/repos/quarto-dev/quarto-cli/releases/latest"
+          DOWNLOAD_URL=$(curl -s $API_URL | jq -r '.assets[] | select(.name | endswith("linux-amd64.deb")).browser_download_url')
+          echo "DOWNLOAD_URL=$DOWNLOAD_URL" >> $GITHUB_ENV
 
-    - name: Download and install Quarto
-      run: |
-        wget ${{ env.DOWNLOAD_URL }} -O quarto-latest-linux-amd64.deb
-        sudo dpkg -i quarto-latest-linux-amd64.deb
+      - name: Download and install Quarto
+        run: |
+          wget ${{ env.DOWNLOAD_URL }} -O quarto-latest-linux-amd64.deb
+          sudo dpkg -i quarto-latest-linux-amd64.deb
 
-    - name: Render site
-      run: |
-          cd ./site 
+      - name: Render site
+        run: |
+          cd ./site
           quarto render &> render_errors.log || { 
-          echo "Quarto render failed immediately";
-          cat render_errors.log;
-          exit 1;
+            echo "Quarto render failed immediately"
+            cat render_errors.log
+            exit 1
           }
 
-    - name: Check for warnings or errors 
-      run: |
-        if grep -q 'WARN:\|ERROR:' site/render_errors.log; then
-          echo "Warnings or errors detected during Quarto render"
-          cat site/render_errors.log
-          exit 1
-        else
-          echo "No warnings or errors detected during Quarto render"
-        fi
+      - name: Check for warnings or errors
+        run: |
+          if grep -q 'WARN:\|ERROR:' site/render_errors.log; then
+            echo "Warnings or errors detected during Quarto render"
+            cat site/render_errors.log
+            exit 1
+          else
+            echo "No warnings or errors detected during Quarto render"
+          fi
 
-    - name: Configure AWS credentials
-      run: aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} && aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} && aws configure set default.region us-east-1
+      - name: Configure AWS credentials
+        run: |
+          aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws configure set default.region us-east-1
 
-    - name: Deploy PR preview
-      run: 
-        aws s3 sync site/_site s3://${{ vars.S3_BUCKET_DEMO }}/site/pr_previews/${{ github.head_ref }} --delete && aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager
+      - name: Deploy PR preview
+        run: |
+          aws s3 sync site/_site s3://${{ vars.S3_BUCKET_DEMO }}/site/pr_previews/${{ github.head_ref }} --delete
+          aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager

--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ make get-source
 
 After you pull in the changes, commit them to this repo as part of the release notes process.
 
-<!-- Need to mention rendered Python `.html` docs and generated `.md` test descriptions -->
+<!-- Aug 2024: Need to mention rendered Python `.html` docs and generated `.md` test descriptions -->


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR adds automatic previews that 

- get deployed to our docs-demo site when you create or update a PR; AND 
- get deleted when the PR gets merged or closed

In our docs CI/CD deployment proposal, this PR adds the following highlight:

<img width="1532" alt="image" src="https://github.com/user-attachments/assets/30eab9b8-cc46-442d-8769-3e2ee1b24fe4">

## Proof it works

### Deploy PR preview 

Successful run: https://github.com/validmind/documentation/actions/runs/10673952942

<img width="1012" alt="image" src="https://github.com/user-attachments/assets/5799f841-d07c-455c-9145-32452136ec79">

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/5b4f0cff-97ed-4521-a315-dee952d9f2f7">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/46fbf2c8-8869-49b8-b5ef-325cf19ce169">

### Delete PR preview

Successful run https://github.com/validmind/documentation/actions/runs/10674028315

<img width="1434" alt="image" src="https://github.com/user-attachments/assets/ff9c6349-1a56-4f63-b84d-5609842999e7">

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/465afa79-6b3b-4374-a68f-b979d6e5c326">

## How it works

We already had a check to render the docs site and run tests. Together with a bit of editing of the existing workflow, we now basically take the output of that `quarto render` step and sync it to AWS S3, making it an efficient solution to deploy PR previews. 

**Why not a separate workflow to deploy PR previews?** The existing quarto render CI check gives us everything we need and is also the most expensive check to run, taking ~5 minutes to complete. 

The PR preview delete is just the `aws s3 rm` command performed on the same path in the docs-demo S3 bucket. The delete is silent as it's not something an author or reviewer needs to engage with — failures in the action should result in an email from GitHub. 

## How to test

- **Deploy PR preview**: Add a commit to this PR and watch it get deployed via the `Validate docs site (render, test, and deploy)` CI check. Use the preview URL from the comment to check the preview is there.
- **Delete PR preview**: Close this PR, wait for the `Delete PR preview` action to run, recheck the preview URL (it should 404), and then reopen this PR

<!--

PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->