### PR TITLE
Live notebook execution workflows, take ... whatever

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0  # Fetch all branches
+          fetch-depth: 0  # Fetch all history
   
       - name: Fetch Quarto
         uses: ./.github/actions/fetch-quarto
@@ -43,7 +43,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: filter
         with:
-          base: prod
+          base: prod~1
           ref: ${{ github.sha }}
           filters: |
             notebooks:

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0  # Fetch all branches
+          fetch-depth: 0  # Fetch all history
   
       - name: Fetch Quarto
         uses: ./.github/actions/fetch-quarto
@@ -43,7 +43,7 @@ jobs:
         uses: dorny/paths-filter@v2
         id: filter
         with:
-          base: staging
+          base: staging~1
           ref: ${{ github.sha }}
           filters: |
             notebooks:

--- a/site/notebooks/README.md
+++ b/site/notebooks/README.md
@@ -20,4 +20,4 @@ If this is your first time trying out ValidMind, you can make use of the followi
 - [Get started](https://docs.validmind.ai/get-started/get-started.html) — The basics, including key concepts, and how our products work
 - [Get started with the ValidMind Library](https://docs.validmind.ai/developer/get-started-validmind-library.html) —  The path for developers, more code samples, and our developer reference
 
-<!-- Test for PR #561 -->
+<!-- Test for PR #567 -->


### PR DESCRIPTION
## Internal Notes for Reviewers

I keep saying I'm giving up but then I don't... anyway. 

The LAST attempt gave me some interesting info in the logs. It did properly check against the correct `base` (`staging`) with the current commit aligning to the PR branch that was being merged in, but it still told me there was no difference in files:

![Screenshot 2024-12-03 at 5 15 39 PM](https://github.com/user-attachments/assets/830d5e15-c10c-45cf-b6f8-ec763a8e2e19)

Presumably because when the `merge-main-into-staging.yaml` workflow is complete, there ARE no changes in between `staging` and the commit being compared, because it's already been smushed in...

And so, I am trying to explicitly call the commit PRIOR to the most recent commit:

```yaml
# See if site/notebooks/ has updates
# Checks against the previous commit to staging prior to the current push event
- name: Filter changed files
  if: ${{ steps.fetch_staging.outcome == 'success' }}
  uses: dorny/paths-filter@v2
  id: filter
  with:
    base: staging~1
    ref: ${{ github.sha }}
    filters: |
      notebooks:
        - 'site/notebooks/**'
```

I am hoping this will work. When I call `git show HEAD~1` when I am on staging, I get the following info:

![Screenshot 2024-12-04 at 11 21 49 AM](https://github.com/user-attachments/assets/46a16eca-7e46-47c8-b105-0710179a1960)

Which aligns with the last commit PRIOR to the last commit that was auto-merged in by the `merge-main-into-staging.yaml` workflow, so in theory the next time the workflows run it will retrieve the right commit to compare against. In theory. (It would help if I knew what I was doing.) 

<img width="1432" alt="Screenshot 2024-12-04 at 11 25 19 AM" src="https://github.com/user-attachments/assets/87ddb8ac-a6a8-4b7a-b566-1ee267abbe74">