### PR TITLE
Automatically set the year in footer & fix links to main site

### DIFF
--- a/site/_extensions/gadenbuie/now/_extension.yml
+++ b/site/_extensions/gadenbuie/now/_extension.yml
@@ -1,0 +1,8 @@
+title: Now
+author: Garrick Aden-Buie
+version: 1.0.0
+quarto-required: ">=1.4.0"
+contributes:
+  shortcodes:
+    - now.lua
+

--- a/site/_extensions/gadenbuie/now/now.lua
+++ b/site/_extensions/gadenbuie/now/now.lua
@@ -1,0 +1,174 @@
+--[[
+# MIT License
+#
+# Copyright (c) 2024 Garrick Aden-Buie
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+]]
+
+local formatMapping = {
+  year = "%Y",
+  month = "%B",
+  day = "%d",
+  weekday = "%A",
+  hour = "%I",
+  minute = "%M",
+  ampm = "%p",
+  date = "%x",
+  time = "%X",
+  datetime = "%c",
+  isodate = "%F",
+  isotime = "%T",
+  isodatetime = "%FT%T%z",
+  timestamp = "%F %T"
+}
+
+local function run_command(command)
+  local handle, err = io.popen(command)
+  if not handle then
+    quarto.log.error("Error running command `" .. command .. "`: " .. err)
+    return nil
+  end
+  local result = handle:read("*a")
+  handle:close()
+  return result
+end
+
+local function last_modified_bsd(file)
+  local command = "stat -f %m " .. file  -- Command to get modification time
+  local result = run_command(command)
+  return tonumber(result)
+end
+
+local function last_modified_linux(file)
+  local command = "stat -c %y " .. file  -- Command to get modification time
+
+  local result = run_command(command)
+  if result == nil then
+    return nil
+  end
+
+  -- Extract modification time string
+  local mod_time_str = string.match(result, "(%d+%-%d+%-%d+ %d+:%d+:%d+)")
+  if mod_time_str == nil then
+    quarto.log.error(
+      "Error parsing the file modification time string, " ..
+      "defaulting to render time."
+    )
+    return nil
+  end
+
+  local mod_time_pattern = "(%d+)-(%d+)-(%d+) (%d+):(%d+):(%d+)"
+  local year, month, day, hour, min, sec = mod_time_str:match(mod_time_pattern)
+  if not (year and month and day and hour and min and sec) then
+    quarto.log.error(
+      "Error parsing the file modification time string, " ..
+      "defaulting to render time."
+    )
+    return nil
+  end
+
+  return os.time{year=year, month=month, day=day, hour=hour, min=min, sec=sec}
+end
+
+local last_modified_fns = {
+  linux = last_modified_linux,
+  bsd = last_modified_bsd,
+  darwin = last_modified_bsd
+}
+
+local function parse_modified_date(meta)
+  if meta.modified == nil then
+    return nil
+  end
+
+  local dt = pandoc.utils.stringify(meta.modified)
+
+  -- Parsing the date string
+  local year, month, day = dt:match("(%d%d%d%d)-(%d%d)-(%d%d)")
+  if not (year and month and day) then
+    quarto.log.error("Invalid `modified` date format. Please use the format 'YYYY-MM-DD HH:MM:SS'")
+    return nil
+  end
+
+  -- parse the time in pieces so we can handle missing parts
+  local hour = dt:match("%d%d%d%d-%d%d-%d%d[ T]?(%d+)")
+  local min  = dt:match("%d%d%d%d-%d%d-%d%d[ T]?%d+:(%d+)")
+  local sec  = dt:match("%d%d%d%d-%d%d-%d%d[ T]?%d+:%d+:(%d+)")
+
+  -- Convert to a time object
+  return os.time{
+    year=year,
+    month=month,
+    day=day,
+    hour=hour or 0,
+    min=min or 0,
+    sec=sec or 0
+  }
+end
+
+local function source_modified_time()
+  local file = quarto.doc.input_file
+  local last_modified = last_modified_fns[pandoc.system.os](file)
+
+  return last_modified
+end
+
+local function get_format(args)
+  local format = formatMapping[args[1]] or args[1] or "%F %T"
+  format = pandoc.utils.stringify(format)
+  return format
+end
+
+---@param format string The format string, see https://www.lua.org/pil/22.1.html
+---@param mod_time integer?
+---@return pandoc.Str
+local function format_time(format, mod_time)
+  local now = os.date(format, mod_time)
+  return pandoc.Str(tostring(now))
+end
+
+return {
+  ['now'] = function(args)
+    local format = get_format(args)
+    return format_time(format)
+  end,
+  ['modified'] = function(args, _, meta)
+    local format = get_format(args)
+
+    local modified = parse_modified_date(meta)
+    if modified then
+      return format_time(format, modified)
+    end
+
+    local os = pandoc.system.os
+    if last_modified_fns[os] == nil then
+      quarto.log.warning(
+        '`modified` shortcode can\'t automatically discover ' ..
+        'the file modification time on "' .. os ..
+        '", using rendered time instead. You can manually set the ' ..
+        '`modified` date in the metadata to avoid this warning.'
+      )
+      return format_time(format)
+    end
+
+    mod_time = source_modified_time()
+    return format_time(format, mod_time)
+  end
+}

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -370,7 +370,7 @@ website:
 
   page-footer:
     background: "#DE257E"
