### PR TITLE
Investigate listing page issue 

### DIFF
--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -31,9 +31,12 @@ jobs:
 
     - name: Render site
       run: |
-          cd site
-          quarto check
-          quarto render
+          cd site 
+          quarto render &> render_errors.log || { 
+          echo "Quarto render failed immediately";
+          cat render_errors.log;
+          exit 1;
+          }
 
     - name: Test for warnings or errors 
       run: |

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -32,7 +32,6 @@ jobs:
     - name: Render site
       run: |
           cd site
-          quarto install tinytex
           quarto check
           quarto render
 

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -32,6 +32,7 @@ jobs:
     - name: Render site
       run: |
           cd site
+          quarto install tinytex
           quarto check
           quarto render
 

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -32,11 +32,7 @@ jobs:
     - name: Render site
       run: |
           cd site 
-          quarto render &> render_errors.log || { 
-          echo "Quarto render failed immediately";
-          cat render_errors.log;
-          exit 1;
-          }
+          quarto render
 
     - name: Test for warnings or errors 
       run: |

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -31,7 +31,8 @@ jobs:
 
     - name: Render site
       run: |
-          cd site 
+          cd site
+          quarto check
           quarto render
 
     - name: Test for warnings or errors 

--- a/site/developer/model-testing/test-descriptions.qmd
+++ b/site/developer/model-testing/test-descriptions.qmd
@@ -36,7 +36,7 @@ This topic describes the tests that are available as part of the {{< var validmi
 Explore our interactive sandbox to see what tests are available in the {{< var validmind.developer >}}.
 :::
 
-:::{.panel-tabset}
+<!-- :::{.panel-tabset} -->
 
 ## {{< fa database >}} Data validation
 
@@ -58,4 +58,4 @@ Explore our interactive sandbox to see what tests are available in the {{< var v
 :::{#ongoing-monitoring}
 :::
 
-:::
+<!-- ::: -->

--- a/site/developer/model-testing/test-descriptions.qmd
+++ b/site/developer/model-testing/test-descriptions.qmd
@@ -21,7 +21,11 @@ listing:
     page-size: 150
     fields: [title, description]  
   - id: ongoing-monitoring
-    contents: "../../tests/ongoing_monitoring/**"
+    contents: 
+    - ../../tests/ongoing_monitoring/FeatureDrift.md
+    - ../../tests/ongoing_monitoring/PredictionAcrossEachFeature.md
+    - ../../tests/ongoing_monitoring/PredictionCorrelation.md
+    - ../../tests/ongoing_monitoring/TargetPredictionDistributionPlot.md
     type: grid
     max-description-length: 250
     page-size: 150
@@ -36,7 +40,7 @@ This topic describes the tests that are available as part of the {{< var validmi
 Explore our interactive sandbox to see what tests are available in the {{< var validmind.developer >}}.
 :::
 
-<!-- :::{.panel-tabset} -->
+:::{.panel-tabset}
 
 ## {{< fa database >}} Data validation
 
@@ -58,4 +62,4 @@ Explore our interactive sandbox to see what tests are available in the {{< var v
 :::{#ongoing-monitoring}
 :::
 
-<!-- ::: -->
+:::

--- a/site/developer/model-testing/test-descriptions.qmd
+++ b/site/developer/model-testing/test-descriptions.qmd
@@ -3,25 +3,25 @@ title: "Test descriptions"
 date: last-modified
 listing:
   - id: data-validation
-    contents: "../../tests/data_validation/"
+    contents: "../../tests/data_validation/*.md"
     type: grid
     max-description-length: 250
     page-size: 150
     fields: [title, description]
   - id: model-validation
     type: grid
-    contents: "../../tests/model_validation/"
+    contents: "../../tests/model_validation/*.md"
     max-description-length: 250
     page-size: 150
     fields: [title, description]
   - id: prompt-validation
-    contents: "../../tests/prompt_validation/"
+    contents: "../../tests/prompt_validation/*.md"
     type: grid
     max-description-length: 250
     page-size: 150
     fields: [title, description]  
   - id: ongoing-monitoring
-    contents: "../../tests/ongoing_monitoring/"
+    contents: "../../tests/ongoing_monitoring/*.md"
     type: grid
     max-description-length: 250
     page-size: 150

--- a/site/developer/model-testing/test-descriptions.qmd
+++ b/site/developer/model-testing/test-descriptions.qmd
@@ -3,29 +3,25 @@ title: "Test descriptions"
 date: last-modified
 listing:
   - id: data-validation
-    contents: "../../tests/data_validation/**"
+    contents: "../../tests/data_validation/"
     type: grid
     max-description-length: 250
     page-size: 150
     fields: [title, description]
   - id: model-validation
     type: grid
-    contents: "../../tests/model_validation/**"
+    contents: "../../tests/model_validation/"
     max-description-length: 250
     page-size: 150
     fields: [title, description]
   - id: prompt-validation
-    contents: "../../tests/prompt_validation/**"
+    contents: "../../tests/prompt_validation/"
     type: grid
     max-description-length: 250
     page-size: 150
     fields: [title, description]  
   - id: ongoing-monitoring
-    contents: 
-    - ../../tests/ongoing_monitoring/FeatureDrift.md
-    - ../../tests/ongoing_monitoring/PredictionAcrossEachFeature.md
-    - ../../tests/ongoing_monitoring/PredictionCorrelation.md
-    - ../../tests/ongoing_monitoring/TargetPredictionDistributionPlot.md
+    contents: "../../tests/ongoing_monitoring/"
     type: grid
     max-description-length: 250
     page-size: 150


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR modifies our test description wildcard embeds from `**` to `*.md` to resolve duplicated but blank tiles.

| Before — [docs.validmind.ai](https://docs.validmind.ai/developer/model-testing/test-descriptions.html) | After —  [Preview URL](https://docs-demo.vm.validmind.ai/pr_previews/nrichers/sc-6331/investigate-listing-page-issue-for-test-descriptions/developer/model-testing/test-descriptions.html) |
|--------|--------|
| <img width="1440" alt="image" src="https://github.com/user-attachments/assets/69c8e6e1-b60d-4ed0-b611-05bc0a87a242"> | <img width="1440" alt="image" src="https://github.com/user-attachments/assets/938cbe9a-5f05-4122-ade8-b2103f3f02de"> |

Note this change seems to work just fine for subdirectories.

## Troubleshooting approach

- [x] Turn off echoing the `quarto render` output into a logfile so that we can see the output
- [x] Debugging
   - [x] Test rendering on a local Linux container — output looks fine
   - [x] Run `quarto check` before render — looks OK 
- [x] Add any missing extensions
   - [x] TinyTex — no difference
- [x] Experiment with the source
   - [x] Try removing tabset as the problem occurs only in tabs — no difference
   - [x] Try a directory embed without wildcard — does not work despite what the Quarto docs say
   - [x] Try a `*.md` wildcard embed — works, including for subdirectories

During testing on a local Linux container, the site rendered just fine but if we continue to run into issues that point towards differences with Linux runners on GitHub, we could also try testing on `macos-latest`. For more info, see [Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->