### PR TITLE
Only running the PR previews bot when a PR is ready for review

### DIFF
--- a/.github/workflows/ai_explain.yaml
+++ b/.github/workflows/ai_explain.yaml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [review_requested]
 
 jobs:
   explain-pr:

--- a/.github/workflows/ai_explain.yaml
+++ b/.github/workflows/ai_explain.yaml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ready_for_review]
 
 jobs:
   explain-pr:


### PR DESCRIPTION
## Internal Notes for Reviewers

> @cachafla The PR Review bot is neat but runs way too often for us. I've adjusted it (hopefully) to only run the once when a PR has a review requested based on these docs: [GitHub — Events that trigger workflows (pull_request)]( https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request)

cc @nrichers for visibility.
