### PR TITLE
Removing the workflow filters for staging & prod

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Fetch all history
   
       - name: Fetch Quarto
         uses: ./.github/actions/fetch-quarto
@@ -32,26 +30,7 @@ jobs:
             exit 1;
             }
 
-      - name: Fetch prod branch
-        id: fetch_prod
-        run: git fetch origin prod
-
-      # See if site/notebooks/ has updates
-      # Checks against the previous commit to prod prior to the current push event
-      - name: Filter changed files
-        if: ${{ steps.fetch_prod.outcome == 'success' }}
-        uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          base: ${{ github.ref }}
-          ref: ${{ github.sha }}
-          filters: |
-            notebooks:
-              - 'site/notebooks/**'
-
-      # If yes then create the .env file for use in execution step
       - name: Create .env file
-        if: steps.filter.outputs.notebooks == 'true'
         id: create_env
         run: |
           touch .env

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v2
-        with:
-          fetch-depth: 0  # Fetch all history
   
       - name: Fetch Quarto
         uses: ./.github/actions/fetch-quarto
@@ -32,26 +30,7 @@ jobs:
             exit 1;
             }
 
-      - name: Fetch staging branch
-        id: fetch_staging
-        run: git fetch origin staging
-
-      # See if site/notebooks/ has updates
-      # Checks against the previous commit to staging prior to the current push event
-      - name: Filter changed files
-        if: ${{ steps.fetch_staging.outcome == 'success' }}
-        uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          base: ${{ github.ref }}
-          ref: ${{ github.sha }}
-          filters: |
-            notebooks:
-              - 'site/notebooks/**'
-
-      # If yes then create the .env file for use in execution step
       - name: Create .env file
-        if: steps.filter.outputs.notebooks == 'true'
         id: create_env
         run: |
           touch .env


### PR DESCRIPTION
## Internal Notes for Reviewers

Yeah, I gave up and just removed the filter for changed files on the `staging` and `prod` workflows. 

Here's the follow-up story in case you want to take a stab at it, @nrichers: https://app.shortcut.com/validmind/story/7680/have-staging-prod-workflows-filter-so-that-they-only-execute-notebooks-when-notebooks-are-changed