### PR TITLE
Update workflows to trigger on workflow_run

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -7,7 +7,8 @@ on:
   workflow_run:
     workflows: ["Merge staging into prod"]
     types:
-     - completed
+      - completed
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -1,11 +1,13 @@
-# Deploy our docs site to S3 whenever we push a commit to the main branch
-
 name: Deploy docs site to production
 
 on:
   push:
     branches:
       - prod
+  workflow_run:
+    workflows: ["Merge staging into prod"]
+    types:
+     - completed
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -8,7 +8,7 @@ on:
     workflows: ["Merge main into staging"]
     types:
       - completed
-
+    workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -1,11 +1,14 @@
-# Deploy our docs site to S3 whenever we push a commit to the main branch
-
 name: Deploy docs site to staging
 
 on:
   push:
     branches:
       - staging
+  workflow_run:
+    workflows: ["Merge main into staging"]
+    types:
+      - completed
+
 
 jobs:
   deploy:


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR adds a trigger to workflows that deploy our docs sites to staging and prod. Specifically, these workflows now also trigger when the workflows to merge into these branches have completed. This change is required to 

(Note the workflow to merge staging into prod doesn't exist, yet. This is for future me who would otherwise be puzzled why deployment doesn't trigger when we try to automate. If you trace it back to this PR — you're welcome.)

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->