### PR TITLE
Added instructions for Wait steps in workflows

### DIFF
--- a/site/guide/model-inventory/manage-model-inventory-fields.qmd
+++ b/site/guide/model-inventory/manage-model-inventory-fields.qmd
@@ -62,13 +62,11 @@ Number
 :::: {.flex .flex-wrap .justify-around}
 
 ::: {.w-50-ns}
-
 ![Simple number field type](number-simple.png){fig-alt="A screenshot showing a simple number field type" .screenshot group="number"} 
 
 :::
 
 ::: {.w-40-ns}
-
 ![Currency number field type](number-currency.png){fig-alt="A screenshot showing a currency number field type" .screenshot group="number"}
 
 :::
@@ -79,10 +77,12 @@ URL
 : Text value in valid URL format.
 
 Date
-: Date value in `yyyy-mm-dd` format.
+: - Date value in `yyyy-mm-dd` format. 
+- Selection is in the current user's timezone; other users viewing this field will see the value automatically in their timezone. 
 
 Date Time
-: Date value in `yyyy-mm-dd, 24hr` format.
+: - Date value in `yyyy-mm-dd, 24hr` format.
+- Selection is in the current user's timezone; other users viewing this field will see the value automatically in their timezone. 
 
 Email
 : Text value in valid email (`user@domain.com`) format.

--- a/site/guide/model-workflows/set-up-model-workflows.qmd
+++ b/site/guide/model-workflows/set-up-model-workflows.qmd
@@ -152,7 +152,7 @@ Workflows cannot be saved until condition branches are connected to other steps.
 
 To configure a condition branch:
 
-1. On the Configure Condition Branch module, click **+ Add Branch**.
+1. On the Configure Condition Branch modal, click **+ Add Branch**.
 2. Enter in the **[path name]{.smallcaps}** and designate the **[conditions]{.smallcaps}**[^12] that apply to this path.
 3. Continue with steps 1 and 2 until your conditional branch logic is complete.
 
@@ -190,6 +190,15 @@ For example, if you wanted your models where the field `GenAI Model` is set to `
 
 - Creates a time condition for displaying next available action.
 - Used to enforce a time delay or a specific date or date time milestone. 
+
+To configure a condition branch, select when you would like to [resume workflow]{.smallcaps}: 
+
+| Option | Required Field | Description |
+|---:|---|---|
+| After Time Interval  | [wait duration]{.smallcaps} | Wait for a set amount of time in minutes, hours, or days. |
+| At Specified Date | [wait until]{.smallcaps}| Wait until a specific timestamp. |
+| At Specified Date on Model Field | [model field]{.smallcaps} | Wait until a specific timestamp as defined by a valid `Date` or `Date Time` type model inventory field. |
+: **Wait** step configuration {.hover tbl-colwidths="[35,15,40]"}
 
 
 ### Add conditional requirements

--- a/site/guide/model-workflows/set-up-model-workflows.qmd
+++ b/site/guide/model-workflows/set-up-model-workflows.qmd
@@ -186,6 +186,12 @@ For example, if you wanted your models where the field `GenAI Model` is set to `
 
 :::
 
+#### Wait
+
+- Creates a time condition for displaying next available action.
+- Used to enforce a time delay or a specific date or date time milestone. 
+
+
 ### Add conditional requirements
 
 Conditional requirements can be configured for all four available step types:

