### PR TITLE
Forgot the guides in the dropdown

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -83,6 +83,8 @@ website:
           file: about/overview.qmd
         - text: "{{< fa rocket >}} Get Started"
           file: get-started/get-started.qmd
+        - text: "{{< fa circle-info >}} Guides"
+          file: guide/guides.qmd
         - text: "{{< fa circle-question >}} FAQ"
           file: faq/faq.qmd
         - text: "{{< fa envelope-open-text >}} Support"


### PR DESCRIPTION
## Internal Notes for Reviewers

Forgot the guides link in the documentation drop-down. Fixed. 🤦🏻 

| Before | After |
|---|---|
|<img width="304" alt="Screenshot 2024-12-12 at 1 05 59 PM" src="https://github.com/user-attachments/assets/189c42dd-cbd2-4713-98f9-8cc2bffdac10" /> | <img width="308" alt="Screenshot 2024-12-12 at 1 03 26 PM" src="https://github.com/user-attachments/assets/257b31af-77ee-4a0b-abb1-65bb1df02399" />|