### PR TITLE
Remove defunct deploy-demo make action

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -9,7 +9,7 @@ PROFILE := exe-demo
 FILE_PATH := notebooks/tutorials/intro_for_model_developers_EXECUTED.ipynb 
 
 # Define .PHONY target for help section
-.PHONY: help clean clone notebooks python-docs docs-site deploy-demo deploy-demo-branch delete-demo-branch deploy-prod deploy-staging release-notes execute docker-build docker-serve
+.PHONY: help clean clone notebooks python-docs docs-site deploy-demo-branch delete-demo-branch deploy-prod deploy-staging release-notes execute docker-build docker-serve
 
 # Help section
 help:
@@ -21,7 +21,6 @@ help:
 	@echo "  python-docs          Copy the Python library docs into _site/validmind"
 	@echo "  get-source           Get all source files (clean, clone, notebooks, python-docs)"
 	@echo "  docs-site            Get all source files and render the docs site with Quarto"
-	@echo "  deploy-demo          Deploy docs demo site to s3://docs-ci-cd-demo/site/"
 	@echo "  deploy-demo-branch   Deploy docs demo site to s3://docs-ci-cd-demo/site/pr_previews/$(GIT_BRANCH)/"
 	@echo "  delete-demo-branch   Delete docs demo site in s3://docs-ci-cd-demo/site/pr_previews/$(GIT_BRANCH)/"
 	@echo "  deploy-prod          Deploy docs prod site to s3://docs-ci-cd-prod/site/"
@@ -93,15 +92,6 @@ docs-site: get-source
 docs-site-lite: get-source
 	@echo "\nRendering the static HTML site ..."
 	quarto render --profile production
-
-# Deployment to https://docs-demo.vm.validmind.ai/
-deploy-demo:
-	@if [ "`git rev-parse --abbrev-ref HEAD`" != "docs-demo" ]; then \
-		echo "You're not on the docs-demo branch, no action taken."; \
-	else \
-		echo "\nDeploying docs-demo site ..."; \
-		quarto render --profile development && aws s3 sync ./_site s3://docs-ci-cd-demo/site/ && aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager > /dev/null; \
-	fi
 
 # Deploy PR branch to https://docs-demo.vm.validmind.ai/
 deploy-demo-branch:


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR removes one of those 'we should fix this some day' annoyances that I've spent more time explaining in the last week than it would take to fix. This PR fixes THE LAST PIECE in the puzzle. 

**Before**
We had an extra docs site in the root of the `s3://docs-ci-cd-demo` bucket that goes back to the very early days of Andres and I experimenting with docs deployment. This site serves no purpose, is not current, and is not used — other than we need in index.html in the root of `origin/` for the PR previews to work. 

You could deploy this site with `make deploy-demo`. 

**After**
This site has now been deleted, replaced with an index.html that redirects to https://docs-staging.validmind.ai/ if you try to access the root of `origin/`. Eventually, we might want to list all the PR previews but for now, not having a stale, defunct docs site kicking around that I have to explain is an improvement. 

The `make deploy-demo` is removed in this PR, preventing accidental redeployment of the site. 


<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `breaking-change`
- `deprecation`
- `bug`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->