### PR TITLE
Filtering for changes on prod/staging

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Fetch all branches
   
       - name: Fetch Quarto
         uses: ./.github/actions/fetch-quarto
@@ -41,7 +43,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: filter
         with:
-          base: origin/prod
+          base: prod
           ref: ${{ github.sha }}
           filters: |
             notebooks:

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Fetch all branches
   
       - name: Fetch Quarto
         uses: ./.github/actions/fetch-quarto
@@ -41,7 +43,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: filter
         with:
-          base: origin/staging
+          base: staging
           ref: ${{ github.sha }}
           filters: |
             notebooks:


### PR DESCRIPTION
## Internal Notes for Reviewers

[Apparently the workflows don't like `origin/{branch}`](https://github.com/validmind/documentation/actions/runs/12147361786/job/33873963795)... SO I am trying ONE MORE THING, and if this doesn't work @nrichers you might have to take over. Stupid workflows. 

Ensuring we fetch all the branches when we check out the repo:

```
- name: Check out repository
  uses: actions/checkout@v2
  with:
    fetch-depth: 0  # Fetch all branches
```

Just using `staging` as `base` instead of `origin/staging`:

```
# See if site/notebooks/ has updates
# Checks against the previous commit to staging prior to the current push event
- name: Filter changed files
  if: ${{ steps.fetch_staging.outcome == 'success' }}
  uses: dorny/paths-filter@v2
  id: filter
  with:
    base: staging
    ref: ${{ github.sha }}
    filters: |
      notebooks:
              - 'site/notebooks/**'
```

**To reiterate, the issue isn't the heap tracking/execution profiles, it's filtering for changed files in the notebooks folder when we merge into `staging` and `prod` via our workflows/publication step.** The only way to get rid of the complexity is to remove this filter and up the render time regardless of whether or not the notebooks have been updated. 