### PR TITLE
Fix link to SR 11-7

### DIFF
--- a/site/about/glossary/_models.qmd
+++ b/site/about/glossary/_models.qmd
@@ -1,7 +1,7 @@
 #### Models
 
 model
-: SR 11-7^[[SR 11-7: Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/sr1107.html)] defines a model as a "quantitative method, system, or approach that applies statistical, economic, financial, or mathematical theories, techniques, and assumptions to process input data into quantitative estimates."
+: SR 11-7^[[SR 11-7: Guidance on Model Risk Management](https://www.federalreserve.gov/supervisionreg/srletters/sr1107.htm)] defines a model as a "quantitative method, system, or approach that applies statistical, economic, financial, or mathematical theories, techniques, and assumptions to process input data into quantitative estimates."
 
 model development
 : An iterative process in which many models are derived, tested, and built upon until a model fitting the desired criteria is achieved.


### PR DESCRIPTION
## Internal Notes for Reviewers

Kevin pointed out this link to SR 11-7 in our glossary is broken, now fixed. 

EDIT: Did a quick search through the repo and this looks to be the only occurrence of this particular malformed link.

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->