### PR TITLE
Docs quick audit — ValidMind Library

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -83,7 +83,7 @@ website:
           file: about/overview.qmd
         - text: "{{< fa rocket >}} Get Started"
           file: get-started/get-started.qmd
-        - text: "{{< fa circle-info >}} Guides"
+        - text: "{{< fa book >}} Guides"
           file: guide/guides.qmd
         - text: "{{< fa circle-question >}} FAQ"
           file: faq/faq.qmd

--- a/site/about/overview-model-documentation.qmd
+++ b/site/about/overview-model-documentation.qmd
@@ -27,7 +27,7 @@ It offers model developers a systematic approach to documenting and testing risk
 
 <!-- Using the variable in alt text messes up the image display  -->
 
-![The two main components of {{< var vm.product >}}. The {{< var validmind.developer >}} that integrates with your existing developer environment, and the {{< var validmind.platform >}}.](/about/deployment/validmind-architecture-overview.png){fig-alt="An image showing the two main components of ValidMind. The ValidMind Library that integrates with your existing developer environment, and the ValidMind Platform."}
+![The two main components of {{< var vm.product >}}: the {{< var validmind.developer >}} that integrates with your existing developer environment, and the {{< var validmind.platform >}}](/about/deployment/validmind-architecture-overview.png){fig-alt="An image showing the two main components of ValidMind: the ValidMind Library that integrates with your existing developer environment, and the ValidMind Platform"}
 
 The {{< var validmind.developer >}} consists of a client-side library, a {{< var vm.api >}} integration for models and testing, and validation tests that streamline the model development process. Implemented as a series of independent libraries in Python and R, our {{< var vm.developer >}} ensures compatibility and flexibility with diverse sets of developer environments and requirements.
 

--- a/site/developer/get-started-validmind-library.qmd
+++ b/site/developer/get-started-validmind-library.qmd
@@ -36,14 +36,15 @@ listing:
     - ../notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb
     - ../notebooks/code_samples/nlp_and_llm/prompt_validation_demo.ipynb
     - ../notebooks/code_samples/time_series/quickstart_time_series_full_suite.ipynb
-  - id: developer-workflow
+  - id: document-models
     type: grid
     grid-columns: 2
     max-description-length: 250
     sort: false
     fields: [title, description]
-    contents:
+    contents: 
     - model-documentation/documenting-models.qmd
+    - ../guide/model-documentation/working-with-model-documentation.qmd
 ---
 
 The {{< var validmind.developer >}} helps you streamline model documentation by automating the generation of drafts. All you need to do is upload your documentation artifacts and test results to the {{< var validmind.platform >}}.
@@ -89,32 +90,57 @@ After you [**sign up**]({{< var url.us1 >}}) for {{< var vm.product >}} to get a
 
 ## Learn how to run tests
 
+:::: {.flex .flex-wrap .justify-around}
+
+::: {.w-80-ns}
 The {{< var validmind.developer >}} provides many built-in tests and test suites which make it easy for developers to automate their model documentation. Start by running a pre-made test, then modify it, and finally create your own test: 
