### PR TITLE
feat: example implementation of trigger in other repo

### DIFF
--- a/.github/workflows/test_installation_trigger.yaml
+++ b/.github/workflows/test_installation_trigger.yaml
@@ -1,4 +1,4 @@
-name: Trigger job in Installation
+name: Trigger job in the installation repo
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test_installation_trigger.yaml
+++ b/.github/workflows/test_installation_trigger.yaml
@@ -1,0 +1,15 @@
+name: Trigger job in Installation
+
+on:
+  workflow_dispatch:
+
+jobs:
+  trigger-repo-a:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Repository Dispatch to Repo A
+        run: |
+          curl -X POST -H "Accept: application/vnd.github.v3+json" \
+               -H "Authorization: token ${{ secrets.INSTALLATION_PAT }}" \
+               https://api.github.com/repos/validmind/installation/dispatches \
+               -d '{"event_type": "trigger-job"}'


### PR DESCRIPTION
## Internal Notes for Reviewers

Just an example of how we can trigger a workflow in another repository via repository dispatch. The purpose of this PR is to test triggering another workflow in the `installation` repo to deploy an instance of our docs site with additional content.

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `breaking-change`
- `deprecation`
- `bug`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->