### PR TITLE
Adjusting training styles

### DIFF
--- a/site/_extensions/nrichers/preview/preview.css
+++ b/site/_extensions/nrichers/preview/preview.css
@@ -5,8 +5,22 @@
   height: 225px;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
   border-radius: 5px;
-  border: 1px solid #222425;
   background: #DE257E;
+  border: 1px solid #DE257E;
+  padding-bottom: 25px;
+}
+
+.preview:hover {
+  position: relative;
+  display: inline-block;
+  width: 400px;
+  height: 225px;
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+  background: #fff;
+  border: 1px solid #083E44;
+  padding-bottom: 25px;
+  /* border-bottom-width: 25px; */
 }
 
 .preview iframe {

--- a/site/_extensions/nrichers/preview/preview.css
+++ b/site/_extensions/nrichers/preview/preview.css
@@ -7,19 +7,6 @@
   border-radius: 5px;
   background: #DE257E;
   border: 1px solid #DE257E;
-  padding-bottom: 25px;
-}
-
-.preview:hover {
-  position: relative;
-  display: inline-block;
-  width: 400px;
-  height: 225px;
-  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2);
-  border-radius: 5px;
-  background: #fff;
-  border: 1px solid #083E44;
-  padding-bottom: 25px;
 }
 
 .preview iframe {

--- a/site/_extensions/nrichers/preview/preview.css
+++ b/site/_extensions/nrichers/preview/preview.css
@@ -20,7 +20,6 @@
   background: #fff;
   border: 1px solid #083E44;
   padding-bottom: 25px;
-  /* border-bottom-width: 25px; */
 }
 
 .preview iframe {

--- a/site/about/contributing/style-guide/conventions.qmd
+++ b/site/about/contributing/style-guide/conventions.qmd
@@ -446,9 +446,31 @@ Refer also to [the glossary](/about/glossary/glossary.qmd) for extended informat
 
 ## Training materials
 
-The ValidMind Academy is delivered in Revealjs presentation format,[^20] with a slightly different set of conventions:
+The ValidMind Academy[^20] is delivered in Revealjs presentation format,[^21] with a slightly different set of conventions:
 
-- It makes use of Tachyons CSS[^21] to provide demonstration overlays.
+- Registration landing pages make use of our custom `.preview` class to display the tile card for the course:
+
+  :::: {.flex .flex-wrap .justify-around}
+
+  ::: {.w-40-ns}
+
+    ```markdown
+  ::: {.preview source="/training/administrator-fundamentals.qmd"}
+  :::
+  ```
+
+  :::
+
+  ::: {.w-50-ns}
+
+  ::: {.preview source="/training/administrator-fundamentals.qmd"}
+  :::
+  <br>
+  :::
+
+  ::::
+
+- Training slides make use of Tachyons CSS[^22] to provide demonstration overlays.
 
   Enable Tachyons CSS in the front matter with:
 
@@ -488,8 +510,7 @@ The ValidMind Academy is delivered in Revealjs presentation format,[^20] with a 
 
   ::::
 
-
-- It uses inline links only instead of footnotes,[^22] as footnotes are not visible in presentation mode.
+- Training slides use inline links only instead of footnotes,[^23] as footnotes are not visible in presentation mode.
 
 ## What's next
 - [Voice and tone](voice-and-tone.qmd)
@@ -535,8 +556,10 @@ The ValidMind Academy is delivered in Revealjs presentation format,[^20] with a 
 
 [^19]: [Code samples](/developer/samples-jupyter-notebooks.qmd)
 
-[^20]: **Quarto:** [Revealjs](https://quarto.org/docs/presentations/revealjs/)
+[^20]: [Welcome to ValidMind Training](/training/training.qmd)
 
-[^21]: **GitHub:** [Tachyons Extension For Quarto](https://github.com/nareal/tachyons)
+[^21]: **Quarto:** [Revealjs](https://quarto.org/docs/presentations/revealjs/)
 
-[^22]: [Inline links](#inline-links)
+[^22]: **GitHub:** [Tachyons Extension For Quarto](https://github.com/nareal/tachyons)
+
+[^23]: [Inline links](#inline-links)

--- a/site/index.qmd
+++ b/site/index.qmd
@@ -53,21 +53,21 @@ listing:
       - 2024-jun-10/release-notes.qmd
   - id: validmind-academy
     type: grid
-    image-height: 300px
+    image-height: 200px
     sort: false
     contents:
     - path: training/administrator-fundamentals-register.qmd
-      image: /assets/img/admin-diagram.png
+      image: training/administrator-fundamentals.png
       title: "Administrator Fundamentals {{< fa gear >}}"
-      subtitle: "docs.validmind.ai/training {{< fa chevron-right >}}"
+      subtitle: "Register now {{< fa chevron-right >}}"
     - path: training/developer-fundamentals-register.qmd
       title: "Developer Fundamentals {{< fa code >}}"
-      subtitle: "docs.validmind.ai/training {{< fa chevron-right >}}"
-      image: /assets/img/developer-diagram.png
+      subtitle: "Register now {{< fa chevron-right >}}"
+      image: training/developer-fundamentals.png
     - path: training/validator-fundamentals-register.qmd
-      image: /assets/img/validator-diagram.png
+      image: training/validator-fundamentals.png
       title: "Validator Fundamentals {{< fa user-check >}}"
-      subtitle: "docs.validmind.ai/training {{< fa chevron-right >}}"
+      subtitle: "Register now {{< fa chevron-right >}}"
     fields: [image, title, subtitle]
 ---
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -153,7 +153,7 @@ div.callout.callout {
   border: 1px solid #083E44;
 }
 
-pre, pre.python, pre.bash, pre.yaml {
+pre, pre.python, pre.bash, pre.yaml, pre.markdown {
   background-color: #083E4420;
   padding: 15px;
   border-radius: 5px;
@@ -482,13 +482,10 @@ figcaption {
   text-align: center;
 }
 
-.training-course {
-  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2); 
-  border: 1px solid #DE257E;
-  border-left-width: 25px;
-  background: #B5B5B510;
+#listing-sample-notebooks .listing-author {
+  color: #083E44; 
+  font-weight: bold;
 }
-
 
 /* section#footnotes {
   display: none !important;

--- a/site/styles.css
+++ b/site/styles.css
@@ -466,21 +466,29 @@ figcaption {
   cursor: pointer;
 }
 
-#listing-training-courses .thumbnail-image.card-img, #listing-fundamentals .thumbnail-image.card-img {
+#listing-training-courses .thumbnail-image.card-img, #listing-validmind-academy .thumbnail-image.card-img {
   object-fit: cover;      
   object-position: top;    
   height: 100%;            
   width: 100%;             
 }
 
-#listing-validmind-academy .no-anchor.listing-title, #listing-fundamentals .no-anchor.listing-title {
+#listing-validmind-academy .no-anchor.listing-title {
   text-align: center;
 }
 
-#listing-validmind-academy .listing-subtitle, #listing-fundamentals .listing-subtitle {
+#listing-validmind-academy .listing-subtitle {
   font-size: smaller;
   text-align: center;
 }
+
+.training-course {
+  box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.2); 
+  border: 1px solid #DE257E;
+  border-left-width: 25px;
+  background: #B5B5B510;
+}
+
 
 /* section#footnotes {
   display: none !important;

--- a/site/training/administrator-fundamentals-register.qmd
+++ b/site/training/administrator-fundamentals-register.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Administrator<br>Fundamentals"
+title: "Administrator Fundamentals"
 subtitle: For {{< var vm.product >}}
 date: last-modified
 filters:

--- a/site/training/training.qmd
+++ b/site/training/training.qmd
@@ -37,21 +37,29 @@ listing:
       subtitle: "Open notebook in JupyterHub {{< fa chevron-right >}}"
       description: "Gets you started with the basic process of documenting models with ValidMind, from the {{< var vm.developer >}} to the {{< var vm.platform >}}."
       categories: ["[Demo] Customer Churn Model"]
+      reading-time: "10"
+      author: "ValidMind"
     - path: https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/tutorials/intro_for_model_developers.ipynb
       title: "ValidMind introduction for model developers"
       subtitle: "Open notebook in JupyterHub {{< fa chevron-right >}}"
       description: "Learn how the end-to-end documentation process works based on common scenarios you encounter in model development settings."
       categories: ["[Demo] Customer Churn Model"]
+      reading-time: "27"
+      author: "ValidMind"
     - path: https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/code_samples/credit_risk/application_scorecard_demo.ipynb
       title: "Document an application scorecard model"
       subtitle: "Open notebook in JupyterHub {{< fa chevron-right >}}"
       description: "Guides you through building and documenting an application scorecard model using the Lending Club sample dataset from Kaggle."
       categories: ["[Demo] Credit Risk Model"]
+      reading-time: "16"
+      author: "ValidMind"
     - path: https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/code_samples/nlp_and_llm/foundation_models_integration_demo.ipynb
       title: "Prompt validation for large language models (LLMs)"
       subtitle: "Open notebook in JupyterHub {{< fa chevron-right >}}"
       description: "Run and document prompt validation tests for a large language model (LLM) specialized in sentiment analysis for financial news."
       categories: ["[Demo] Foundation Model - Text Sentiment Analysis"]
+      reading-time: "8"
+      author: "ValidMind"
 ---
 
 Gain hands-on experience and explore what ValidMind has to offer with our training courses.

--- a/site/training/training.qmd
+++ b/site/training/training.qmd
@@ -12,7 +12,7 @@ listing:
   - id: training-courses
     type: grid
     max-description-length: 250
-    image-height: 225px
+    image-height: 175px
     sort: false
     contents:
     - path: administrator-fundamentals-register.qmd


### PR DESCRIPTION
## Internal Notes for Reviewers

Cleaned up the neat training edits Nik set up!

[**LIVE PREVIEW**](https://docs-demo.vm.validmind.ai/pr_previews/beck/training-adjusts/index.html)

### Index Academy section

<img width="1316" alt="Screenshot 2024-10-28 at 2 33 09 PM" src="https://github.com/user-attachments/assets/0305efc7-d6c9-49f6-b097-c5aba96ff04f">

### Training landing 

Just made sure the admin training was all in one line:

<img width="1198" alt="Screenshot 2024-10-28 at 2 41 10 PM" src="https://github.com/user-attachments/assets/ffe18a28-7d4e-4d3b-a580-fdf0e2bae706">

Added the author & reading time to the notebooks:

<img width="1137" alt="Screenshot 2024-10-28 at 2 57 22 PM" src="https://github.com/user-attachments/assets/8a94cf27-e074-4074-8d79-08808de39431">

### Style guide reference

<img width="936" alt="Screenshot 2024-10-28 at 3 10 27 PM" src="https://github.com/user-attachments/assets/d78e7ea1-41e8-4a1f-bb68-7f9b419ae63d">
