### PR TITLE
Add Docker image for our docs site

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM nginx:alpine
 # Copy the static site content to the Nginx HTML directory
 COPY site/_site /usr/share/nginx/html
 
-# Expose port 80
+# Expose port 4444
 EXPOSE 4444
 
 # Nginx starts automatically as the default CMD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Dockerfile to build the validmind-docs image
+
+# Use the official Nginx image
+FROM nginx:alpine
+
+# Copy the static site content to the Nginx HTML directory
+COPY site/_site /usr/share/nginx/html
+
+# Expose port 80
+EXPOSE 4444
+
+# Nginx starts automatically as the default CMD

--- a/README.md
+++ b/README.md
@@ -137,25 +137,32 @@ After you pull in the changes, commit them to this repo as part of the release n
 
 <!-- Testing conditional changes on site/notebooks/  -->
 
-## Build a Docker image  
+## Build and serve the site with Docker
 
-You can build and serve the static HTML site using Docker for deployment as part of our product or to test locally in a consistent environment.
+You can build and serve the static HTML docs site using Docker — for deployment as part of our product or for testing in a consistent local environment.
 
 ### Prerequisites  
 
 - [Docker](https://docs.docker.com/get-docker/)
 
-### Build and serve the site  
-
+### Build the site  
 
 ```bash
 cd site
-make docker-image
+make docker-build
 ```
 
-This command:  
-1. Renders the static site in `site/_site`.  
-2. Builds a Docker image using the `Dockerfile`.  
-3. Serves the site on port **4444**.
+This command:
+
+1. Gets all the source files.
+2. Renders the static site in `site/_site`.  
+3. Builds a Docker image using the `Dockerfile`.  
+
+### Serve the site  
+
+```bash
+cd site
+make docker-serve
+```
 
 Access the site locally: http://localhost:4444  

--- a/README.md
+++ b/README.md
@@ -136,3 +136,26 @@ After you pull in the changes, commit them to this repo as part of the release n
 <!-- September 16, 2024: Need to mention rendered Python `.html` docs and generated `.md` test descriptions -->
 
 <!-- Testing conditional changes on site/notebooks/  -->
+
+## Build a Docker image  
+
+You can build and serve the static HTML site using Docker for deployment as part of our product or to test locally in a consistent environment.
+
+### Prerequisites  
+
+- [Docker](https://docs.docker.com/get-docker/)
+
+### Build and serve the site  
+
+
+```bash
+cd site
+make docker-image
+```
+
+This command:  
+1. Renders the static site in `site/_site`.  
+2. Builds a Docker image using the `Dockerfile`.  
+3. Serves the site on port **4444**.
+
+Access the site locally: http://localhost:4444  

--- a/site/Makefile
+++ b/site/Makefile
@@ -8,7 +8,7 @@ PROFILE := exe-demo
 FILE_PATH := notebooks/tutorials/intro_for_model_developers_EXECUTED.ipynb 
 
 # Define .PHONY target for help section
-.PHONY: help clean clone notebooks python-docs docs-site deploy-demo deploy-demo-branch delete-demo-branch deploy-prod deploy-staging release-notes execute docker-image
+.PHONY: help clean clone notebooks python-docs docs-site deploy-demo deploy-demo-branch delete-demo-branch deploy-prod deploy-staging release-notes execute docker-build docker-serve
 
 # Help section
 help:
@@ -27,7 +27,8 @@ help:
 	@echo "  help                 Display this help message (default target)"
 	@echo "  release-notes        Generate release notes from pull requests since latest tag and update _quarto.yml"
 	@echo "  execute              Execute a Jupyter Notebook (must have valid .env credentials set up in root)"
-	@echo "  docker-image         Builds a Docker image of site/_site"
+	@echo "  docker-build         Builds a Docker image of the docs site"
+	@echo "  docker-serve         Serves the docs site at http://localhost:4444/"
 
 # Clean up source directory
 clean:
@@ -134,8 +135,10 @@ release-notes:
 execute:
 	quarto render --profile $(PROFILE) $(FILE_PATH)
 
-docker-image: docs-site
+docker-build: docs-site
 	@echo "\nBuilding the Docker image ..."
 	@docker build -f ../Dockerfile -t validmind-docs ..
+
+docker-serve:
 	@echo "\nStarting the Docker container on http://localhost:4444/ ..."
-	@docker run -p 4444:80 validmind-docs && echo "Access the docs site at: http://localhost:4444/"
+	@docker run -p 4444:80 validmind-docs

--- a/site/Makefile
+++ b/site/Makefile
@@ -108,7 +108,7 @@ delete-demo-branch:
 
 # Deployment to https://docs.validmind.ai/
 deploy-prod:
-	@if [ "`git rev-parse --abbrev-ref HEAD`" != "prod" ]; then \runn
+	@if [ "`git rev-parse --abbrev-ref HEAD`" != "prod" ]; then \
 		echo "You're not on the prod branch, no action taken."; \
 	else \
 		echo "\nDeploying prod site ..."; \

--- a/site/Makefile
+++ b/site/Makefile
@@ -8,7 +8,7 @@ PROFILE := exe-demo
 FILE_PATH := notebooks/tutorials/intro_for_model_developers_EXECUTED.ipynb 
 
 # Define .PHONY target for help section
-.PHONY: help clean clone notebooks python-docs docs-site deploy-demo deploy-demo-branch delete-demo-branch deploy-prod deploy-staging release-notes execute
+.PHONY: help clean clone notebooks python-docs docs-site deploy-demo deploy-demo-branch delete-demo-branch deploy-prod deploy-staging release-notes execute docker-image
 
 # Help section
 help:
@@ -27,6 +27,7 @@ help:
 	@echo "  help                 Display this help message (default target)"
 	@echo "  release-notes        Generate release notes from pull requests since latest tag and update _quarto.yml"
 	@echo "  execute              Execute a Jupyter Notebook (must have valid .env credentials set up in root)"
+	@echo "  docker-image         Builds a Docker image of site/_site"
 
 # Clean up source directory
 clean:
@@ -82,8 +83,9 @@ test-descriptions:
 get-source: clean clone notebooks python-docs test-descriptions
 
 # Get all source files
-docs-site: clean clone notebooks python-docs test-descriptions
-	quarto render --profile development
+docs-site: get-source
+	@echo "\nRendering the static HTML site ..."
+	quarto render --profile production
 
 # Deployment to https://docs-demo.vm.validmind.ai/
 deploy-demo:
@@ -106,7 +108,7 @@ delete-demo-branch:
 
 # Deployment to https://docs.validmind.ai/
 deploy-prod:
-	@if [ "`git rev-parse --abbrev-ref HEAD`" != "prod" ]; then \
+	@if [ "`git rev-parse --abbrev-ref HEAD`" != "prod" ]; then \runn
 		echo "You're not on the prod branch, no action taken."; \
 	else \
 		echo "\nDeploying prod site ..."; \
@@ -131,3 +133,9 @@ release-notes:
 # To override: make execute PROFILE=select-profile FILE_PATH=notebooks/notebook-path-here.ipynb
 execute:
 	quarto render --profile $(PROFILE) $(FILE_PATH)
+
+docker-image: docs-site
+	@echo "\nBuilding the Docker image ..."
+	@docker build -f ../Dockerfile -t validmind-docs ..
+	@echo "\nStarting the Docker container on http://localhost:4444/ ..."
+	@docker run -p 4444:80 validmind-docs && echo "Access the docs site at: http://localhost:4444/"


### PR DESCRIPTION
## Internal Notes for Reviewers

For self-hosted installations, we agreed to create a Docker image that can be shipped with the rest of the product. This PR adds:

- `Dockerfile` — Uses the rendered site output in `site/_site` and turns it into a Docker image that can be served on port 4444
- `make docker-image`— Renders the docs site, builds the image, and serves it locally for testing
- `README.md` — Explains the above

I also updated the mostly unused `docs-site` action to use our production profile. We don't use this action as part of our workflow generally, so it should be fine to repurpose for the Docker image. 

## Proof it works

Relevant bits from `make docker-image`:

```
Building the Docker image ...
[+] Building 2.9s (7/7) FINISHED                                                                                                                                           
 => [internal] load build definition from Dockerfile                                                                                                                  0.0s
 => => transferring dockerfile: 37B                                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                     0.0s
 => => transferring context: 2B                                                                                                                                       0.0s
 => [internal] load metadata for docker.io/library/nginx:alpine                                                                                                       1.0s
 => [internal] load build context                                                                                                                                     0.5s
 => => transferring context: 62.39MB                                                                                                                                  0.5s
 => CACHED [1/2] FROM docker.io/library/nginx:alpine@sha256:41523187cf7d7a2f2677a80609d9caa14388bf5c1fbca9c410ba3de602aaaab4                                          0.0s
 => [2/2] COPY site/_site /usr/share/nginx/html                                                                                                                       0.9s
 => exporting to image                                                                                                                                                0.4s
 => => exporting layers                                                                                                                                               0.4s
 => => writing image sha256:c4f5c2232248f2ad3fd53b528f36f3a34ebaddbbeadd04147b996ae4a6815a57                                                                          0.0s
 => => naming to docker.io/library/validmind-docs                                                                                                                     0.0s

Use 'docker scan' to run Snyk tests against images to find vulnerabilities and learn how to fix them

Starting the Docker container on http://localhost:4444/ ...
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
/docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
2024/12/17 19:09:02 [notice] 1#1: using the "epoll" event method
2024/12/17 19:09:02 [notice] 1#1: nginx/1.27.3
2024/12/17 19:09:02 [notice] 1#1: built by gcc 13.2.1 20240309 (Alpine 13.2.1_git20240309) 
2024/12/17 19:09:02 [notice] 1#1: OS: Linux 5.15.49-linuxkit
2024/12/17 19:09:02 [notice] 1#1: getrlimit(RLIMIT_NOFILE): 1048576:1048576
2024/12/17 19:09:02 [notice] 1#1: start worker processes
2024/12/17 19:09:02 [notice] 1#1: start worker process 30
2024/12/17 19:09:02 [notice] 1#1: start worker process 31
2024/12/17 19:09:02 [notice] 1#1: start worker process 32
2024/12/17 19:09:02 [notice] 1#1: start worker process 33
2024/12/17 19:09:02 [notice] 1#1: start worker process 34
172.17.0.1 - - [17/Dec/2024:19:22:21 +0000] "GET / HTTP/1.1" 200 61628 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36" "-"
172.17.0.1 - - [17/Dec/2024:19:22:21 +0000] "GET /site_libs/quarto-contrib/fontawesome6-0.1.0/all.css HTTP/1.1" 200 137826 "http://localhost:4444/" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36" "-"
...
```

What Docker shows:

![image](https://github.com/user-attachments/assets/f9dce5d9-0ca4-49dc-a85e-96a333762dbc)

And finally, accessing the site locally:

![image](https://github.com/user-attachments/assets/166ed415-2085-479d-8c67-b33e08a2ecd9)

We use port 4444 since this is a Quarto site and this is what I already use locally. 

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->