### PR TITLE
Quick workflow filter tweak

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -36,7 +36,7 @@ jobs:
         id: filter
         with:
           base: prod
-          head: staging
+          head: ${{ github.head_ref }}
           filters: |
             notebooks:
               - 'site/notebooks/**'

--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -36,7 +36,7 @@ jobs:
         id: filter
         with:
           base: prod
-          head: ${{ github.head_ref }}
+          ref: ${{ github.head_ref }}
           filters: |
             notebooks:
               - 'site/notebooks/**'

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -36,7 +36,7 @@ jobs:
         id: filter
         with:
           base: staging
-          head: main
+          head: ${{ github.head_ref }}
           filters: |
             notebooks:
               - 'site/notebooks/**'

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -36,7 +36,7 @@ jobs:
         id: filter
         with:
           base: staging
-          head: ${{ github.head_ref }}
+          ref: ${{ github.head_ref }}
           filters: |
             notebooks:
               - 'site/notebooks/**'

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -35,7 +35,7 @@ jobs:
       id: filter
       with:
         base: main
-        head: ${{ github.head_ref }}
+        ref: ${{ github.head_ref }}
         filters: |
           notebooks:
             - 'site/notebooks/**'

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -4,7 +4,7 @@ project:
 
 website:
   announcement: 
-    content: "[**{{< fa book-open-reader >}} Validating Generative AI**](https://validmind.com/download-whitepaper-validating-generative-ai/) — Read our original technical brief created in collaboration with Parker & Lawrence Growth Advisory" 
+    content: "[**{{< fa book-open-reader >}} EU AI Act Compliance**](https://validmind.com/download-whitepaper-the-eu-ai-act/) — Read our original regulation brief on how the EU AI Act aims to balance innovation with safety and accountability, setting standards for responsible AI use" 
     position: below-navbar 
   favicon: validmind.png
   title: "ValidMind"

--- a/site/notebooks/README.md
+++ b/site/notebooks/README.md
@@ -19,3 +19,5 @@ If this is your first time trying out ValidMind, you can make use of the followi
 
 - [Get started](https://docs.validmind.ai/get-started/get-started.html) — The basics, including key concepts, and how our products work
 - [Get started with the ValidMind Library](https://docs.validmind.ai/developer/get-started-validmind-library.html) —  The path for developers, more code samples, and our developer reference
+
+<!-- TEST FOR #554 -->

--- a/site/notebooks/README.md
+++ b/site/notebooks/README.md
@@ -19,5 +19,3 @@ If this is your first time trying out ValidMind, you can make use of the followi
 
 - [Get started](https://docs.validmind.ai/get-started/get-started.html) — The basics, including key concepts, and how our products work
 - [Get started with the ValidMind Library](https://docs.validmind.ai/developer/get-started-validmind-library.html) —  The path for developers, more code samples, and our developer reference
-
-<!-- TEST FOR #554 -->


### PR DESCRIPTION
## Internal Notes for Reviewers

Refer to https://github.com/validmind/documentation/pull/552:

> I think I know why the comparison is failing — our branches essentially match between merges, so we actually have to compare the PR being merged to the base instead

![documentation-workflows](https://github.com/user-attachments/assets/3ac4da49-3863-4bf8-ba29-20d6c5767c3d)

### Expected behaviour

#### PR > `main`

1. - [x] Initial PR creation will NOT trigger the notebook execution: [**SUCCESSFUL WORKFLOW RUN**](https://github.com/validmind/documentation/actions/runs/12075894036/job/33676434071?pr=554)
2. - [x] `site/notebooks/**` has a change pushed up to the PR, it will trigger the notebook execution: [**SUCCESSFUL WORKFLOW RUN**](https://github.com/validmind/documentation/actions/runs/12077048656/job/33679352389?pr=554)

#### `main` > `staging`

- [ ] After this PR is merged into `main`, the workflow merging into `staging` from `main` will trigger the notebook execution: [**SUCCESSFUL WORKFLOW RUN**](url)

#### `staging` > `prod`

- [ ] The next time we publish to `prod`, the workflow merging into `staging` from `prod` will trigger the notebook execution: [**WORKFLOW LINK PLACEHOLDER**](url)