-    left: "© Copyright 2023-2024 {{< var validmind.legal >}}  All Rights Reserved."
+    left: "© Copyright {{< now year >}} {{< var validmind.legal >}}  All Rights Reserved."
     right:
       - text: "validmind.com {{< fa external-link >}}"
         href: https://validmind.com/

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -376,9 +376,9 @@ website:
         href: https://validmind.com/
         target: _blank
       - text: "Privacy Policy"
-        href: https://validmind.com/privacy-policy/
+        href: https://validmind.com/about/legal/privacy-policy/
       - text: "Terms of Use"
-        href: https://validmind.com/terms-of-use/
+        href: https://validmind.com/about/legal/terms-of-use/
       - icon: github
         href: https://github.com/validmind/documentation
       - icon: linkedin

--- a/site/about/fine-print/data-privacy-policy.qmd
+++ b/site/about/fine-print/data-privacy-policy.qmd
@@ -2,6 +2,15 @@
 title: "Data privacy policy"
 keywords: "data privacy, ai risk, model risk management, {{< var vm.product >}}"
 date: last-modified
+listing:
+  id: legal-ease
+  type: grid
+  grid-columns: 2
+  contents:
+    - path: https://validmind.com/about/legal/
+      title: "Legal Ease"
+      description: "These documents detail our practices in data handling, privacy, AI usage policy, terms of service, and more."
+      author: validmind.com
 aliases:
   - /about/data-privacy-policy.html
   - /guide/data-privacy-policy.html
@@ -54,6 +63,10 @@ When you generate documentation or run tests, {{< var vm.product >}} imports the
 
 The {{< var validmind.developer >}} does not send any personally identifiable information (PII) through our {{< var validmind.api >}}. 
 
-<!-- ## What's next
+## A commitment to transparency
 
-- [Configure AWS PrivateLink](/guide/configuration/configure-aws-privatelink.qmd) -->
+Understanding our policies shouldn’t feel like deciphering code, so we’ve made our legal texts as clear and accessible as possible: 
+
+::: {#legal-ease}
+:::
+

--- a/site/about/fine-print/license-agreement.qmd
+++ b/site/about/fine-print/license-agreement.qmd
@@ -40,4 +40,4 @@ By installing, copying, or otherwise using the Software, you as a user of the So
 
 By installing or using the Software, you acknowledge that you have read this Agreement, understand it, and agree to be bound by its terms and conditions.
 
-Copyright © 2023 {{< var validmind.legal >}}  All rights reserved.
+Copyright © {{< now year >}} {{< var validmind.legal >}}  All rights reserved.

--- a/site/about/overview-llm-features.qmd
+++ b/site/about/overview-llm-features.qmd
@@ -98,27 +98,21 @@ Assesses each part of the model documentation for adherence to internal guidelin
 
 :::: {.flex .flex-wrap .justify-around}
 
-::: {.w-50-ns}
+::: {.w-33-ns .pr3}
 ### A commitment to transparency
 
-Understanding our policies shouldn’t feel like deciphering code, so we’ve made our legal texts as clear and accessible as possible. 
-These documents detail our practices in data handling, privacy, [AI usage policy](https://validmind.com/about/legal/ai-usage-policy/), and regulatory compliance.
+Understanding our policies shouldn’t feel like deciphering code, so we’ve made our legal texts as clear and accessible as possible: [Legal Ease](https://validmind.com/about/legal/)
+
+These documents detail our [AI usage policy](https://validmind.com/about/legal/ai-usage-policy/) and more.
 :::
 
-::: {.w-50-ns}
+::: {.w-33-ns .pr3}
 ### Try it yourself
 
 Discover how {{< var vm.product >}}’s LLM-powered platform, purpose-built for model risk management teams, enables streamlined and confident testing, documentation, validation, and governance of generative AI models and processes.
 :::
 
-::: {.w-50-ns}
-
-::: {.preview source="https://validmind.com/about/legal" height="240" width="430" offset="90"}
-:::
-
-:::
-
-::: {.w-50-ns}
+::: {.w-33-ns .mt3}
 
 ::: {.preview source="https://validmind.com/contact/" height="240" width="430" offset="90"}
 :::


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR updates our site footer & license agreement to automatically use the current year, which is what our main site uses, and fixes some links to our main site for the legal fine print. 

@mehdi0501 FYI

## Footer 

**Before**

![Capto_ 2025-04-23_02-46-04_pm](https://github.com/user-attachments/assets/f02c5982-1cf0-4262-a853-f3b5b32b950f)

**After**

![Capto_ 2025-04-23_02-45-33_pm](https://github.com/user-attachments/assets/397f394a-5a64-46ea-a481-1f1e329d6a75)


## License agreement

Now also uses the current year automatically: 

![Capto_ 2025-04-24_06-23-13_am](https://github.com/user-attachments/assets/10eec181-c624-4aef-a920-d7f43f73efd6)

## Links to the main site

These links were broken, now fixed: 

![Capto_ 2025-04-24_06-21-46_am](https://github.com/user-attachments/assets/780f527c-7af6-469e-b56c-7ab3f885d5d3)

Our data privacy topic now includes a new section that links users to the “Legal Ease” on our main site:

![Capto_ 2025-04-24_06-24-45_am](https://github.com/user-attachments/assets/7614bc2e-6e98-4855-b5a0-a748128eedd2)

Our LLM features topic had a preview to the "Legal Ease" that was broken, simplified with a new listing tile that contains the link:

![Capto_ 2025-04-24_06-27-22_am2](https://github.com/user-attachments/assets/07e1ad9d-1da1-49f6-8a44-92950dc424d9)

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `breaking-change`
- `deprecation`
- `bug`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->