### PR TITLE
fix: [sc-9632] Add missing "Export ongoing monitoring document" section to docs

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -316,7 +316,6 @@ website:
           contents:
           - guide/reporting/view-report-data.qmd
           - guide/reporting/manage-custom-reports.qmd
-        - guide/model-documentation/export-documentation.qmd
         - text: "---"
         - text: "Monitoring"
         - file: guide/monitoring/ongoing-monitoring.qmd

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -325,6 +325,7 @@ website:
           - guide/monitoring/review-monitoring-results.qmd
           - text: "Metrics over time"
             file: guide/monitoring/work-with-metrics-over-time.qmd
+        - guide/model-documentation/export-documentation.qmd
         - text: "---"
         - text: "Attestation"
         - file: guide/attestation/working-with-attestations.qmd

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -292,7 +292,6 @@ website:
             file: guide/model-documentation/assign-documentation-section-statuses.qmd
           - guide/model-documentation/collaborate-with-others.qmd
           - guide/model-documentation/submit-for-approval.qmd
-        - guide/model-documentation/export-documentation.qmd
         - text: "---"
         - text: "Model Validation"
         - guide/model-validation/manage-validation-guidelines.qmd
@@ -309,13 +308,13 @@ website:
             file: guide/model-validation/view-filter-model-findings.qmd
           - text: "Add and manage findings"
             file: guide/model-validation/add-manage-model-findings.qmd
-        - guide/model-documentation/export-documentation.qmd
         - text: "---"
         - text: "Reporting"
         - file: guide/reporting/working-with-analytics.qmd
           contents:
           - guide/reporting/view-report-data.qmd
           - guide/reporting/manage-custom-reports.qmd
+        - guide/reporting/export-documentation.qmd
         - text: "---"
         - text: "Monitoring"
         - file: guide/monitoring/ongoing-monitoring.qmd
@@ -324,7 +323,6 @@ website:
           - guide/monitoring/review-monitoring-results.qmd
           - text: "Metrics over time"
             file: guide/monitoring/work-with-metrics-over-time.qmd
-        - guide/model-documentation/export-documentation.qmd
         - text: "---"
         - text: "Attestation"
         - file: guide/attestation/working-with-attestations.qmd

--- a/site/about/overview-model-risk-management.qmd
+++ b/site/about/overview-model-risk-management.qmd
@@ -222,4 +222,4 @@ By integrating these features, {{< var vm.product >}} provides a comprehensive s
 
 [^4]: [Working with documentation templates](/guide/model-documentation/working-with-documentation-templates.qmd)
 
-[^5]: [Export documentation](/guide/model-documentation/export-documentation.qmd)
+[^5]: [Export documentation](/guide/reporting/export-documentation.qmd)

--- a/site/faq/faq-documentation.qmd
+++ b/site/faq/faq-documentation.qmd
@@ -13,7 +13,6 @@ listing:
     contents:
     - ../guide/model-documentation/working-with-documentation-templates.qmd
     - ../guide/model-documentation/working-with-model-documentation.qmd
-    - ../guide/reporting/export-documentation.qmd
 categories: ["templates", "model documentation", "customization", "images", "validmind platform", "validmind library"]
 ---
 

--- a/site/faq/faq-documentation.qmd
+++ b/site/faq/faq-documentation.qmd
@@ -13,7 +13,7 @@ listing:
     contents:
     - ../guide/model-documentation/working-with-documentation-templates.qmd
     - ../guide/model-documentation/working-with-model-documentation.qmd
-    - ../guide/model-documentation/export-documentation.qmd
+    - ../guide/reporting/export-documentation.qmd
 ---
 
 ## What kind of templates are available through {{< var vm.product >}}?

--- a/site/faq/faq-reporting.qmd
+++ b/site/faq/faq-reporting.qmd
@@ -9,7 +9,7 @@ listing:
     sort: false
     fields: [title, description]
     contents:
-    - ../guide/model-documentation/export-documentation.qmd
+    - ../guide/reporting/export-documentation.qmd
     - ../guide/reporting/working-with-analytics.qmd
     - ../guide/monitoring/ongoing-monitoring.qmd
 ---

--- a/site/guide/guides.qmd
+++ b/site/guide/guides.qmd
@@ -50,7 +50,6 @@ listing:
     contents: 
     - model-documentation/working-with-documentation-templates.qmd
     - model-documentation/working-with-model-documentation.qmd
-    # - model-documentation/export-documentation.qmd
   - id: guides-developer
     type: grid
     max-description-length: 250
@@ -71,6 +70,7 @@ listing:
   - id: guides-reports
     contents: 
     - reporting/working-with-analytics.qmd
+    - reporting/export-documentation.qmd
     type: grid
     max-description-length: 250
     sort: false
