### PR TITLE
Indicate original PR in title for auto merged PRs — NOT READY FOR REVIEW

### DIFF
--- a/.github/workflows/merge-main-into-staging.yaml
+++ b/.github/workflows/merge-main-into-staging.yaml
@@ -30,13 +30,18 @@ jobs:
           git fetch origin main-test:main-test
           git merge main-test --no-ff --allow-unrelated-histories --strategy-option theirs -m "Merging latest changes from main-test into staging-test"
 
-      - name: Extract merged pull request details
+      - name: Get last merged pull request details
         id: pr-details
         run: |
-          PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
-          PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
+          PR_INFO=$(gh pr list --repo "${{ github.repository }}" --state merged --base main-test --limit 1 --json number,title --jq '.[0]')
+          PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number')
+          PR_TITLE=$(echo "$PR_INFO" | jq -r '.title')
+          echo "PR_NUMBER=$PR_NUMBER"
+          echo "PR_TITLE=$PR_TITLE"
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_ENV
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create pull request
         id: pr-number

--- a/.github/workflows/merge-main-into-staging.yaml
+++ b/.github/workflows/merge-main-into-staging.yaml
@@ -44,7 +44,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update-staging-${{ github.run_id }}
-          title: 'Merge main into staging - PR #${{ env.PR_NUMBER }}: ${{ env.PR_TITLE }}'
+          title: 'Merge main into staging — PR #${{ env.PR_NUMBER }}: ${{ env.PR_TITLE }}'
           body: 'Automatically merge main into staging branch.'
 
       - name: Merge pull request

--- a/.github/workflows/merge-main-into-staging.yaml
+++ b/.github/workflows/merge-main-into-staging.yaml
@@ -30,13 +30,21 @@ jobs:
           git fetch origin main:main
           git merge main --no-ff --allow-unrelated-histories --strategy-option theirs -m "Merging latest changes from main into staging"
 
+      - name: Extract PR details
+        id: pr-details
+        run: |
+          PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")
+          PR_TITLE=$(jq -r '.pull_request.title' "$GITHUB_EVENT_PATH")
+          echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
+          echo "PR_TITLE=$PR_TITLE" >> $GITHUB_ENV
+
       - name: Create pull request
         id: pr-number
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: update-staging-${{ github.run_id }}
-          title: 'Merge main into staging'
+          title: 'Merge main into staging - PR #${{ env.PR_NUMBER }}: ${{ env.PR_TITLE }}'
           body: 'Automatically merge main into staging branch.'
 
       - name: Merge pull request

--- a/.github/workflows/merge-main-into-staging.yaml
+++ b/.github/workflows/merge-main-into-staging.yaml
@@ -30,7 +30,7 @@ jobs:
           git fetch origin main:main
           git merge main --no-ff --allow-unrelated-histories --strategy-option theirs -m "Merging latest changes from main into staging"
 
-      - name: Extract PR details
+      - name: Extract merged pull request details
         id: pr-details
         run: |
           PR_NUMBER=$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")

--- a/.github/workflows/merge-main-into-staging.yaml
+++ b/.github/workflows/merge-main-into-staging.yaml
@@ -1,9 +1,9 @@
-name: Merge main into staging
+name: Merge main-test into staging-test
 
 on:
   push:
     branches:
-      - main
+      - nrichers/sc-6286/indicate-original-pr-in-title-for-prs-auto
 
 permissions:
   contents: write
@@ -11,24 +11,24 @@ permissions:
   pull-requests: write
 
 jobs:
-  merge-main-into-staging:
+  merge-main-test-into-staging-test:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout staging branch
+      - name: Checkout staging-test branch
         uses: actions/checkout@v3
         with:
-          ref: staging
+          ref: staging-test
 
       - name: Configure git
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Merge in main branch
+      - name: Merge in main-test branch
         run: |
-          git fetch origin main:main
-          git merge main --no-ff --allow-unrelated-histories --strategy-option theirs -m "Merging latest changes from main into staging"
+          git fetch origin main-test:main-test
+          git merge main-test --no-ff --allow-unrelated-histories --strategy-option theirs -m "Merging latest changes from main-test into staging-test"
 
       - name: Extract merged pull request details
         id: pr-details
@@ -43,9 +43,9 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: update-staging-${{ github.run_id }}
-          title: 'Merge main into staging — PR #${{ env.PR_NUMBER }}: ${{ env.PR_TITLE }}'
-          body: 'Automatically merge main into staging branch.'
+          branch: update-staging-test-${{ github.run_id }}
+          title: 'Merge main-test into staging-test — PR #${{ env.PR_NUMBER }}: ${{ env.PR_TITLE }}'
+          body: 'Automatically merge main-test into staging-test branch.'
 
       - name: Merge pull request
         if: ${{ steps.pr-number.outputs.pull-request-number != '' }}
@@ -55,6 +55,6 @@ jobs:
 
       - name: Delete pull request branch
         if: ${{ success() && steps.pr-number.outputs.pull-request-number != '' }}
-        run: gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/update-staging-${{ github.run_id }}"
+        run: gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/update-staging-test-${{ github.run_id }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge-main-into-staging.yaml
+++ b/.github/workflows/merge-main-into-staging.yaml
@@ -33,9 +33,13 @@ jobs:
       - name: Get last merged pull request details
         id: pr-details
         run: |
-          PR_INFO=$(gh pr list --repo "${{ github.repository }}" --state merged --base main-test --limit 1 --json number,title --jq '.[0]')
-          PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number')
-          PR_TITLE=$(echo "$PR_INFO" | jq -r '.title')
+          echo "Fetching the last merged PR details..."
+          PR_INFO=$(gh pr list --repo "${{ github.repository }}" --state merged --base main-test --limit 1 --json number,title)
+          echo "Raw PR info: $PR_INFO"  # Debug: Show raw output
+          PR_NUMBER=$(echo "$PR_INFO" | jq -r '.[0].number')
+          PR_TITLE=$(echo "$PR_INFO" | jq -r '.[0].title')
+          echo "Extracted PR_NUMBER=$PR_NUMBER"
+          echo "Extracted PR_TITLE=$PR_TITLE"
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_ENV
         env:

--- a/.github/workflows/merge-main-into-staging.yaml
+++ b/.github/workflows/merge-main-into-staging.yaml
@@ -36,8 +36,6 @@ jobs:
           PR_INFO=$(gh pr list --repo "${{ github.repository }}" --state merged --base main-test --limit 1 --json number,title --jq '.[0]')
           PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number')
           PR_TITLE=$(echo "$PR_INFO" | jq -r '.title')
-          echo "PR_NUMBER=$PR_NUMBER"
-          echo "PR_TITLE=$PR_TITLE"
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
           echo "PR_TITLE=$PR_TITLE" >> $GITHUB_ENV
         env:


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR modifies our workflow for auto merging PRs from `main` into `staging` by including information about the original PR that triggered the workflow on merging. 

## How to test 

(Gotta figure this one out, as we now have a workflow that auto merges commits. Might need to make some copies of branches to test.)

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->