### PR TITLE
Fixing on the fly notebook execution filter

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -31,12 +31,13 @@ jobs:
             }
 
       # See if site/notebooks/ has updates
+      # Checks against the previous commit to the branch prior to the current push event
       - name: Filter changed files
         uses: dorny/paths-filter@v2
         id: filter
         with:
-          base: prod
-          ref: ${{ github.head_ref }}
+          base: ${{ github.event.before }}
+          ref: ${{ github.sha }}
           filters: |
             notebooks:
               - 'site/notebooks/**'

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -31,12 +31,13 @@ jobs:
             }
 
       # See if site/notebooks/ has updates
+      # Checks against the previous commit to the branch prior to the current push event
       - name: Filter changed files
         uses: dorny/paths-filter@v2
         id: filter
         with:
-          base: staging
-          ref: ${{ github.head_ref }}
+          base: ${{ github.event.before }}
+          ref: ${{ github.sha }}
           filters: |
             notebooks:
               - 'site/notebooks/**'

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -30,11 +30,12 @@ jobs:
           }
     
     # See if site/notebooks/ has updates
+    # Checks the current PR branch against the target branch
     - name: Filter changed files
       uses: dorny/paths-filter@v2
       id: filter
       with:
-        base: main
+        base: ${{ github.event.pull_request.base_ref }}
         ref: ${{ github.head_ref }}
         filters: |
           notebooks:

--- a/site/notebooks/README.md
+++ b/site/notebooks/README.md
@@ -19,5 +19,3 @@ If this is your first time trying out ValidMind, you can make use of the followi
 
 - [Get started](https://docs.validmind.ai/get-started/get-started.html) — The basics, including key concepts, and how our products work
 - [Get started with the ValidMind Library](https://docs.validmind.ai/developer/get-started-validmind-library.html) —  The path for developers, more code samples, and our developer reference
-
-<!-- TEST FOR #554 -->


### PR DESCRIPTION
## Internal Notes for Reviewers

I THINK I finally refined it to the point where it will work. Some of the issue was the previous set-up defaults to always checking against `main` because that is the behaviour of how `${{ github.head_ref }}` works:

- Only available in the context of a PR and not a workflow push (So for example, when I tried to hack the deploy staging & docs workflows further because those are triggered by the `merge-x-into-...` workflows it ignored the input) 
- Always checks against the branch the PR was created from (in this case, `main`) even if you specify a different `base`

### validate-docs-site.yaml

Now this checks the current PR against the branch you're intending to merge into (so it will in theory also work when we preview the site for pushes to `prod` and not just working PRs pre-`main` merge 🤞🏻):

```
# See if site/notebooks/ has updates
# Checks the current PR branch against the target branch
- name: Filter changed files
  uses: dorny/paths-filter@v2
  id: filter
  with:
    base: ${{ github.event.pull_request.base_ref }}
    ref: ${{ github.head_ref }}
    filters: |
      notebooks:
        - 'site/notebooks/**'
```

### deploy-docs-staging.yaml & deploy-docs-prod.yaml

Other than the `on.push.branches` filter at the top of each workflow, these are now the same:

```
# See if site/notebooks/ has updates
# Checks against the previous commit to the branch prior to the current push event
- name: Filter changed files
  uses: dorny/paths-filter@v2
  id: filter
  with:
    base: ${{ github.event.before }}
    ref: ${{ github.sha }}
    filters: |
      notebooks:
        - 'site/notebooks/**'
```

We are now checking for changes against the PREVIOUS commit prior to the push that triggered the workflow. HOPEFULLY??? this is the final solution??? Allegedly `${{ github.sha }}` is available to push workflows so that should solve our issue. 

### Expected behaviour

#### PR > `main` 

1. - [x] Initial PR creation will NOT trigger the notebook execution: **[SUCCESSFUL WORKFLOW RUN](https://github.com/validmind/documentation/actions/runs/12127175161/job/33810867786)**
2. - [x] `site/notebooks/**` has a change pushed up to the PR, it will trigger the notebook execution: **[SUCCESSFUL WORKFLOW RUN](https://github.com/validmind/documentation/actions/runs/12127311576/job/33811298815?pr=559)**

#### `main` > `staging`

- [ ] After this PR is merged into `main`, the workflow merging into `staging` from `main` will trigger the notebook execution:

#### `staging` > `prod`

- [ ] The next time we publish to `prod`, the workflow merging into `staging` from `prod` will trigger the notebook execution: 
