### PR TITLE
Added new aliases to `training.qmd`

### DIFF
--- a/site/training/training.qmd
+++ b/site/training/training.qmd
@@ -5,6 +5,8 @@ filters:
   - tachyons
 aliases:
   - ../training.html
+  - index.html
+  - training-overview.html
 ---
 
 Gain hands-on experience and explore what ValidMind has to offer with our training environment. 


### PR DESCRIPTION
## Internal Notes for Reviewers

> sc-6684

I added two new aliases to `training.qmd`:

- `index.html`
- `training-overview.html`

I tested these redirects locally and they work! Neat Quarto feature, we can probably use the alias tool for some of our other renamed docs as well just for fallback's sake.

### Live tests

- **`index.html`:** https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-6684/create-redirect-for-docs-validmind-ai-training/training/index.html
- **`training-overview.html`:** https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-6684/create-redirect-for-docs-validmind-ai-training/training/training-overview.html