### PR TITLE
Add login button to docs site

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -74,6 +74,7 @@ website:
     right:
       - text: "Login"
         menu:
+          - text: "Public Internet"
           - text: "{{< var validmind.platform >}} · `US1` {{< fa right-to-bracket >}}"
             href:  https://app.prod.validmind.ai/
             target: _blank
@@ -81,9 +82,12 @@ website:
             href: https://app.ca1.validmind.ai
             target: _blank
           - text: "---"
+          - text: "Private Link"
+          - text: "{{< var validmind.vpv >}} (VPV)"
+            href: "guide/configuration/log-in-to-validmind.qmd#section"
+          - text: "---"
           - text: "<small>Which login should I use?</small>"
             href: "guide/configuration/log-in-to-validmind.qmd"
-
 
 #  COMMENT THIS OUT WHEN DONE TESTING
       # - text: "{{< fa flask >}} Testing"

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -13,9 +13,6 @@ website:
   google-analytics: 
     tracking-id: "G-S46CKWPNSS"
     anonymize-ip: true
-  search:
-    location: sidebar
-    type: textbox
     show-item-context: true
   page-navigation: true
   repo-url: https://github.com/validmind/documentation/
@@ -74,6 +71,15 @@ website:
       - text: "validmind.com {{< fa external-link >}}"
         file: https://validmind.com/
         target: _blank
+    right:
+      - text: "Login"
+        menu:
+          - text: " {{< fa right-to-bracket >}} Default · US1 · us-east-1"
+            href:  https://app.prod.validmind.ai/
+            target: _blank
+          - text: " {{< fa right-to-bracket >}} Canada · CA1 · ca-west-1"
+            href: https://app.ca1.validmind.ai
+            target: _blank
 
 #  COMMENT THIS OUT WHEN DONE TESTING
       # - text: "{{< fa flask >}} Testing"

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -74,12 +74,16 @@ website:
     right:
       - text: "Login"
         menu:
-          - text: " {{< fa right-to-bracket >}} Default · US1 · us-east-1"
+          - text: "{{< var validmind.platform >}} · `US1` {{< fa right-to-bracket >}}"
             href:  https://app.prod.validmind.ai/
             target: _blank
-          - text: " {{< fa right-to-bracket >}} Canada · CA1 · ca-west-1"
+          - text: "{{< var validmind.platform >}} · `CA1` {{< fa right-to-bracket >}}"
             href: https://app.ca1.validmind.ai
             target: _blank
+          - text: "---"
+          - text: "<small>Which login should I use?</small>"
+            href: "guide/configuration/log-in-to-validmind.qmd"
+
 
 #  COMMENT THIS OUT WHEN DONE TESTING
       # - text: "{{< fa flask >}} Testing"

--- a/site/guide/configuration/log-in-to-validmind.qmd
+++ b/site/guide/configuration/log-in-to-validmind.qmd
@@ -54,7 +54,7 @@ Signing up is FREE — {{< var link.register >}}
 
 ## {{< var validmind.vpv >}}
 
-To configure and log in through a private endpoint for your company VPC using a supported service:
+To configure and log in through a private link for your company VPC using a supported service:
 
 :::{#private-networks}
 :::

--- a/site/guide/configuration/log-in-to-validmind.qmd
+++ b/site/guide/configuration/log-in-to-validmind.qmd
@@ -21,7 +21,7 @@ Log in to our cloud-hosted {{< var validmind.platform >}} to work with your mode
 {{< var vm.product >}} supports the following methods for logging in:
 
 - [Public internet](#public-internet) — easiest, less secure
-- [Private network endpoints](#private-network-endpoints) — requires additional configuration, more secure
+- [{{< var validmind.vpv >}}](#section) — requires additional configuration, more secure
 
 ::: {.attn}
 
@@ -52,7 +52,7 @@ Signing up is FREE — {{< var link.register >}}
 
     After successful login, you will be redirected to the main dashboard of the {{< var validmind.platform >}}.
 
-## Private network endpoints
+## {{< var validmind.vpv >}}
 
 To configure and log in through a private endpoint for your company VPC using a supported service:
 

--- a/site/styles.css
+++ b/site/styles.css
@@ -460,6 +460,20 @@ figcaption {
   filter: brightness(125%);
 }
 
+#nav-menu-login {
+  background-color: #083E44;
+  border: 1px solid #083E44;
+  color: white;
+  padding: 0.375rem 0.75rem;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+#nav-menu-login:hover {
+  text-decoration: none;
+  filter: brightness(125%);
+}
+
 .video, iframe[src*="youtube.com"] {
   box-shadow: 5px 5px 5px #ccc; 
   border-radius: 5px;

--- a/site/styles.css
+++ b/site/styles.css
@@ -173,7 +173,7 @@ pre, pre.python, pre.bash, pre.yaml, pre.markdown {
 
 .hero {
   position: relative;
-  margin-top: -35px;
+  margin-top: -50px;
   padding: 75px;
   padding-bottom: 50px;
   color: white;

--- a/site/styles.css
+++ b/site/styles.css
@@ -474,6 +474,10 @@ figcaption {
   filter: brightness(125%);
 }
 
+.dropdown-menu.dropdown-menu-end.show {
+  padding-top: 0.5rem; /* Adjust the value as needed */
+}
+
 .video, iframe[src*="youtube.com"] {
   box-shadow: 5px 5px 5px #ccc; 
   border-radius: 5px;

--- a/site/training/assets/training.css
+++ b/site/training/assets/training.css
@@ -8,7 +8,7 @@ a:hover {
 
 .training-hero {
     position: relative;
-    margin-top: -35px;
+    margin-top: -50px;
     padding: 100px;
     background-color: #042426;
     color: #EAF8FA;


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR adds a **Login** button & menu to our docs site. If this format works for you, we can ask CSTMR to add the same button to our main site: [**LIVE PREVIEW**](https://docs-demo.vm.validmind.ai/pr_previews/nrichers/sc-7484/add-login-button-to-docs-site/index.html)

![image](https://github.com/user-attachments/assets/594de582-62fe-48a3-8e1e-8b255eb7d29c)

As part of this change, I'm also switching the search over to the navbar icon — it helps with spacing for the Login button and helps differentiate how search on the front page is subtly different from search that is available elsewhere. 

How it works: 

![2024-11-25_13-20-38 (1)](https://github.com/user-attachments/assets/1a397dea-9a52-49ca-b533-45186f3e80b3)

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

We added the option to log in to the ValidMind Platform to our docs site, making it easy for you to find the right login. Click **Login** to try it out.