### PR TITLE
Docs — Customize model overview page

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -264,6 +264,7 @@ website:
           - guide/model-inventory/register-models-in-inventory.qmd
           - guide/model-inventory/customize-model-inventory-layout.qmd
           - guide/model-inventory/edit-model-inventory-fields.qmd
+          - guide/model-inventory/customize-model-overview-page.qmd
         - file: guide/model-inventory/managing-model-inventory.qmd
           contents:
           - guide/model-inventory/configure-model-interdependencies.qmd

--- a/site/guide/model-inventory/customize-model-inventory-layout.qmd
+++ b/site/guide/model-inventory/customize-model-inventory-layout.qmd
@@ -81,8 +81,8 @@ Deletion of saved views is permanent.
 
 ## What's next
 
-- [Register models in the inventory](register-models-in-inventory.qmd)
 - [Manage model inventory fields](manage-model-inventory-fields.qmd)
+- [Customize model overview page](customize-model-overview-page.qmd)
 
 
 <!-- FOOTNOTES -->

--- a/site/guide/model-inventory/customize-model-overview-page.qmd
+++ b/site/guide/model-inventory/customize-model-overview-page.qmd
@@ -22,7 +22,7 @@ Customizations will apply to all models in your inventory.
 ## Show or hide fields
 
 ::: {.callout title="Only custom inventory fields can be shown or hidden."}
-Default fields will always appear on your model overview pages.
+Default fields will always appear on your model overview pages and are represented by by faded cells. Their positions cannot be adjusted.
 :::
 
 1. In the left sidebar, click **{{< fa cubes >}} Inventory**. 
@@ -34,7 +34,7 @@ Default fields will always appear on your model overview pages.
 4. On the Customize Section Layout modal that appears, configure the model inventory fields[^3] that will appear: 
 
    - Toggle optional model inventory fields on or off to show or hide them from view.
-   - Click and hold a field to drag-and-drop to rearrange the order of fields. 
+   - Click and hold a field to drag-and-drop to rearrange the order of fields. Fields can be moved from the Side Column to the Main Column and vice versa.[^4]
 
    To narrow down your list of fields, search via the **{{< fa filter >}} Filter** bar.
 