--- a/site/guide/model-workflows/set-up-model-workflows.qmd
+++ b/site/guide/model-workflows/set-up-model-workflows.qmd
@@ -189,17 +189,20 @@ For example, if you wanted your models where the field `GenAI Model` is set to `
 #### Wait
 
 - Creates a time condition for displaying next available action.
-- Used to enforce a time delay or a specific date or date time milestone. 
+- Used to enforce a time delay or a calendar date milestone. 
 
-To configure a condition branch, select when you would like to [resume workflow]{.smallcaps}: 
+::: {.callout title="Time stamp configuration is in the current user's timezone."}
+Other users viewing those fields or the workflow will see the value automatically in their timezone. 
+:::
 
-| Option | Required Field | Description |
+To configure a wait step, select when you would like to [resume workflow]{.smallcaps}: 
+
+| Option | Required field | Description | 
 |---:|---|---|
-| After Time Interval  | [wait duration]{.smallcaps} | Wait for a set amount of time in minutes, hours, or days. |
-| At Specified Date | [wait until]{.smallcaps}| Wait until a specific timestamp. |
-| At Specified Date on Model Field | [model field]{.smallcaps} | Wait until a specific timestamp as defined by a valid `Date` or `Date Time` type model inventory field. |
-: **Wait** step configuration {.hover tbl-colwidths="[35,15,40]"}
-
+| After Time Interval  | [wait duration]{.smallcaps} | Wait for a set amount of time in minutes, hours, or days. Applies to all models under the workflow. |
+| At Specified Date | [wait until]{.smallcaps} | Wait until a specific timestamp. Applies to all models under the workflow. If the milestone date inputted is in the past, the next workflow step will display immediately. |
+| At Specified Date on Model Field | [model field]{.smallcaps}[^15] | Wait until a specific timestamp as defined by a valid `Date` or `Date Time` type model inventory field on a per model basis. If the selected field is empty[^16] or the milestone date inputted is in the past, the next workflow step will display immediately. |
+: **Wait** step configuration {.hover tbl-colwidths="[30,15,45]"}
 
 ### Add conditional requirements
 
@@ -213,7 +216,7 @@ Conditional requirements can be configured for all four available step types:
 | Condition Branch | Under each branch's **[conditions]{.smallcaps}**, you're able to designate the `AND` and `OR` conditions that apply to that path. |
 : Step type conditional options {.hover tbl-colwidths="[20,80]"}
 
-For Status Change[^15], User Action[^16], and Condition Branch[^17] conditions, you're able to add a single independent **Rule** or a linked condition **Group**. These rules and groups can be nested if desired:
+For Status Change[^17], User Action[^18], and Condition Branch[^19] conditions, you're able to add a single independent **Rule** or a linked condition **Group**. These rules and groups can be nested if desired:
 
 - Click **{{< fa plus >}} Rule** to add an independent rule.
 - Click **{{< fa plus >}} Group** to add a linked group of rules that all must be true to qualify. 
@@ -225,9 +228,9 @@ For Status Change[^15], User Action[^16], and Condition Branch[^17] conditions, 
 #### Link approval steps
 Approval steps need to be subsequently linked to both a [Rejected]{.bubble .red .red-bg} and an [Approved]{.bubble .green .green-bg} Status Change step:
 
-1. First, configure an **Approval** step.[^18]
+1. First, configure an **Approval** step.[^20]
 
-2. Then, drag two **Status Change** steps onto the canvas:[^19]
+2. Then, drag two **Status Change** steps onto the canvas:[^21]
 
     - Assign a `Rejected` status to one in the **Set Document Status** field.
     - Assign an `Approved` status to the other in the **Set Document Status** field.
@@ -295,15 +298,19 @@ Approval steps need to be subsequently linked to both a [Rejected]{.bubble .red 
 
 [^14]: [Approval](#approval) steps
 
-[^15]: [Status Change](#status-change) steps
+[^15]: [Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd#inventory-field-types)
 
-[^16]: [User Action](#user-action) steps
+[^16]: Make model inventory fields **[required on registration]{.smallcaps}** to ensure necessary fields have valid values.
 
-[^17]: [Condition Branch](#condition-branch) steps
+[^17]: [Status Change](#status-change) steps
 
-[^18]: 
+[^18]: [User Action](#user-action) steps
+
+[^19]: [Condition Branch](#condition-branch) steps
+
+[^20]: 
 
     - [Configure workflow steps](#configure-workflow-steps)
     - [Approval](#approval) steps
 
-[^19]: [Status Change](#status-change) steps
+[^21]: [Status Change](#status-change) steps


### PR DESCRIPTION
## Internal Notes for Reviewers

> sc-7615

### Manage model inventory fields

**[LIVE PREVIEW](https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-7615/documentation-support-for-wait-steps/guide/model-inventory/manage-model-inventory-fields.html#inventory-field-types)**

Added some clarification on timezone/displays under `Inventory field types` for these fields as they were missing before.

![Screenshot 2025-01-16 at 10 51 51 AM](https://github.com/user-attachments/assets/f59b5303-1a7c-4e61-8686-4416e9618af7)

### Set up model workflows

**[LIVE PREVIEW](https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-7615/documentation-support-for-wait-steps/guide/model-workflows/set-up-model-workflows.html#wait)**

New `Wait` step under `Available step types`:

![Screenshot 2025-01-16 at 10 50 52 AM](https://github.com/user-attachments/assets/8f1fcdab-77d8-441d-9660-851c13e9c887)