### PR TITLE
+ `breaking-change` releases tag, PR template, & release script update

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,9 @@ PR instructions for release notes:
 - `internal` (skip Step 2, no release notes required)
 - `highlight`
 - `enhancement`
-- `bug`
+- `breaking-change`
 - `deprecation`
+- `bug`
 - `documentation`
 
 2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.

--- a/release-scripts/generate-release-notes.ipynb
+++ b/release-scripts/generate-release-notes.ipynb
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "label_hierarchy = [\"highlight\", \"enhancement\", \"deprecation\", \"bug\", \"documentation\"]\n",
+    "label_hierarchy = [\"highlight\", \"enhancement\", \"breaking-change\", \"deprecation\", \"bug\", \"documentation\"]\n",
     "gro.display_list(label_hierarchy)"
    ]
   },

--- a/release-scripts/generate_release_objects.py
+++ b/release-scripts/generate_release_objects.py
@@ -346,6 +346,7 @@ label_to_category = {
 categories = { 
     "highlight": [],
     "enhancement": [],
+    "breaking-change": [],
     "deprecation": [],
     "bug": [],
     "documentation": []

--- a/release-scripts/generate_release_objects.py
+++ b/release-scripts/generate_release_objects.py
@@ -338,6 +338,7 @@ def setup_openai_api(env_location):
 label_to_category = {
     "highlight": "## Release highlights",
     "enhancement": "## Enhancements",
+    "breaking-change": "## Breaking changes",
     "deprecation": "## Deprecations",
     "bug": "## Bug fixes",
     "documentation": "## Documentation"
@@ -900,7 +901,7 @@ def main():
         setup_openai_api(env_location)
         print()
 
-        label_hierarchy = ["highlight", "enhancement", "deprecation", "bug", "documentation"]
+        label_hierarchy = ["highlight", "enhancement", "breaking-change", "deprecation", "bug", "documentation"]
         display_list(label_hierarchy)
         print()
 

--- a/site/releases/2024/2024-jan-26/highlights.qmd
+++ b/site/releases/2024/2024-jan-26/highlights.qmd
@@ -295,6 +295,21 @@ To work with Azure OpenAI API endpoints, you need to set the following environme
 - We have updated our demonstration notebooks for large language models (LLMs) to provide the correct support for `openai >= 1.0.0`. 
 - Previously, some notebooks were using an older version of the OpenAI client API.
 
+## Breaking changes
+
+### {{< var validmind.developer >}} (v1.25.3)
+
+<!---[SC-2771] Remove deprecated high level api methods by @juanmleng in [#310](https://github.com/validmind/validmind-library/pull/310)--->
+#### Removed deprecated {{< var validmind.api >}} methods
+
+The {{< var vm.api >}} methods `run_template` and `run_test_plan` had been deprecated previously. They have now been removed from the {{< var validmind.developer >}}.
+
+You'll need to update your code to use the recommended high-level API methods:
+
+- **`run_template` (removed):** Use [`run_documentation_tests()`](/validmind/validmind.html#run_documentation_tests){target="_blank"}
+- **`run_test_plan` (removed):** Use [`run_test_suite()`](/validmind/validmind.html#run_test_suite){target="_blank"}
+
+
 ## Deprecations
 
 ### {{< var validmind.developer >}} (v1.25.3)
@@ -336,16 +351,6 @@ The {{< var validmind.developer >}} now supports passing custom inputs[^3] as an
 :::
 
 ::::
-
-<!---[SC-2771] Remove deprecated high level api methods by @juanmleng in [#310](https://github.com/validmind/validmind-library/pull/310)--->
-#### Removed deprecated {{< var validmind.api >}} methods
-
-The {{< var vm.api >}} methods `run_template` and `run_test_plan` had been deprecated previously. They have now been removed from the {{< var validmind.developer >}}.
-
-You'll need to update your code to use the recommended high-level API methods:
-
-- **`run_template` (removed):** Use [`run_documentation_tests()`](/validmind/validmind.html#run_documentation_tests){target="_blank"}
-- **`run_test_plan` (removed):** Use [`run_test_suite()`](/validmind/validmind.html#run_test_suite){target="_blank"}
 
 ## Documentation
 

--- a/site/releases/breaking-changes/README.md
+++ b/site/releases/breaking-changes/README.md
@@ -71,7 +71,7 @@ Make a copy of `~/releases/breaking-changes/year.csv` in the `~/releases/breakin
 
 #### Create collateral
 
-You'll need the links for the release notes and any blog posts associated with the breaking change or deprecation to include in the table, so make sure those are published that first unless you want to fill them in at a later date.
+You'll need the links for the release notes associated with the breaking change or deprecation to include in the table, so make sure those are published that first unless you want to fill them in at a later date.
 
 #### Enter an entry
 
@@ -85,7 +85,6 @@ Open up the `.csv` for the year you want to update and create a new entry under 
 | Type | Whether it's a breaking change or deprecation | `Deprecation` |
 | Date announced | ISO 8601 date of announcement | `2024-01-26` |
 | Release notes | Markdown format **HTML** link to the associated release notes enclosed by `""` | `"[Read](/releases/2024/2024-jan-26/highlights.html#standard-inputs-are-deprecated)"` |
-| Blog post | Markdown format link to the associated blog post enclosed by `""` | `"[Read](https://validmind.com/blog/)"` |
 | Date effective | ISO 8601 date of feature removal/deprecation | `2024-01-26` |
 
 > [!NOTE]


### PR DESCRIPTION
## Internal Notes for Reviewers

> sc-8459

### `breaking-change` release tag

Added to:

- [`documentation`](https://github.com/validmind/documentation/issues/labels)
- [`validmind-library`](https://github.com/validmind/validmind-library/issues/labels)
- [`frontend`](https://github.com/validmind/frontend/issues/labels)

### PR templates

Added the instructions for the `breaking-change` label to:

- `documentation`: 
https://github.com/validmind/documentation/blob/61a07ecc5d27e274733f0bacbe5305c869667e07/.github/pull_request_template.md?plain=1#L11
- `validmind-library`: https://github.com/validmind/validmind-library/pull/318
- `frontend`: https://github.com/validmind/frontend/pull/1234

### Generate release script & notebook

Updated both of these to include the `breaking-change` > `## Breaking changes` label to header in the hierarchy:

#### generate_release_objects.py

Setting up the object for the categories based on PR labels:

https://github.com/validmind/documentation/blob/61a07ecc5d27e274733f0bacbe5305c869667e07/release-scripts/generate_release_objects.py#L350

Transforming the label to the header category:

https://github.com/validmind/documentation/blob/61a07ecc5d27e274733f0bacbe5305c869667e07/release-scripts/generate_release_objects.py#L341

Setting the label hierarchy in `main` for when the script is called via Make:

https://github.com/validmind/documentation/blob/61a07ecc5d27e274733f0bacbe5305c869667e07/release-scripts/generate_release_objects.py#L904

#### generate-release-notes.ipynb

Default label hierarchy when the notebook is run:

https://github.com/validmind/documentation/blob/61a07ecc5d27e274733f0bacbe5305c869667e07/release-scripts/generate-release-notes.ipynb#L158

### Other

- Removed references to the blog post column in the breaking changes/deprecations README as we decided to omit that from the table.
- Updated the release notes for `January 26, 2024` to separate out the breaking change from the deprecations to keep things uniform going forward: [**LIVE PREVIEW**](https://docs-demo.vm.validmind.ai/pr_previews/beck/sc-8459/qol-updates-breaking-changes-deprecation/releases/2024/2024-jan-26/highlights.html)

![Screenshot 2025-02-18 at 11 12 49 AM](https://github.com/user-attachments/assets/fb433393-5158-4dcb-bbdc-5511172e6a96)