### PR TITLE
Add link to GitHub for code samples

### DIFF
--- a/site/developer/samples-jupyter-notebooks.qmd
+++ b/site/developer/samples-jupyter-notebooks.qmd
@@ -25,20 +25,33 @@ Our code samples, based on Jupyter Notebooks, showcase the capabilities and feat
 
 :::: {.flex .flex-wrap .justify-around}
 
-::: {.w-40-ns .mt2}
+::: {.w-10-ns}
+<!-- SPACER, DO NOT REMOVE -->
+:::
+
+::: {.w-30-ns .mt2}
 
  <form method="get" action="https://jupyterhub.validmind.ai/" target="_blank">
    <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-left: 16px; margin-bottom: 40px;">{{< fa code >}} Try Notebooks on JupyterHub</button>
 </form>
 :::
 
-::: {.w-40-ns .mt2}
+::: {.w-30-ns .mt2}
 
 <form method="get" action="/notebooks.zip">
    <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-left: 16px; margin-bottom: 40px;">{{< fa download >}} Download Notebooks & Datasets</button>
 </form>
 
 :::
+
+::: {.w-30-ns .mt2}
+
+<form method="get" action="https://github.com/validmind/developer-framework">
+   <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-left: 16px; margin-bottom: 40px;">{{< fa code-fork >}} Try it on GitHub </button>
+</form>
+
+:::
+
 
 ::::
 

--- a/site/developer/samples-jupyter-notebooks.qmd
+++ b/site/developer/samples-jupyter-notebooks.qmd
@@ -47,7 +47,7 @@ Our code samples, based on Jupyter Notebooks, showcase the capabilities and feat
 ::: {.w-30-ns .mt2}
 
 <form method="get" action="https://github.com/validmind/developer-framework">
-   <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-left: 16px; margin-bottom: 40px;">{{< fa code-fork >}} Try it on GitHub </button>
+   <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-left: 16px; margin-bottom: 40px;">{{< fa brands github >}} Try it on GitHub </button>
 </form>
 
 :::

--- a/site/developer/samples-jupyter-notebooks.qmd
+++ b/site/developer/samples-jupyter-notebooks.qmd
@@ -25,21 +25,17 @@ Our code samples, based on Jupyter Notebooks, showcase the capabilities and feat
 
 :::: {.flex .flex-wrap .justify-around}
 
-::: {.w-10-ns}
-<!-- SPACER, DO NOT REMOVE -->
-:::
-
 ::: {.w-30-ns .mt2}
 
  <form method="get" action="https://jupyterhub.validmind.ai/" target="_blank">
-   <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-left: 16px; margin-bottom: 40px;">{{< fa code >}} Try Notebooks on JupyterHub</button>
+   <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-bottom: 40px;">{{< fa code >}} Try Notebooks on JupyterHub</button>
 </form>
 :::
 
 ::: {.w-30-ns .mt2}
 
 <form method="get" action="/notebooks.zip">
-   <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-left: 16px; margin-bottom: 40px;">{{< fa download >}} Download Notebooks & Datasets</button>
+   <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-bottom: 40px;">{{< fa download >}} Download Notebooks & Datasets</button>
 </form>
 
 :::
@@ -47,7 +43,7 @@ Our code samples, based on Jupyter Notebooks, showcase the capabilities and feat
 ::: {.w-30-ns .mt2}
 
 <form method="get" action="https://github.com/validmind/developer-framework">
-   <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-left: 16px; margin-bottom: 40px;">{{< fa brands github >}} Try it on GitHub </button>
+   <button type="submit" style="color: white; background-color: #de257e; border-radius: 8px; border: none; font-size: 16px; padding: 6.25px 12.5px; margin-bottom: 40px;">{{< fa brands github >}} Access Notebooks on GitHub </button>
 </form>
 
 :::


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR adds a link to our open-source repo on GitHub:

<img width="1283" alt="image" src="https://github.com/user-attachments/assets/dd4ebdb1-a668-4a3f-ab81-26f803385112">

LIVE PREVIEW

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

We added a link to our open-source software on GitHub to the code samples page. [Try it on GitHub](https://github.com/validmind/developer-framework)