### PR TITLE
Enable cloning at a specific release tag

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -38,10 +38,11 @@ clean:
 	@echo "\nDeleting copies of files sourced from other repos ..."
 	rm -rf $(SRC_DIR)
 
-# Clone the source repository we need
+# Prompt for a release tag and clone the repository at that tag
 clone:
-	@echo "\nCloning source repos ..."
-	git clone -b $(BRANCH) git@github.com:validmind/validmind-library.git $(SRC_DIR)
+	@read -p "Enter release tag (example: v2.8.10): " TAG; \
+	echo "\nCloning source repo at tag $$TAG ..."; \
+	git clone --depth 1 --branch $$TAG git@github.com:validmind/validmind-library.git $(SRC_DIR)
 
 # Copy over Jupyter notebooks and supporting files
 notebooks:

--- a/site/Makefile
+++ b/site/Makefile
@@ -42,12 +42,18 @@ clean:
 clone:
 	@if [ -n "$(BRANCH)" ] && [ "$(BRANCH)" != "main" ]; then \
 		echo "\nWARNING: Cloning non-release files from $(BRANCH) — DO NOT COMMIT"; \
-		git clone --depth 1 --branch $(BRANCH) git@github.com:validmind/validmind-library.git $(SRC_DIR); \
+		CHECKOUT="$(BRANCH)"; \
 	else \
-		read -p "Enter release tag (example: v2.8.10): " TAG; \
-		echo "\nCloning source repo at tag $$TAG ..."; \
-		git clone --depth 1 --branch $$TAG git@github.com:validmind/validmind-library.git $(SRC_DIR); \
-	fi
+		read -p "Enter release tag (example: v2.8.10, or HEAD for latest): " TAG; \
+		if [ "$$TAG" = "HEAD" ]; then \
+			echo "\nWARNING: Cloning latest non-release files — DO NOT COMMIT"; \
+			CHECKOUT="$(BRANCH)"; \
+		else \
+			echo "\nCloning source repo at tag $$TAG ..."; \
+			CHECKOUT="$$TAG"; \
+		fi \
+	fi; \
+	git clone --depth 1 --branch $$CHECKOUT git@github.com:validmind/validmind-library.git $(SRC_DIR)
 
 # Copy over Jupyter notebooks and supporting files
 notebooks:

--- a/site/Makefile
+++ b/site/Makefile
@@ -1,5 +1,6 @@
 # Define source and destination directories
-BRANCH ?= main
+LIBRARY_BRANCH ?= $(or $(BRANCH),main)
+INSTALLATION_BRANCH := main
 SRC_ROOT := _source
 SRC_DIR := $(SRC_ROOT)/validmind-library
 DEST_DIR_NB := notebooks
@@ -42,25 +43,25 @@ clean:
 
 # Prompt for a branch or release tag and clone the repository
 clone:
-	# Clone the validmind-library repo
-	@if [ -n "$(BRANCH)" ] && [ "$(BRANCH)" != "main" ]; then \
-		echo "\nWARNING: Cloning non-release files from $(BRANCH) — DO NOT COMMIT"; \
-		CHECKOUT="$(BRANCH)"; \
+	@if [ -n "$(LIBRARY_BRANCH)" ] && [ "$(LIBRARY_BRANCH)" != "main" ]; then \
+		echo "\nWARNING: Cloning non-release files from $(LIBRARY_BRANCH) — DO NOT COMMIT"; \
+		echo "\nCloning validmind-library repo from $(LIBRARY_BRANCH) ..."; \
+		CHECKOUT="$(LIBRARY_BRANCH)"; \
 	else \
 		read -p "Enter release tag (example: v2.8.10, or HEAD for latest): " TAG; \
 		if [ "$$TAG" = "HEAD" ]; then \
 			echo "\nWARNING: Cloning latest non-release files — DO NOT COMMIT"; \
-			CHECKOUT="$(BRANCH)"; \
+			echo "\nCloning validmind-library repo at HEAD ..."; \
+			CHECKOUT="$(LIBRARY_BRANCH)"; \
 		else \
-			echo "\nCloning validmind-library repo at tag $$TAG ..."; \
+			echo "\nCloning validmind-library repo at $$TAG ..."; \
 			CHECKOUT="$$TAG"; \
 		fi \
 	fi; \
 	git clone --depth 1 -b $$CHECKOUT git@github.com:validmind/validmind-library.git $(SRC_DIR)
 
-	# Clone the installation repo
-	@echo "\nCloning installation repo ..."
-	git clone  --depth 1 -b $(BRANCH) git@github.com:validmind/installation.git $(SRC_ROOT)/installation
+	@echo "\nCloning installation repo from $(INSTALLATION_BRANCH) ..."; \
+	git clone  --depth 1 -b $(INSTALLATION_BRANCH) git@github.com:validmind/installation.git $(SRC_ROOT)/installation
 
 copy-installation:
 	cp -r $(SRC_ROOT)/installation/site/installation installation

--- a/site/Makefile
+++ b/site/Makefile
@@ -38,11 +38,16 @@ clean:
 	@echo "\nDeleting copies of files sourced from other repos ..."
 	rm -rf $(SRC_DIR)
 
-# Prompt for a release tag and clone the repository at that tag
+# Prompt for a branch or release tag and clone the repository
 clone:
-	@read -p "Enter release tag (example: v2.8.10): " TAG; \
-	echo "\nCloning source repo at tag $$TAG ..."; \
-	git clone --depth 1 --branch $$TAG git@github.com:validmind/validmind-library.git $(SRC_DIR)
+	@if [ -n "$(BRANCH)" ] && [ "$(BRANCH)" != "main" ]; then \
+		echo "\nWARNING: Cloning non-release files from $(BRANCH) — DO NOT COMMIT"; \
+		git clone --depth 1 --branch $(BRANCH) git@github.com:validmind/validmind-library.git $(SRC_DIR); \
+	else \
+		read -p "Enter release tag (example: v2.8.10): " TAG; \
+		echo "\nCloning source repo at tag $$TAG ..."; \
+		git clone --depth 1 --branch $$TAG git@github.com:validmind/validmind-library.git $(SRC_DIR); \
+	fi
 
 # Copy over Jupyter notebooks and supporting files
 notebooks:


### PR DESCRIPTION
## Internal Notes for Reviewers

### Do not commit the output until the next release tag is available

This PR enables cloning the validmind-library at a specific release tag to ensure version-accurate documentation for:
- Notebooks with code samples
- Generated Quarto Markdown for our Python API reference
- Test descriptions generated on the fly

<img width="767" alt="Capto_2025-03-20_07-41-13_am" src="https://github.com/user-attachments/assets/c97cd72a-c031-4e2e-9904-c47c4b21c372" />

The detached HEAD state is expected — we are checking out a specific SHA rather than tracking the latest commit (which is HEAD)

**Important:** It’s safe to run `make get-source` to test the changes, but do not commit the output yet.

Our docs site now relies on the generated Quarto Markdown for the Python API reference. To avoid breaking the documentation, we must wait for a new release tag in the `validmind-library` repository that includes this Quarto Markdown before committing the cloned source.

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `breaking-change`
- `deprecation`
- `bug`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->