+
+:::
+
+::: {.w-20-ns .tc}
+[Run tests & test suites](model-testing/testing-overview.qmd){.button .button-green}
+
+:::
+
+::::
 
 :::{#developer-how-to-beginner}
 :::
 
-{{< fa hand-point-right >}} Learn more: [Run tests & test suites](model-testing/testing-overview.qmd)
-
 ## Try the code samples
 
+:::: {.flex .flex-wrap .justify-around}
+
+::: {.w-80-ns}
 Our code samples showcase the capabilities of the {{< var validmind.developer >}}. Examples that you can build on and adapt for your own use cases include:
+
+:::
+
+::: {.w-20-ns .tc}
+[Code samples](samples-jupyter-notebooks.qmd){.button .button-green}
+
+:::
+
+::::
 
 :::{#developer-code-samples}
 ::: 
 
-{{< fa hand-point-right >}} Try more: [Code samples](samples-jupyter-notebooks.qmd)
+## Document models
 
-## What's next
+:::: {.flex .flex-wrap .justify-around}
 
-After you have tried out the {{< var validmind.developer >}}, continue [working with your model documentation](/guide/model-documentation/working-with-model-documentation.qmd) in the {{< var validmind.platform >}} online. There, you can:
+::: {.w-80-ns}
+After you have tried out the {{< var validmind.developer >}}, continue working with your model documentation in the {{< var validmind.platform >}}:
 
-- Work with documentation templates to customize them to your specific needs
-- Work with model documentation in the {{< var vm.platform >}} to make edits, collaborate with validators, and submit your model documentation for approval
-- Export your finalized model documentation
-
-For more in-depth guides, check out our breakdown of your complete journey as a model developer with {{< var vm.product >}}: 
-
-:::{#developer-workflow}
 :::
 
+::: {.w-20-ns .tc}
+[Supported models](model-documentation/supported-models.qmd){.button .button-green}
+
+:::
+
+::::
+
+:::{#document-models}
+:::

--- a/site/developer/get-started-validmind-library.qmd
+++ b/site/developer/get-started-validmind-library.qmd
@@ -54,7 +54,7 @@ The {{< var validmind.developer >}} provides a rich collection of documentation 
  
 <!-- Using the variable in alt text messes up the image display  --> 
 
-![](/get-started/validmind-lifecycle.jpg){width=70% fig-alt="An image showing the two main components of ValidMind. The ValidMind Library that integrates with your existing developer environment, and the ValidMind Platform."}
+![The two main components of {{< var vm.product >}}: the {{< var validmind.developer >}} that integrates with your existing developer environment, and the {{< var validmind.platform >}}](/get-started/validmind-lifecycle.jpg){width=70% fig-alt="An image showing the two main components of ValidMind: the ValidMind Library that integrates with your existing developer environment, and the ValidMind Platform"}
 
 {{< var vm.product >}} offers two primary methods for automating model documentation:
 

--- a/site/developer/model-documentation/install-and-initialize-validmind-library.qmd
+++ b/site/developer/model-documentation/install-and-initialize-validmind-library.qmd
@@ -102,11 +102,11 @@ Version: 2.5.15
     %pip install --upgrade validmind
     ```
 
-::: {.column-margin}
+<!-- ::: {.column-margin}
 ::: {.callout title="Current version:"}
 {{< var version.validmind >}}
 :::
-:::
+::: -->
 
 
 <!-- FOOTNOTES -->

--- a/site/developer/model-documentation/supported-models.qmd
+++ b/site/developer/model-documentation/supported-models.qmd
@@ -3,6 +3,16 @@ title: "Supported models"
 date: last-modified
 aliases:
   - ../../guide/supported-models.html
+listing:
+  - id: next-models
+    type: grid
+    max-description-length: 250
+    sort: false
+    fields: [title, description]
+    contents:
+    - ../model-testing/testing-overview.qmd
+    - ../model-testing/test-descriptions.qmd
+    - ../samples-jupyter-notebooks.qmd
 ---
 
 The {{< var validmind.developer >}} provides out-of-the-box support for testing and documentation for an array of model types and modeling packages.
@@ -11,52 +21,100 @@ The {{< var validmind.developer >}} provides out-of-the-box support for testing 
 
 A _supported model_ refers to a model for which predefined testing or documentation functions exist in the {{< var validmind.developer >}}, provided that the model you are developing is documented using a supported version of our {{< var vm.developer >}}. These model types cover a very large portion of the models used in commercial and retail banking. 
 
-Given the rapid developments in the AI space, including the advent of large language models (LLMs), {{< var vm.product >}} product development has also focused on making sure that our {{< var vm.developer >}} is extensible to support future model types or modeling packages, so that we do not limit our users to specific model types. You always have the flexibility to:
-
-- [Implement custom tests](/notebooks/code_samples/custom_tests/implement_custom_tests.ipynb)
-- [Integrate external test providers](/notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb)
+::: {.callout}
+## {{< var vm.product >}} does not limit our users to specific model types.
+ 
+- The {{< var validmind.developer >}} is extensible to support future model types or modeling packages to accomodate rapid developments in the AI space, including the advent of large language models (LLMs).
+- You always have the flexibility to implement custom tests and integrate external test providers.[^1]
+:::
 
 <!--- Please note the inherent dependency on data types, such as tabular, time series, and text data types. This distinction isn't always immediately evident. For example: while binary classification is possible on text datasets, only the `tabular_dataset` suite is explicitly mentioned in our list of supported models.--->
 
-## Supported model types
+## Supported model types[^2]
 
 ### Traditional statistical models
 
-- Linear regression — Models relationship between a scalar response and one or more explanatory variables.
-- Logistic regression — Predicts the probability of a binary outcome based on one or more predictor variables.
-- Time series — Analyzes data points collected or sequenced over time.
+:::: {.flex .flex-wrap .justify-around}
+
+::: {.w-30-ns}
+::: {.feature}
+Linear regression
+: Models relationship between a scalar response and one or more explanatory variables.
+:::
+
+:::
+
+::: {.w-30-ns}
+::: {.feature}
+Logistic regression
+: Models relationship between a scalar response and one or more explanatory variables.
+:::
+
+:::
+
+::: {.w-30-ns}
+::: {.feature}
+Time series 
+: Analyzes data points collected or sequenced over time.
+:::
+
+:::
+
+::::
 
 ### Machine learning models
 
+:::: {.flex .flex-wrap .justify-around}
+
+::: {.w-50-ns .pr2}
+
+::: {.feature}
 Hugging Face-compatible models
 : - Natural language processing (NLP) text classification — Categorizes text into predefined classes.
 - Tabular classification — Assigns categories to tabular dataset entries.
 - Tabular regression — Predicts continuous outcomes from tabular data.
+:::
 
-Tree-based models (XGBoost / CatBoost / random forest)
-: - Classification — Predicts categorical outcomes using decision trees.
-- Regression — Predicts continuous outcomes using decision trees.
-
-K-nearest neighbors (KNN)
-: - Classification — Assigns class by majority vote of the k-nearest neighbors.
-- Regression — Predicts value based on the average of the k-nearest neighbors.
-
-Clustering
-: - K-means — Partitions _n_ observations into _k_ clusters in which each observation belongs to the cluster with the nearest mean.
-
+::: {.feature}
 Neural networks
 : - Long short-term memory (LSTM) — Processes sequences of data, remembering inputs over long periods.
 - Recurrent neural network (RNN) — Processes sequences by maintaining a state that reflects the history of processed elements.
 - Convolutional neural network (CNN) — Primarily used for processing grid-like data such as images.
 
+:::
+
+:::
+
+::: {.w-50-ns .pl2 .pr2}
+
+::: {.feature}
+Tree-based models (XGBoost / CatBoost / random forest)
+: - Classification — Predicts categorical outcomes using decision trees.
+- Regression — Predicts continuous outcomes using decision trees.
+:::
+
+::: {.feature}
+K-nearest neighbors (KNN)
+: - Classification — Assigns class by majority vote of the k-nearest neighbors.
+- Regression — Predicts value based on the average of the k-nearest neighbors.
+
+:::
+
+::: {.feature}
+Clustering
+: - K-means — Partitions _n_ observations into _k_ clusters in which each observation belongs to the cluster with the nearest mean.
+:::
+
+:::
+
+::::
+
 ### Generative AI models
 
+::: {.feature}
 Large language models (LLMs)
 : - Classification — Categorizes input into predefined classes.
 - Text summarization — Generates concise summaries from longer texts.
-
-:::{.callout}
-{{< var vm.product >}} offers support for both first-party models and [third-party vendor models](/about/glossary/glossary.qmd#vendor-model).
 :::
 
 ## Supported modeling libraries and other tools
@@ -65,26 +123,42 @@ Large language models (LLMs)
 
 ::: {.w-50-ns}
 
-- [scikit-learn](https://scikit-learn.org/stable/) — A Python library for machine learning, offering a range of supervised and unsupervised learning algorithms.
-- [statsmodels](https://www.statsmodels.org/stable/index.html) — A Python module that provides classes and functions for the estimation of many different statistical models, as well as for conducting statistical tests and exploring data.
-- [PyTorch](https://pytorch.org/) — An open-source machine learning library based on the Torch library, used for applications such as computer vision and natural language processing.
-- [Hugging Face Transformers](https://huggingface.co/docs/transformers/en/index) — Provides thousands of pre-trained models to perform tasks on texts such as classification, information extraction, question answering, summarization, translation, and text generation.
-- [XGBoost](https://xgboost.readthedocs.io/en/stable/) — An optimized distributed gradient boosting library designed to be highly efficient, flexible, and portable, implementing machine learning algorithms under the Gradient Boosting framework.
+- **[scikit-learn](https://scikit-learn.org/stable/)** — A Python library for machine learning, offering a range of supervised and unsupervised learning algorithms.
+
+- **[statsmodels](https://www.statsmodels.org/stable/index.html)** — A Python module that provides classes and functions for the estimation of many different statistical models, as well as for conducting statistical tests and exploring data.
+
+- **[PyTorch](https://pytorch.org/)** — An open-source machine learning library based on the Torch library, used for applications such as computer vision and natural language processing.
+
+- **[Hugging Face Transformers](https://huggingface.co/docs/transformers/en/index)** — Provides thousands of pre-trained models to perform tasks on texts such as classification, information extraction, question answering, summarization, translation, and text generation.
+
+- **[XGBoost](https://xgboost.readthedocs.io/en/stable/)** — An optimized distributed gradient boosting library designed to be highly efficient, flexible, and portable, implementing machine learning algorithms under the Gradient Boosting framework.
 
 :::
 
 ::: {.w-50-ns}
 
-- [CatBoost](https://catboost.ai/) — An open-source gradient boosting on decision trees library with categorical feature support out of the box, for ranking, classification, regression, and other ML tasks.
-- [LightGBM](https://lightgbm.readthedocs.io/en/stable/) — A fast, distributed, high-performance gradient boosting (GBDT, GBRT, GBM, or MART) framework based on decision tree algorithms, used for ranking, classification, and many other machine learning tasks.
-- R models, via [rpy2 - R in Python](https://rpy2.github.io/) — Facilitates the integration of R's statistical computing and graphics capabilities with Python, allowing for R models to be called from Python.
-- Large language models (LLMs), via [OpenAI-compatible APIs](https://platform.openai.com/docs/introduction) — Access to advanced AI models trained by OpenAI for a variety of natural language tasks, including text generation, translation, and analysis, through a compatible API interface. This support includes both the OpenAI API and the Azure OpenAI Service via API.
+- **[CatBoost](https://catboost.ai/)** — An open-source gradient boosting on decision trees library with categorical feature support out of the box, for ranking, classification, regression, and other ML tasks.
+
+- **[LightGBM](https://lightgbm.readthedocs.io/en/stable/)** — A fast, distributed, high-performance gradient boosting (GBDT, GBRT, GBM, or MART) framework based on decision tree algorithms, used for ranking, classification, and many other machine learning tasks.
+
+- **R models, via [rpy2 - R in Python](https://rpy2.github.io/)** — Facilitates the integration of R's statistical computing and graphics capabilities with Python, allowing for R models to be called from Python.
+
+- **Large language models (LLMs), via [OpenAI-compatible APIs](https://platform.openai.com/docs/introduction)** — Access to advanced AI models trained by OpenAI for a variety of natural language tasks, including text generation, translation, and analysis, through a compatible API interface. This support includes both the OpenAI API and the Azure OpenAI Service via API.
 :::
 
 ::::
 
 ## What's next
 
-- [Run tests & test suites](/developer/model-testing/testing-overview.qmd)
-- [Test descriptions](/developer/model-testing/test-descriptions.qmd)
-- [Code samples](/developer/samples-jupyter-notebooks.qmd)
+:::{#next-models}
+:::
+
+
+<!-- FOOTNOTES -->
+
+[^1]: 
+
+  - [Implement custom tests](/notebooks/code_samples/custom_tests/implement_custom_tests.ipynb)
+  - [Integrate external test providers](/notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb)
+
+[^2]: {{< var vm.product >}} offers support for both first-party models and [third-party vendor models](/about/glossary/glossary.qmd#vendor-model).

--- a/site/developer/model-documentation/supported-models.qmd
+++ b/site/developer/model-documentation/supported-models.qmd
@@ -88,7 +88,7 @@ Neural networks
 ::: {.w-50-ns .pl2 .pr2}
 
 ::: {.feature}
-Tree-based models (XGBoost / CatBoost / random forest)
+Tree-based models <br> (XGBoost / CatBoost / random forest)
 : - Classification — Predicts categorical outcomes using decision trees.
 - Regression — Predicts continuous outcomes using decision trees.
 :::

--- a/site/developer/model-documentation/supported-models.qmd
+++ b/site/developer/model-documentation/supported-models.qmd
@@ -30,33 +30,38 @@ A _supported model_ refers to a model for which predefined testing or documentat
 
 <!--- Please note the inherent dependency on data types, such as tabular, time series, and text data types. This distinction isn't always immediately evident. For example: while binary classification is possible on text datasets, only the `tabular_dataset` suite is explicitly mentioned in our list of supported models.--->
 
-## Supported model types[^2]
+## Supported model types
+
+::: {.column-margin}
+::: {.feature}
+Vendor models
+: {{< var vm.product >}} offers support for both first-party models and [third-party vendor models](/about/glossary/glossary.qmd#vendor-model).
+
+:::
+
+:::
 
 ### Traditional statistical models
 
 :::: {.flex .flex-wrap .justify-around}
 
 ::: {.w-30-ns}
-::: {.feature}
+
 Linear regression
 : Models relationship between a scalar response and one or more explanatory variables.
-:::
 
 :::
 
 ::: {.w-30-ns}
-::: {.feature}
+
 Logistic regression
 : Models relationship between a scalar response and one or more explanatory variables.
-:::
 
 :::
 
 ::: {.w-30-ns}
-::: {.feature}
 Time series 
 : Analyzes data points collected or sequenced over time.
-:::
 
 :::
 
@@ -67,43 +72,32 @@ Time series
 :::: {.flex .flex-wrap .justify-around}
 
 ::: {.w-50-ns .pr2}
-
-::: {.feature}
 Hugging Face-compatible models
 : - Natural language processing (NLP) text classification — Categorizes text into predefined classes.
 - Tabular classification — Assigns categories to tabular dataset entries.
 - Tabular regression — Predicts continuous outcomes from tabular data.
-:::
 
-::: {.feature}
 Neural networks
 : - Long short-term memory (LSTM) — Processes sequences of data, remembering inputs over long periods.
 - Recurrent neural network (RNN) — Processes sequences by maintaining a state that reflects the history of processed elements.
 - Convolutional neural network (CNN) — Primarily used for processing grid-like data such as images.
 
-:::
 
 :::
 
 ::: {.w-50-ns .pl2 .pr2}
 
-::: {.feature}
 Tree-based models <br> (XGBoost / CatBoost / random forest)
 : - Classification — Predicts categorical outcomes using decision trees.
 - Regression — Predicts continuous outcomes using decision trees.
-:::
 
-::: {.feature}
 K-nearest neighbors (KNN)
 : - Classification — Assigns class by majority vote of the k-nearest neighbors.
 - Regression — Predicts value based on the average of the k-nearest neighbors.
 
-:::
-
-::: {.feature}
 Clustering
 : - K-means — Partitions _n_ observations into _k_ clusters in which each observation belongs to the cluster with the nearest mean.
-:::
+
 
 :::
 
@@ -111,11 +105,9 @@ Clustering
 
 ### Generative AI models
 
-::: {.feature}
 Large language models (LLMs)
 : - Classification — Categorizes input into predefined classes.
 - Text summarization — Generates concise summaries from longer texts.
-:::
 
 ## Supported modeling libraries and other tools
 
@@ -160,5 +152,3 @@ Large language models (LLMs)
 
   - [Implement custom tests](/notebooks/code_samples/custom_tests/implement_custom_tests.ipynb)
   - [Integrate external test providers](/notebooks/code_samples/custom_tests/integrate_external_test_providers.ipynb)
-
-[^2]: {{< var vm.product >}} offers support for both first-party models and [third-party vendor models](/about/glossary/glossary.qmd#vendor-model).

--- a/site/developer/model-documentation/supported-models.qmd
+++ b/site/developer/model-documentation/supported-models.qmd
@@ -47,21 +47,21 @@ Vendor models
 
 ::: {.w-30-ns}
 
-Linear regression
-: Models relationship between a scalar response and one or more explanatory variables.
+#### Linear regression
+Models relationship between a scalar response and one or more explanatory variables.
 
 :::
 
 ::: {.w-30-ns}
 
-Logistic regression
-: Models relationship between a scalar response and one or more explanatory variables.
+#### Logistic regression
+Models relationship between a scalar response and one or more explanatory variables.
 
 :::
 
 ::: {.w-30-ns}
-Time series 
-: Analyzes data points collected or sequenced over time.
+#### Time series 
+Analyzes data points collected or sequenced over time.
 
 :::
 
@@ -72,13 +72,13 @@ Time series
 :::: {.flex .flex-wrap .justify-around}
 
 ::: {.w-50-ns .pr2}
-Hugging Face-compatible models
-: - Natural language processing (NLP) text classification — Categorizes text into predefined classes.
+#### Hugging Face-compatible models
+- Natural language processing (NLP) text classification — Categorizes text into predefined classes.
 - Tabular classification — Assigns categories to tabular dataset entries.
 - Tabular regression — Predicts continuous outcomes from tabular data.
 
-Neural networks
-: - Long short-term memory (LSTM) — Processes sequences of data, remembering inputs over long periods.
+#### Neural networks
+- Long short-term memory (LSTM) — Processes sequences of data, remembering inputs over long periods.
 - Recurrent neural network (RNN) — Processes sequences by maintaining a state that reflects the history of processed elements.
 - Convolutional neural network (CNN) — Primarily used for processing grid-like data such as images.
 
@@ -87,16 +87,16 @@ Neural networks
 
 ::: {.w-50-ns .pl2 .pr2}
 
-Tree-based models <br> (XGBoost / CatBoost / random forest)
-: - Classification — Predicts categorical outcomes using decision trees.
+#### Tree-based models <br> (XGBoost / CatBoost / random forest)
+- Classification — Predicts categorical outcomes using decision trees.
 - Regression — Predicts continuous outcomes using decision trees.
 
-K-nearest neighbors (KNN)
-: - Classification — Assigns class by majority vote of the k-nearest neighbors.
+#### K-nearest neighbors (KNN)
+- Classification — Assigns class by majority vote of the k-nearest neighbors.
 - Regression — Predicts value based on the average of the k-nearest neighbors.
 
-Clustering
-: - K-means — Partitions _n_ observations into _k_ clusters in which each observation belongs to the cluster with the nearest mean.
+#### Clustering
+- K-means — Partitions _n_ observations into _k_ clusters in which each observation belongs to the cluster with the nearest mean.
 
 
 :::
@@ -105,8 +105,8 @@ Clustering
 
 ### Generative AI models
 
-Large language models (LLMs)
-: - Classification — Categorizes input into predefined classes.
+#### Large language models (LLMs)
+- Classification — Categorizes input into predefined classes.
 - Text summarization — Generates concise summaries from longer texts.
 
 ## Supported modeling libraries and other tools

--- a/site/developer/model-testing/test-descriptions.qmd
+++ b/site/developer/model-testing/test-descriptions.qmd
@@ -33,7 +33,7 @@ listing:
 Tests that are available as part of the {{< var validmind.developer >}}, grouped by type of validation or monitoring test.
 
 ::: {.callout}
-## {{< fa flask >}} [Try the test sandbox (BETA)](test-sandbox.qmd)
+## {{< fa flask >}} [Try the test sandbox <sup>[beta]{.smallcaps}</sup>](test-sandbox.qmd)
 
 Explore our interactive sandbox to see what tests are available in the {{< var validmind.developer >}}.
 :::

--- a/site/developer/model-testing/test-descriptions.qmd
+++ b/site/developer/model-testing/test-descriptions.qmd
@@ -30,7 +30,7 @@ listing:
     fields: [title, description]  
 ---
 
-This topic describes the tests that are available as part of the {{< var validmind.developer >}}, grouped by type of validation or monitoring test.
+Tests that are available as part of the {{< var validmind.developer >}}, grouped by type of validation or monitoring test.
 
 ::: {.callout}
 ## {{< fa flask >}} [Try the test sandbox (BETA)](test-sandbox.qmd)

--- a/site/developer/model-testing/test-sandbox.qmd
+++ b/site/developer/model-testing/test-sandbox.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Test sandbox (BETA)"
+title: "Test sandbox <sup>[beta]{.smallcaps}</sup>"
 date: last-modified
 aliases:
   - ../../guide/test-sandbox.html

--- a/site/developer/model-testing/testing-overview.qmd
+++ b/site/developer/model-testing/testing-overview.qmd
@@ -147,4 +147,4 @@ Absolutely! {{< var vm.product >}} supports custom tests that you develop yourse
 
 ## Reference
 
-<a href="https://docs.validmind.ai/validmind/validmind.html" target="_blank">{{< var validmind.developer >}} Reference</a> 
+[{{< var validmind.developer >}} Reference](https://docs.validmind.ai/validmind/validmind.html){target="_blank" .button .button-green}

--- a/site/developer/model-testing/testing-overview.qmd
+++ b/site/developer/model-testing/testing-overview.qmd
@@ -145,6 +145,6 @@ Absolutely! {{< var vm.product >}} supports custom tests that you develop yourse
 :::{#tests-custom}
 :::
 
-## Reference
+## {{< var validmind.api >}} reference
 
 [{{< var validmind.developer >}} Reference](https://docs.validmind.ai/validmind/validmind.html){target="_blank" .button .button-green}

--- a/site/developer/samples-jupyter-notebooks.qmd
+++ b/site/developer/samples-jupyter-notebooks.qmd
@@ -15,25 +15,25 @@ aliases:
   - ../guide/samples-jupyter-notebooks.html
 ---
 
-Our code samples, based on Jupyter Notebooks, showcase the capabilities and features of the {{< var validmind.developer >}}, while also providing you with useful examples that you can build on and adapt for your own use cases. 
+Our Jupyter Notebook code samples showcase the capabilities and features of the {{< var validmind.developer >}}, while also providing you with useful examples that you can build on and adapt for your own use cases. 
 
 :::: {.flex .flex-wrap .justify-around}
 
 ::: {.w-30-ns .mt2 .pb3}
 
-[{{< fa code >}} Try Notebooks on JupyterHub](https://jupyterhub.validmind.ai/){.button target="_blank"}
+[{{< fa code >}} Try Notebooks on JupyterHub](https://jupyterhub.validmind.ai/){.button .button-green target="_blank"}
 
 :::
 
 ::: {.w-30-ns .mt2 .pb3}
 
-[{{< fa download >}} Download Notebooks & Datasets](/notebooks.zip){.button target="_blank"}
+[{{< fa download >}} Download Notebooks & Datasets](/notebooks.zip){.button .button-green target="_blank"}
 
 :::
 
 ::: {.w-30-ns .mt2 .pb3}
 
-[{{< fa brands github >}} Access Notebooks on GitHub](https://github.com/validmind/validmind-library){.button target="_blank"}
+[{{< fa brands github >}} Access Notebooks on GitHub](https://github.com/validmind/validmind-library){.button .button-green target="_blank"}
 
 :::
 
@@ -49,18 +49,24 @@ Learn how to use dataset and model documentation function on a simple customer c
 ::: {.w-50-ns}
 
 JupyterHub
-: A a web-based platform when you can interact with Jupyter Notebook instances on a shared server. It is commonly used as a collaborative and interactive computing environment for data analysis, scientific research, and programming.<br>
+: A a web-based platform when you can interact with Jupyter Notebook instances on a shared server. It is commonly used as a collaborative and interactive computing environment for data analysis, scientific research, and programming.
 
-[![{{< fa code >}} Try it on JupyterHub:](jupyter-hub-logo.svg){width=120px fig-alt="JupyterHub logo"}](https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/quickstart_customer_churn_full_suite.ipynb)
+::: {.tc}
+[{{< fa code >}} Quickstart on JupyterHub](https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/quickstart_customer_churn_full_suite.ipynb){.button target="_blank"}
+
+:::
 
 :::
 
 ::: {.w-40-ns}
 
 Google Colaboratory (Colab)
-: A free Jupyter Notebook environment that runs in the cloud. There, you can work with our Jupyter Notebooks by saving your own copy, write and execute code, share your work to collaborate with others in real-time.<br>
+: A free Jupyter Notebook environment that runs in the cloud. There, you can work with our Jupyter Notebooks by saving your own copy, write and execute code, share your work to collaborate with others in real-time.
 
-[![{{< fa code >}} Try it on Colab:](https://colab.research.google.com/assets/colab-badge.svg){fig-alt="Google Colaboratory logo"}](https://colab.research.google.com/drive/1NLtjCFUZV2I_ttGUkiAL9uwGZK_SGUlw?usp=share_link)
+::: {.tc}
+[{{< fa brands google >}} Quickstart on Colab](https://colab.research.google.com/drive/1NLtjCFUZV2I_ttGUkiAL9uwGZK_SGUlw?usp=share_link){.button target="_blank"}
+
+:::
 
 :::
 

--- a/site/get-started/get-started.qmd
+++ b/site/get-started/get-started.qmd
@@ -51,7 +51,7 @@ The {{< var validmind.product >}} provides two main product components:
    
 For more information about the benefits that {{< var vm.product >}} can offer, **check out the [{{< var vm.product >}} overview](/about/overview.qmd).**
 
-::: {.callout-important collapse="false" appearance="minimal"}
+::: {.callout-important collapse="true" appearance="minimal"}
 ## {{< fa building-columns >}} Key {{< var vm.product >}} concepts
 
 {{< include /about/glossary/key_concepts/_key-concepts.qmd >}}

--- a/site/releases/2024-jun-10/release-notes.qmd
+++ b/site/releases/2024-jun-10/release-notes.qmd
@@ -20,7 +20,7 @@ Within the {{< var validmind.platform >}}, you can now edit the names of your bu
 
 ::: {.w-30-ns}
 
-[Manage business units](/guide/configuration/set-up-your-organization.qmd#manage-business-units){.button}
+[Manage business units](/guide/configuration/set-up-your-organization.qmd#manage-business-units){.button .button-green}
 
 :::
 


### PR DESCRIPTION
## Internal Notes for Reviewers

> sc-6526

### Documentation drop-down icon

Realised I used the same icon for "Guides" and "About" when I fixed this, so:

| Old | New |
|---|---|
|<img width="275" alt="Screenshot 2024-12-16 at 12 59 58 PM" src="https://github.com/user-attachments/assets/ca918c71-c620-48de-982b-287c950e885b" />|<img width="288" alt="Screenshot 2024-12-16 at 1 11 26 PM" src="https://github.com/user-attachments/assets/59075c76-3156-40bb-94f9-88ad933d8a60" /> |

### ValidMind Library portal

[**LIVE PREVIEW**](https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-6526/docs-audit-p3-developer-framework/developer/get-started-validmind-library.html)

Just some quick visual cleanup, made sure any images had alt-text & captions, etc. as we are likely going to make more notable edits when we restructure our docs. 

#### Get started with the ValidMind Library

| Old | New |
|---|---|
|<img width="1187" alt="Screenshot 2024-12-16 at 12 58 49 PM" src="https://github.com/user-attachments/assets/e1586f92-48e6-4576-880d-2c803d4e1e10" /> | <img width="1187" alt="Screenshot 2024-12-16 at 1 11 49 PM" src="https://github.com/user-attachments/assets/d3f523f8-2c34-4775-bd16-3eb3978600a1" />|
|<img width="893" alt="Screenshot 2024-12-16 at 12 59 10 PM" src="https://github.com/user-attachments/assets/d28ed404-5ce0-493e-971c-12bcbde657e7" /> | <img width="966" alt="Screenshot 2024-12-16 at 1 12 00 PM" src="https://github.com/user-attachments/assets/e910d528-2419-43f0-bf13-cf511aed79bf" />|

#### Supported models

| Old | New |
|---|---|
|<img width="1188" alt="Screenshot 2024-12-16 at 12 59 24 PM" src="https://github.com/user-attachments/assets/eadef95c-7ffb-4878-aa4b-16d6ae6e2784" /> | <img width="1285" alt="Screenshot 2024-12-16 at 1 12 51 PM" src="https://github.com/user-attachments/assets/6af98902-8130-42f3-b4fa-78edfea08104" />|
|<img width="1071" alt="Screenshot 2024-12-16 at 12 59 39 PM" src="https://github.com/user-attachments/assets/a8fa6690-5a6c-422c-84d6-ea760bc37620" /> | <img width="1009" alt="Screenshot 2024-12-16 at 1 13 04 PM" src="https://github.com/user-attachments/assets/6158859a-d03e-4ec2-9493-79a505599bdf" />|
| <img width="1074" alt="Screenshot 2024-12-16 at 12 59 45 PM" src="https://github.com/user-attachments/assets/28457161-0b78-414a-97e3-419e51682689" />|<img width="745" alt="Screenshot 2024-12-16 at 1 13 11 PM" src="https://github.com/user-attachments/assets/e5a215ef-a791-4028-9cd4-3cf6f485e101" /> | 

#### Run tests & test suites

| Old | New |
|---|---|
|<img width="1047" alt="Screenshot 2024-12-16 at 1 04 32 PM" src="https://github.com/user-attachments/assets/9864c280-e521-4567-a4ad-3efe770e389d" /> | <img width="1201" alt="Screenshot 2024-12-16 at 1 13 58 PM" src="https://github.com/user-attachments/assets/b06aa0a7-8f0b-4fd6-9a63-d8f824e550dd" />|

#### Test descriptions

| Old | New |
|---|---|
|<img width="1270" alt="Screenshot 2024-12-16 at 1 04 56 PM" src="https://github.com/user-attachments/assets/2c2d23f1-21a6-4dce-9798-0a639056fc2f" /> | <img width="1415" alt="Screenshot 2024-12-16 at 1 14 06 PM" src="https://github.com/user-attachments/assets/2a735233-a818-40d1-b0d2-1032a8b69c17" />|

#### Test sandbox

| Old | New |
|---|---|
| <img width="981" alt="Screenshot 2024-12-16 at 1 05 12 PM" src="https://github.com/user-attachments/assets/093b2eb1-2b11-4677-94cb-43c00f2310c4" />| <img width="1114" alt="Screenshot 2024-12-16 at 1 14 13 PM" src="https://github.com/user-attachments/assets/09745eb6-3d25-4ca0-86ae-6d366a9d3bd7" />|

#### Code samples

| Old | New |
|---|---|
|<img width="1062" alt="Screenshot 2024-12-16 at 1 02 19 PM" src="https://github.com/user-attachments/assets/e2284a5a-6b35-4be5-928d-18322d659395" /> | <img width="1168" alt="Screenshot 2024-12-16 at 1 15 30 PM" src="https://github.com/user-attachments/assets/e6eb0580-3a85-4cee-9d2f-4d40e94a02ff" />|

##### Code samples: QuickStart for Customer Churn Model Documentation — Full Suite

For some reason the old image links to JupyterHub & Colab don't actually work... you can't click on them, oops. I just changed them to our buttons to simplify the experience (and solve the links not working in one fell swoop).