@@ -151,7 +151,7 @@ Set up validation guidelines and prepare validation reports, work with findings 
 :::{#guides-model-validation}
 :::
 
-### Reporting
+## Reporting
 
 Review reports or export your documentation for external records:
 

--- a/site/guide/guides.qmd
+++ b/site/guide/guides.qmd
@@ -70,8 +70,7 @@ listing:
     - model-validation/working-with-model-findings.qmd
   - id: guides-reports
     contents: 
-    - model-validation/view-reports.qmd
-    - model-documentation/export-documentation.qmd
+    - reporting/working-with-analytics.qmd
     type: grid
     max-description-length: 250
     sort: false

--- a/site/guide/model-documentation/export-documentation.qmd
+++ b/site/guide/model-documentation/export-documentation.qmd
@@ -53,6 +53,18 @@ Export your model documentation or validation reports as Microsoft Word files (`
 
 6. Click **{{< fa file-arrow-down >}} Download File** to download the file locally on your machine.
 
+## Export ongoing monitoring documentation
+
+1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
+
+2. Select a model or find your model by applying a filter or searching for it.[^4]
+
+3. In the left sidebar that appears for your model, click **{{< fa desktop >}} Ongoing Monitoring**.
+
+4. In right sidebar, click **{{< fa download >}} Export Document**.
+
+7. Click **{{< fa file-arrow-down >}} Download File** to download the file locally on your machine.
+
 ## What's next
 
 * [Working with model documentation](working-with-model-documentation.qmd)

--- a/site/guide/model-documentation/export-documentation.qmd
+++ b/site/guide/model-documentation/export-documentation.qmd
@@ -5,7 +5,7 @@ aliases:
   - /guide/export-documentation.html
 ---
 
-Export your model documentation or validation reports as Microsoft Word files (`.docx`) for use outside of the {{< var validmind.platform >}}.
+Export your model documentation, validation reports, and ongoing monitoring documentation as Microsoft Word files (`.docx`) for use outside of the {{< var validmind.platform >}}.
 
 ::: {.callout}
 {{< var vm.product >}} supports Word 365, Word 2019, Word 2016, and Word 2013.

--- a/site/guide/model-validation/working-with-model-findings.qmd
+++ b/site/guide/model-validation/working-with-model-findings.qmd
@@ -67,6 +67,6 @@ residual analysis
 
 - [Preparing validation reports](preparing-validation-reports.qmd)
 - [Working with analytics](/guide/reporting/working-with-analytics.qmd)
-- [Export documentation](/guide/model-documentation/export-documentation.qmd)
+- [Export documentation](/guide/reporting/export-documentation.qmd)
 - [View model activity](/guide/model-inventory/view-model-activity.qmd)
 

--- a/site/guide/reporting/export-documentation.qmd
+++ b/site/guide/reporting/export-documentation.qmd
@@ -67,18 +67,16 @@ Export your model documentation, validation reports, and ongoing monitoring docu
 
 ## What's next
 
-* [Working with model documentation](working-with-model-documentation.qmd)
-* [Collaborate on documentation](collaborate-with-others.qmd)
-* [Submit for approval](submit-for-approval.qmd)
-
-
+* [Working with model documentation](/guide/model-documentation/working-with-model-documentation.qmd)
+* [Collaborate on documentation](/guide/model-documentation/collaborate-with-others.qmd)
+* [Submit for approval](/guide/model-documentation/submit-for-approval.qmd)
 
 
 <!-- FOOTNOTES -->
 
 [^1]: [Register models in the inventory](/guide/model-inventory/register-models-in-inventory.qmd)
 
-[^2]: [Working with model documentation](working-with-model-documentation.qmd)
+[^2]: [Working with model documentation](/guide/model-documentation/working-with-model-documentation.qmd)
 
 [^3]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
 

--- a/site/guide/reporting/export-documentation.qmd
+++ b/site/guide/reporting/export-documentation.qmd
@@ -3,6 +3,7 @@ title: "Export documentation"
 date: last-modified
 aliases:
   - /guide/export-documentation.html
+  - /guide/model-documentation/export-documentation.html
 ---
 
 Export your model documentation, validation reports, and ongoing monitoring documentation as Microsoft Word files (`.docx`) for use outside of the {{< var validmind.platform >}}.

--- a/site/releases/2023/release-notes-2023-may-30.qmd
+++ b/site/releases/2023/release-notes-2023-may-30.qmd
@@ -52,7 +52,7 @@ Plots and visual outputs have been enhanced with the Plotly package. Users can n
 :::
 
 ::: {.w-30-ns .tc}
-[Export documentation](/guide/model-documentation/export-documentation.qmd){.button .button-green}
+[Export documentation](/guide/reporting/export-documentation.qmd){.button .button-green}
 
 :::
 

--- a/site/releases/2025/2025-mar-07/release-notes.qmd
+++ b/site/releases/2025/2025-mar-07/release-notes.qmd
@@ -85,7 +85,7 @@ We now support additional configuration when exporting validation reports, allow
 :::
 
 ::: {.w-30-ns}
-[Export documentation](/guide/model-documentation/export-documentation.qmd#export-validation-report){.button}
+[Export documentation](/guide/reporting/export-documentation.qmd#export-validation-report){.button}
 :::
 
 ::::


### PR DESCRIPTION
This PR adds the missing steps for exporting ongoing monitoring documentation:

![Capto_ 2025-04-16_09-55-43_pm](https://github.com/user-attachments/assets/477bcb8b-36f5-46b1-93b5-ab5e53aac8d2)

Story details: https://app.shortcut.com/validmind/story/9632
