### PR TITLE
Fix notebook link

### DIFF
--- a/site/releases/2025/2025-jan-31/release-notes.qmd
+++ b/site/releases/2025/2025-jan-31/release-notes.qmd
@@ -34,7 +34,7 @@ listing:
     max-description-length: 250
     # image-height: 100%
     contents:
-      - path: https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/code_samples/ongoing_monitoring/application_scorecard_ongoing_monitoring.ipynb)
+      - path: https://jupyterhub.validmind.ai/hub/user-redirect/lab/tree/code_samples/ongoing_monitoring/application_scorecard_ongoing_monitoring.ipynb
         title: "Ongoing monitoring for application scorecard"
         description: "Open notebook in JupyterHub {{< fa chevron-right >}}"
   - id: e2e-template


### PR DESCRIPTION
## Internal Notes for Reviewers

Small fix for a broken link I noticed in our Jan 31 release notes

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `deprecation`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->