### PR TITLE
Quick CSS cleanup

### DIFF
--- a/site/about/contributing/style-guide/conventions.qmd
+++ b/site/about/contributing/style-guide/conventions.qmd
@@ -332,7 +332,7 @@ lightbox: true
 ##### Embedded
 
 ```html
-<div style="position: relative; padding-bottom: 65.2962515114873%; height: 0;"><iframe src="https://www.loom.com/embed/4d0572607d254b04a5c951b4d3f91f73?sid=ac7ffa93-e9e2-42f0-9392-abcf8d52c104" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 90%; height: 90%; box-shadow: 5px 5px 5px #ccc; border-radius: 5px; border: 1px solid #DE257E;"></iframe></div>
+<div style="position: relative; padding-bottom: 65.2962515114873%; height: 0;"><iframe src="https://www.loom.com/embed/4d0572607d254b04a5c951b4d3f91f73?sid=ac7ffa93-e9e2-42f0-9392-abcf8d52c104" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 90%; height: 90%; box-shadow: 5px 5px 5px #ccc; border-radius: 5px; border: 1px solid #196972;"></iframe></div>
 ```
 
 #### Code

--- a/site/releases/2024-oct-22/release-notes.qmd
+++ b/site/releases/2024-oct-22/release-notes.qmd
@@ -282,7 +282,7 @@ Watch the demo:
 <div style="position: relative; padding-bottom: 62.5%; height: 0;">
   <iframe src="https://www.loom.com/embed/4d7d14b21d17416caefddf2b46fe05af?sid=70f2acd6-9a29-4856-a6ed-b3a0b28b084b"
     frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen
-    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; box-shadow: 5px 5px 5px #ccc, -5px 5px 5px #ccc; border-radius: 5px; box-shadow: 5px 5px 5px #ccc; border-radius: 5px; border: 1px solid #DE257E;"></iframe>
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; box-shadow: 5px 5px 5px #ccc, -5px 5px 5px #ccc; border-radius: 5px; box-shadow: 5px 5px 5px #ccc; border-radius: 5px; border: 1px solid #196972;"></iframe>
 </div>
 
 <!---

--- a/site/styles.css
+++ b/site/styles.css
@@ -53,8 +53,8 @@ a.nav-link, a.dropdown-item {
   position: relative;
 }
 
-a.nav-link:not(nav#TOC a.nav-link):before, 
-a.dropdown-item:not(nav#TOC a.dropdown-item):before {
+a.nav-link:not(nav#TOC a.nav-link, .nav-footer a:hover):before, 
+a.dropdown-item:before {
   content: "";
   position: absolute;
   display: block;
@@ -258,6 +258,11 @@ pre, pre.python, pre.bash, pre.yaml, pre.markdown {
 
 .nav-footer {
   padding-top: 25px;
+}
+
+.nav-footer a:hover {
+  color: #1A202C;
+  text-decoration: none;
 }
 
 .alert, .alert-primary {

--- a/site/styles.css
+++ b/site/styles.css
@@ -463,7 +463,7 @@ figcaption {
 .video, iframe[src*="youtube.com"] {
   box-shadow: 5px 5px 5px #ccc; 
   border-radius: 5px;
-  border: 1px solid #DE257E;
+  border: 1px solid #196972;
 }
 
 #listing-validmind-academy .thumbnail-image.card-img {

--- a/site/training/training.qmd
+++ b/site/training/training.qmd
@@ -68,6 +68,14 @@ listing:
       author: "{{< var vm.product >}}"
 ---
 
+```{=html}
+<style>
+  .navbar {
+  background-color: white !important;
+}
+</style>
+```
+
 ::: {.column-screen}
 
 ::: {.training-hero}


### PR DESCRIPTION
## Internal Notes for Reviewers

- Reverted the `training/training.qmd` (training landing page) top nav to white for contrast with the special hero banner
- Fixed the disappearing footer hover links
- Adjusted the video border convention

| Old | New |
|---|---|
| <img width="1711" alt="Screenshot 2024-11-18 at 10 04 59 AM" src="https://github.com/user-attachments/assets/329545f3-430b-45f5-993c-af2e8564ef62">| <img width="1710" alt="Screenshot 2024-11-18 at 10 25 15 AM" src="https://github.com/user-attachments/assets/cefb9a10-0485-4aaf-9029-d3f06b0c674f">|
|<img width="1710" alt="Screenshot 2024-11-18 at 10 05 11 AM" src="https://github.com/user-attachments/assets/506b2d16-5bfb-4aef-b666-0cd6786dcd67"> |<img width="1710" alt="Screenshot 2024-11-18 at 10 25 26 AM" src="https://github.com/user-attachments/assets/7d1235e6-841b-4016-8b79-c338b9082111"> |
|<img width="791" alt="Screenshot 2024-11-18 at 10 05 21 AM" src="https://github.com/user-attachments/assets/efe30fee-70c4-4223-9f69-ae0f9c2fe6e7"> |<img width="790" alt="Screenshot 2024-11-18 at 10 25 34 AM" src="https://github.com/user-attachments/assets/30a85bfa-0232-4cf9-a5ee-20ae4fb72502"> |