@@ -53,3 +53,5 @@ Default fields will always appear on your model overview pages.
 [^2]: [Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)
 
 [^3]: [Manage model inventory fields](manage-model-inventory-fields.qmd#inventory-field-types)
+
+[^4]: `Attachments` or `Long Text` type fields can only be placed in the Main Column.

--- a/site/guide/model-inventory/customize-model-overview-page.qmd
+++ b/site/guide/model-inventory/customize-model-overview-page.qmd
@@ -1,0 +1,32 @@
+---
+title: "Customize model overview page"
+date: last-modified
+---
+
+Configure what and how model inventory fields appear when you pull up a model's details in the inventory. 
+
+:::{.callout}
+Changes are automatically saved to your account and do not affect other users.
+:::
+
+::: {.attn}
+
+## Prerequisites
+
+- [x] {{< var link.login >}}
+- [x] There are models registered in the model inventory.[^1]
+
+:::
+
+## Show or hide fields
+
+
+## What's next
+
+- [Edit model inventory fields](edit-model-inventory-fields.qmd)
+- [Manage model inventory fields](manage-model-inventory-fields.qmd)
+
+
+<!-- FOOTNOTES -->
+
+[^1]: [Register models in the inventory](register-models-in-inventory.qmd)

--- a/site/guide/model-inventory/customize-model-overview-page.qmd
+++ b/site/guide/model-inventory/customize-model-overview-page.qmd
@@ -5,8 +5,9 @@ date: last-modified
 
 Configure what and how model inventory fields appear when you pull up a model's details in the inventory. 
 
-:::{.callout}
-Changes are automatically saved to your account and do not affect other users.
+:::{.callout title="Changes are automatically saved to your account and do not affect other users."}
+Customizations will apply to all models in your inventory.
+
 :::
 
 ::: {.attn}
@@ -20,6 +21,24 @@ Changes are automatically saved to your account and do not affect other users.
 
 ## Show or hide fields
 
+::: {.callout title="Only custom inventory fields can be shown or hidden."}
+Default fields will always appear on your model overview pages.
+:::
+
+1. In the left sidebar, click **{{< fa cubes >}} Inventory**. 
+
+2. Select a model or find your model by applying a filter or searching for it.[^2]
+
+3. Click on **{{< fa table-cells-large >}} Customize Layout**.
+
+4. On the Customize Section Layout modal that appears, configure the model inventory fields[^3] that will appear: 
+
+   - Toggle optional model inventory fields on or off to show or hide them from view.
+   - Click and hold a field to drag-and-drop to rearrange the order of fields. 
+
+   To narrow down your list of fields, search via the **{{< fa filter >}} Filter** bar.
+
+5. Click **Save Layout** to apply your changes to all model overview pages.
 
 ## What's next
 
@@ -30,3 +49,7 @@ Changes are automatically saved to your account and do not affect other users.
 <!-- FOOTNOTES -->
 
 [^1]: [Register models in the inventory](register-models-in-inventory.qmd)
+
+[^2]: [Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)
+
+[^3]: [Manage model inventory fields](manage-model-inventory-fields.qmd#inventory-field-types)

--- a/site/guide/model-inventory/edit-model-inventory-fields.qmd
+++ b/site/guide/model-inventory/edit-model-inventory-fields.qmd
@@ -48,8 +48,8 @@ To work with attachments on models, first add an attachment inventory field.[^4]
 
 ## What's next
 
-- [Register models in the inventory](register-models-in-inventory.qmd)
 - [Manage model inventory fields](manage-model-inventory-fields.qmd)
+- [Customize model overview page](customize-model-overview-page.qmd)
 
 
 <!-- FOOTNOTES -->

--- a/site/guide/model-inventory/register-models-in-inventory.qmd
+++ b/site/guide/model-inventory/register-models-in-inventory.qmd
@@ -61,8 +61,8 @@ If additional fields are required on model registration for your organization:
 
 ## What's next
 
-* [Edit model inventory fields](edit-model-inventory-fields.qmd)
-* [Generate documentation for your model](/get-started/platform/generate-documentation-for-your-model.qmd)
+- [Edit model inventory fields](edit-model-inventory-fields.qmd)
+- [Generate documentation for your model](/get-started/platform/generate-documentation-for-your-model.qmd)
 
 
 <!-- FOOTNOTES -->

--- a/site/guide/model-inventory/working-with-model-inventory.qmd
+++ b/site/guide/model-inventory/working-with-model-inventory.qmd
@@ -5,12 +5,14 @@ listing:
   - id: whats-next-listing
     type: grid
     max-description-length: 250
+    grid-columns: 2
     sort: false
     fields: [title, description]
     contents:
       - register-models-in-inventory.qmd
       - customize-model-inventory-layout.qmd
       - edit-model-inventory-fields.qmd
+      - customize-model-overview-page.qmd
 aliases:
   - ../working-with-model-inventory.html
 ---


### PR DESCRIPTION
## Internal Notes for Reviewers

> sc-4752

### Customize model overview page

Net-new page: [**LIVE PREVEW**](https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-4752/documentation-implement-customizable-model/guide/model-inventory/customize-model-overview-page.html)

<img width="1207" alt="Screenshot 2025-01-07 at 4 29 29 PM" src="https://github.com/user-attachments/assets/8c1cfdca-cbe1-41e3-bf34-f4a0c6952b49" />

Added under the "Working with the model inventory umbrella": [**LIVE PREVEW**](https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-4752/documentation-implement-customizable-model/guide/model-inventory/working-with-model-inventory.html)

<img width="1498" alt="Screenshot 2025-01-07 at 4 29 22 PM" src="https://github.com/user-attachments/assets/ba8cfdd0-126c-497d-ad37-669d356ca99b" />