### PR TITLE
Quick adjustment to hero BG img for training 

### DIFF
--- a/site/training/assets/training.css
+++ b/site/training/assets/training.css
@@ -20,6 +20,7 @@ a:hover {
     align-items: center; 
     flex-direction: column; 
     text-align: center;
+    background-size: cover;
 }
 
 #quarto-sidebar.sidebar {


### PR DESCRIPTION
## Internal Notes for Reviewers

I noticed during the demo video that was filmed the BG img for the training hero banner repeats instead of being seamless. Fixed now.

| Old | New |
|---|---|
| <img width="1710" alt="Screenshot 2024-11-12 at 2 06 04 PM" src="https://github.com/user-attachments/assets/ca262a1a-1718-4f8b-a668-0fd675153ae0"> | <img width="1708" alt="Screenshot 2024-11-12 at 2 06 28 PM" src="https://github.com/user-attachments/assets/58171f3c-d9f8-407e-8bf6-0778d150ba1b">|