### PR TITLE
Added attachment field type

### DIFF
--- a/site/guide/model-documentation/work-with-content-blocks.qmd
+++ b/site/guide/model-documentation/work-with-content-blocks.qmd
@@ -90,7 +90,7 @@ While editing a simple text block, you can have ValidMind assist you with genera
    - Ensure that content is in compliance with the quality guidelines outlined by your organization. 
    - Use the content editing toolbar[^7] just as you would with any other text block.
 
-![Generating content with AI within a simple text block](generate-with-ai.gif){width=100% fig-alt="An animation that showcases the Generate with AI feature within a simple text block"}
+![Generating content with AI within a simple text block](generate-with-ai.gif){width=100% fig-alt="An animation that showcases the Generate with AI feature within a simple text block" class="screenshot"}
 
 ::: {.callout}
 When generating content drafts with AI, accepted versions and edits are retained in your Model Activity[^8] just like other updates to your documentation, reports, or plans. 

--- a/site/guide/model-inventory/edit-model-inventory-fields.qmd
+++ b/site/guide/model-inventory/edit-model-inventory-fields.qmd
@@ -28,7 +28,7 @@ Edit individual detail fields on a model to ensure that model details are accura
 
 ### Manage supporting documentation
 
-::: {.callout title="Uploaded files must be less than 50 MB in size."}
+::: {.callout title="Uploaded files must be less than 50 MB each in size."}
 To work with attachments on models, first add an attachment inventory field.[^4]
 :::
 

--- a/site/guide/model-inventory/edit-model-inventory-fields.qmd
+++ b/site/guide/model-inventory/edit-model-inventory-fields.qmd
@@ -26,6 +26,33 @@ Edit individual detail fields on a model to ensure that model details are accura
    - Click **Save** to apply your changes.
    - Click **Cancel** to discard your changes.
 
+### Manage supporting documentation
+
+::: {.callout title="Uploaded files must be less than 50 MB in size."}
+To work with attachments on models, first add an attachment inventory field.[^4]
+:::
+
+#### Add attachments to a model
+
+1. On the model's detail page, click on the header of your attachment field.
+
+2. Click **{{< fa circle-plus >}} Select Files** to add a file.
+
+3. Click **Save** to submit the upload.
+
+#### Remove attachments from a model
+
+1. On the model's detail page, click on the header of your attachment field.
+
+2. Locate the file you want to remove.
+
+   - Click **{{< fa trash-can>}}** to remove the file. 
+   - After you confirm, the attachment will be removed from the list.
+
+3. Click **Save** to apply the deletion. 
+
+   After you save, the attachment will be removed permanently.
+
 ## What's next
 
 - [Register models in the inventory](register-models-in-inventory.qmd)
@@ -39,3 +66,5 @@ Edit individual detail fields on a model to ensure that model details are accura
 [^2]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
 
 [^3]: [Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)
+
+[^4]: [Manage model inventory fields](manage-model-inventory-fields.qmd#inventory-field-types)

--- a/site/guide/model-inventory/manage-model-inventory-fields.qmd
+++ b/site/guide/model-inventory/manage-model-inventory-fields.qmd
@@ -36,6 +36,9 @@ Create and edit the fields that appear on all models in your model inventory. Ch
 Single Line Text
 : Simple text value.
 
+Attachments
+: Upload supporting files for your model.[^3] Files must be less than 50 MB in size.
+
 Long Text
 : Toggle **Enable rich text formatting** to create a template using the rich text editor.
 
@@ -58,13 +61,13 @@ Number
 
 ::: {.w-50-ns}
 
-![Simple number field type](number-simple.png){fig-alt="A screenshot showing a simple number field type"} 
+![Simple number field type](number-simple.png){fig-alt="A screenshot showing a simple number field type" class="screenshot"} 
 
 :::
 
 ::: {.w-40-ns}
 
-![Currency number field type](number-currency.png){fig-alt="A screenshot showing a currency number field type"}
+![Currency number field type](number-currency.png){fig-alt="A screenshot showing a currency number field type" class="screenshot"}
 
 :::
 
@@ -83,7 +86,7 @@ Email
 : Text value in valid email (`user@domain.com`) format.
 
 User
-: Select list pre-populated with users from your User Directory.[^3] 
+: Select list pre-populated with users from your User Directory.[^4] 
 
 Calculation
 : Define a `formula(params)` function that returns a value using the params dictionary, which includes selected custom field keys.
@@ -111,4 +114,6 @@ Calculation
 
 [^2]: [Inventory field types](#inventory-field-types)
 
-[^3]: [Managing users](/guide/configuration/managing-users.qmd)
+[^3]: [Edit model inventory fields](/guide/model-inventory/edit-model-inventory-fields.qmd#manage-supporting-documentation)
+
+[^4]: [Managing users](/guide/configuration/managing-users.qmd)

--- a/site/guide/model-inventory/manage-model-inventory-fields.qmd
+++ b/site/guide/model-inventory/manage-model-inventory-fields.qmd
@@ -37,7 +37,7 @@ Single Line Text
 : Simple text value.
 
 Attachments
-: Upload supporting files for your model.[^3] Files must be less than 50 MB in size.
+: Upload supporting files for your model.[^3] Files must be less than 50 MB each in size.
 
 Long Text
 : Toggle **Enable rich text formatting** to create a template using the rich text editor.

--- a/site/guide/model-validation/add-manage-model-findings.qmd
+++ b/site/guide/model-validation/add-manage-model-findings.qmd
@@ -96,7 +96,7 @@ After a finding is created, you're able to add supporting documentation to it.
 #### Add attachments to findings
 
 ::: {.callout}
-Uploaded files must be less than 50 MB in size.
+Uploaded files must be less than 50 MB each in size.
 :::
 
 1. On the findings detail page, click on the **[attachments]{.smallcaps}** header.

--- a/site/guide/model-validation/add-manage-model-findings.qmd
+++ b/site/guide/model-validation/add-manage-model-findings.qmd
@@ -93,7 +93,7 @@ Most updates are applied immediately but you must click **Save** to make changes
 
 After a finding is created, you're able to add supporting documentation to it. 
 
-#### Add attachment to finding
+#### Add attachments to findings
 
 ::: {.callout}
 Uploaded files must be less than 50 MB in size.
@@ -105,7 +105,7 @@ Uploaded files must be less than 50 MB in size.
 
 3. Click **Save** to submit the upload.
 
-#### Remove attachment from finding
+#### Remove attachments from findings
 
 1. On the findings detail page, click on the **[attachments]{.smallcaps}** header.
 


### PR DESCRIPTION
## Internal Notes for Reviewers

> sc-6602

Confirmed that we are only adding the model inventory field type to models at the moment, not present on documentation/reports/workflows/etc.

### LIVE PREVIEWS

**Manage model inventory fields:** [LINK](https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-6602/documentation-user-should-be-able-to-define/guide/model-inventory/manage-model-inventory-fields.html#inventory-field-types)
**Edit model inventory fields:** [LINK](https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-6602/documentation-user-should-be-able-to-define/guide/model-inventory/edit-model-inventory-fields.html#manage-supporting-documentation)