### PR TITLE
Add Pa11y, Lighthouse, and Vale to CI checks — DO NOT TOUCH

### DIFF
--- a/.github/actions/lighthouse-check/.lighthouserc.js
+++ b/.github/actions/lighthouse-check/.lighthouserc.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+module.exports = {
+  ci: {
+    collect: {
+      staticDistDir: 'site/_site',
+      url: fs.readFileSync('lhci-urls.txt', 'utf-8').split('\n').filter(Boolean),
+    },
+    assert: {
+      assertions: {
+        'categories:accessibility': ['error', { minScore: 0.9 }],
+      },
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+}; 

--- a/.github/actions/lighthouse-check/action.yml
+++ b/.github/actions/lighthouse-check/action.yml
@@ -1,0 +1,51 @@
+name: 'Lighthouse Audit'
+description: 'Runs Lighthouse CI against a local docs site and outputs a report'
+
+inputs:
+  site_dir:
+    description: 'The directory to serve as the static site'
+    required: true
+    default: 'site/_site'
+  config_file:
+    description: 'Path to the Lighthouse CI config file'
+    required: true
+    default: '.lighthouserc.js'
+
+outputs:
+  accessibility_score:
+    description: 'Accessibility score from Lighthouse'
+    value: ${{ steps.lhci.outputs.accessibility_score }}
+  report_url:
+    description: 'Public Lighthouse report URL'
+    value: ${{ steps.lhci.outputs.report_url }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install Lighthouse CI
+      shell: bash
+      run: npm install -g @lhci/cli
+
+    - name: Run Lighthouse CI
+      id: lhci
+      shell: bash
+      run: |
+        output=$(lhci autorun --config="${{ inputs.config_file }}" 2>&1)
+        status=$?
+        # Extract accessibility score from the latest report
+        score=$(jq '.categories.accessibility.score' .lighthouseci/*report.json | head -n1)
+        echo "DEBUG: Extracted score: $score"
+        echo "accessibility_score=$score" >> $GITHUB_OUTPUT
+        # Extract public report URL
+        report_url=$(echo "$output" | grep -o 'https://storage.googleapis.com[^ ]*')
+        echo "DEBUG: Extracted report_url: $report_url"
+        echo "report_url=$report_url" >> $GITHUB_OUTPUT
+        if [ $status -ne 0 ]; then
+          echo "Lighthouse audit failed"
+          exit $status
+        fi 

--- a/.github/actions/pa11y-check/action.yml
+++ b/.github/actions/pa11y-check/action.yml
@@ -1,0 +1,48 @@
+name: 'Pa11y Accessibility Check'
+description: 'Runs Pa11y accessibility checks against the docs site and outputs a report'
+
+inputs:
+  site_url:
+    description: 'The URL of the site to check'
+    required: true
+  report_file:
+    description: 'Path to save the report file'
+    required: true
+    default: 'pa11y-report.json'
+
+outputs:
+  has_issues:
+    description: 'Whether any accessibility issues were found'
+    value: ${{ steps.pa11y.outputs.has_issues }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Pa11y
+      shell: bash
+      run: |
+        npm install -g pa11y-ci
+
+    - name: Run Pa11y check
+      id: pa11y
+      shell: bash
+      run: |
+        # Create a temporary configuration file with the necessary settings
+        echo '{
+          "defaults": {
+            "chromeLaunchConfig": {
+              "args": ["--no-sandbox"]
+            }
+          },
+          "urls": ["${{ inputs.site_url }}"]
+        }' > pa11y-config.json
+
+    # Run Pa11y and save results to file
+    pa11y-ci --config pa11y-config.json --json > "${{ inputs.report_file }}"
+
+    # Check if any issues were found
+    if grep -q '"type": "error"' "${{ inputs.report_file }}"; then
+      echo "has_issues=true" >> $GITHUB_OUTPUT
+    else
+      echo "has_issues=false" >> $GITHUB_OUTPUT
+    fi

--- a/.github/workflows/vale-lint.yaml
+++ b/.github/workflows/vale-lint.yaml
@@ -1,0 +1,98 @@
+name: Vale Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  vale:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Install Vale
+      run: |
+        wget https://github.com/errata-ai/vale/releases/download/v2.28.0/vale_2.28.0_Linux_64-bit.tar.gz
+        tar -xvzf vale_2.28.0_Linux_64-bit.tar.gz
+        sudo mv vale /usr/local/bin/
+
+    - name: Download Vale community styles
+      run: |
+        mkdir -p .vale/styles
+        vale sync
+
+    - name: Run Vale
+      id: vale
+      continue-on-error: true
+      run: |
+        vale --output=JSON site/ > vale-report.json || {
+          echo "Vale linting found issues"
+          exit 1
+        }
+
+    - name: Format Vale report for PR comment
+      run: jq . vale-report.json > vale-report-pretty.json
+
+    - name: Upload Vale report as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: vale-report
+        path: vale-report.json
+        retention-days: 1
+
+    - name: Post Vale results comment
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const runId = context.runId;
+          // Get artifacts for this run
+          const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: runId,
+          });
+          const valeArtifact = artifacts.artifacts.find(a => a.name === 'vale-report');
+          const valeArtifactUrl = valeArtifact
+            ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${valeArtifact.id}`
+            : null;
+          
+          const fs = require('fs');
+          const report = JSON.parse(fs.readFileSync('vale-report.json', 'utf8'));
+          const prettyReport = fs.readFileSync('vale-report-pretty.json', 'utf8');
+          
+          let comment = '## Vale source linter\n\n';
+          
+          if (Object.keys(report).length === 0) {
+            comment += `✓ INFO: No writing issues were found ([report](${valeArtifactUrl}))\n\n`;
+          } else {
+            comment += `⚠️ WARN: Source issues were found — Check the Vale output or [download the report](${valeArtifactUrl})\n\n`;
+
+            // Build the summary output
+            let summaryOutput = '';
+            for (const [file, issues] of Object.entries(report)) {
+              summaryOutput += `### ${file}\n`;
+              for (const issue of issues) {
+                summaryOutput += `- Line ${issue.Line}: ${issue.Message} (${issue.Severity})\n`;
+              }
+              summaryOutput += '\n';
+            }
+
+            // Add the summary output in a collapsed section
+            comment += `<details>\n<summary>Show Vale output</summary>\n\n`;
+            comment += '\n' + summaryOutput + '\n\n';
+            comment += `</details>\n\n`;
+          }
+
+          github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            body: comment
+          });

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -89,21 +89,168 @@ jobs:
           echo "No warnings or errors detected during Quarto render"
         fi
 
-      # Demo bucket is in us-east-1
+    # Demo bucket is in us-east-1
     - name: Configure AWS credentials
       run: aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID }} && aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY }} && aws configure set default.region us-east-1
 
     - name: Deploy PR preview
       run: aws s3 sync site/_site s3://docs-ci-cd-demo/site/pr_previews/${{ github.head_ref }} --delete && aws cloudfront create-invalidation --distribution-id E38AINJY5CYN6P --paths "/*" --no-cli-pager
 
-    - name: Post comment with preview URL
+    - name: Install Lighthouse CI
+      run: npm install -g @lhci/cli
+
+    - name: Debug Lighthouse files
+      run: |
+        echo "Files in site/_site:"
+        find site/_site -type f -name "*.html" | sort
+        echo -e "\nLighthouse will check these files:"
+        lhci collect --config=.lighthouserc.js --dry-run
+
+    - name: Run Pa11y accessibility check
+      id: pa11y
+      continue-on-error: true
+      env:
+        PUPPETEER_ARGS: --no-sandbox
+      run: |
+        npx pa11y-ci --json https://docs-demo.vm.validmind.ai/pr_previews/${{ github.head_ref }}/index.html > pa11y-report.json
+
+    - name: Upload Pa11y report as artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: pa11y-report
+        path: pa11y-report.json
+        retention-days: 1
+
+    - name: Post combined PR results comment
       uses: actions/github-script@v6
       with:
         script: |
-          const url = `https://docs-demo.vm.validmind.ai/pr_previews/${{ github.head_ref }}/index.html`;
+          const runId = context.runId;
+          const previewUrl = `https://docs-demo.vm.validmind.ai/pr_previews/${{ github.head_ref }}/index.html`;
+
+          // Get artifacts for this run
+          const { data: artifacts } = await github.rest.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: runId,
+          });
+
+          // Pa11y artifact
+          const pa11yArtifact = artifacts.artifacts.find(a => a.name === 'pa11y-report');
+          const pa11yArtifactUrl = pa11yArtifact
+            ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${pa11yArtifact.id}`
+            : null;
+
+          // Lighthouse artifact
+          const lighthouseArtifact = artifacts.artifacts.find(a => a.name === 'lighthouse-report');
+          const lighthouseArtifactUrl = lighthouseArtifact
+            ? `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${lighthouseArtifact.id}`
+            : null;
+
+          // Pa11y
+          const hasPa11yIssues = '${{ steps.pa11y.outputs.has_issues }}' === 'true';
+          let pa11yComment = '';
+          if (hasPa11yIssues) {
+            pa11yComment = `⚠️ WARN: Accessibility issues were found — [Download the Pa11y report](${pa11yArtifactUrl})`;
+          } else {
+            pa11yComment = `✓ INFO: No accessibility issues were found — [Download the Pa11y report](${pa11yArtifactUrl})`;
+          }
+
+          // Lighthouse
+          const lighthouseScore = '${{ steps.lighthouse_outputs.outputs.accessibility_score }}';
+          const lighthouseReportUrl = '${{ steps.lighthouse_outputs.outputs.report_url }}' || lighthouseArtifactUrl;
+          let lighthouseComment = '';
+          if (parseFloat(lighthouseScore) >= 0.9) {
+            lighthouseComment = `✓ INFO: Accessibility score is ${lighthouseScore} (required: >0.9) — [View the Lighthouse report](${lighthouseReportUrl})`; 
+          } else {
+            lighthouseComment = `⚠️ WARN: Accessibility score is ${lighthouseScore} (required: >0.9) — [Check the Lighthouse report](${lighthouseReportUrl})`;
+          }
+
+          // DEBUG block for Lighthouse outputs
+          let debugInfo = `<details>\n<summary>Show Lighthouse debug info</summary>\n\n`;
+          debugInfo += `Raw outputs from steps.lighthouse_outputs.outputs:\n`;
+          debugInfo += `- accessibility_score: \`${'${{ steps.lighthouse_outputs.outputs.accessibility_score }}'}\`\n`;
+          debugInfo += `- report_url: \`${'${{ steps.lighthouse_outputs.outputs.report_url }}'}\`\n`;
+          debugInfo += `- artifact url: \`${lighthouseArtifactUrl}\`\n`;
+          debugInfo += `- env.LHCI_BUILD_CONTEXT__CURRENT_HASH: \`${process.env.LHCI_BUILD_CONTEXT__CURRENT_HASH || 'undefined'}\`\n`;
+          debugInfo += `- env.LHCI_BUILD_CONTEXT__GITHUB_REPOSITORY: \`${process.env.LHCI_BUILD_CONTEXT__GITHUB_REPOSITORY || 'undefined'}\`\n`;
+          debugInfo += `</details>\n`;
+
+          let comment = `## Validate docs site\n\n`;
+          comment += `✓ INFO: A live preview of the docs site is available — [Open the preview](${previewUrl})\n\n`;
+          comment += `${pa11yComment}\n\n`;
+          comment += `${lighthouseComment}\n\n`;
+          comment += debugInfo;
+
           github.rest.issues.createComment({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
-            body: `A PR preview is available: [Preview URL](${url})`
+            body: comment
           });
+
+    - name: Generate Lighthouse URLs (up to 3 levels deep)
+      id: lhci_urls
+      run: |
+        BASE_URL="http://localhost:8080"
+        ROOTS=(
+          "index.html"
+          "get-started/get-started.html"
+          "guide/guides.html"
+          "developer/validmind-library.html"
+          "support/support.html"
+          "releases/all-releases.html"
+          "training/training.html"
+        )
+        URLS=()
+        for ROOT in "${ROOTS[@]}"; do
+          # Add the root page
+          if [ -f "site/_site/$ROOT" ]; then
+            URLS+=("$BASE_URL/${ROOT}")
+          fi
+          # Add child pages up to 3 levels deep
+          DIR=$(dirname "$ROOT")
+          if [ -d "site/_site/$DIR" ]; then
+            while IFS= read -r -d '' file; do
+              relpath="${file#site/_site/}"
+              URLS+=("$BASE_URL/$relpath")
+            done < <(find "site/_site/$DIR" -mindepth 1 -maxdepth 3 -type f -name "*.html" -print0)
+          fi
+        done
+        # Remove duplicates and write to file
+        printf "%s\n" "${URLS[@]}" | sort -u > lhci-urls.txt
+        echo "Lighthouse will check the following URLs:"
+        cat lhci-urls.txt
+
+    - name: Run Lighthouse audit
+      uses: treosh/lighthouse-ci-action@v11
+      id: lighthouse
+      continue-on-error: true
+      with:
+        configPath: .github/actions/lighthouse-check/.lighthouserc.js
+        uploadArtifacts: true
+        temporaryPublicStorage: true
+
+    - name: Extract Lighthouse outputs
+      id: lighthouse_outputs
+      run: |
+        # Get the links JSON and manifest from the previous step
+        LINKS_JSON='${{ steps.lighthouse.outputs.links }}'
+        MANIFEST_JSON='${{ steps.lighthouse.outputs.manifest }}'
+        # Extract the report URL for index.html
+        REPORT_URL=$(echo "$LINKS_JSON" | jq -r 'to_entries[] | select(.key | test("/index.html$")) | .value')
+        # Extract the JSON path for index.html from the manifest
+        INDEX_JSON_PATH=$(echo "$MANIFEST_JSON" | jq -r '.[] | select(.url | test("/index.html$")) | .jsonPath')
+        # Extract the accessibility score for index.html
+        SCORE=$(jq '.summary.accessibility' "$INDEX_JSON_PATH")
+        echo "accessibility_score=$SCORE" >> $GITHUB_OUTPUT
+        echo "report_url=$REPORT_URL" >> $GITHUB_OUTPUT
+        echo "Extracted score: $SCORE"
+        echo "Extracted report URL: $REPORT_URL"
+
+    - name: Output Lighthouse scores for all pages
+      run: |
+        MANIFEST_JSON='${{ steps.lighthouse.outputs.manifest }}'
+        echo "| Page | Accessibility | Performance | Best Practices | SEO |"
+        echo "|------|---------------|-------------|----------------|-----|"
+        echo "$MANIFEST_JSON" | jq -r '.[] | "| \(.url | sub("http://localhost:8080/"; "/")) | \(.summary.accessibility) | \(.summary.performance) | \(.summary[\"best-practices\"]) | \(.summary.seo) |"' | sort

--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -1,0 +1,15 @@
+module.exports = {
+  ci: {
+    collect: {
+      staticDistDir: 'site/_site',
+    },
+    assert: {
+      assertions: {
+        'categories:accessibility': ['error', { minScore: 0.9 }],
+      },
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+}; 

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = .vale/styles
+MinAlertLevel = suggestion
+
+[*.{md,yml,yaml}]
+BasedOnStyles = Vale 


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR includes a triad of new checks to get better data on our docs site source and static HTML output:

- Pa11y — audits static HTML for accessibility issues using WCAG standards
- Lighthouse CLI — runs accessibility, performance, and SEO checks via headless Chrome
- Vale linter — enforces style and clarity rules in Markdown and text content

These checks partially overlap, e.g. Pa11y is tailored towards accessibility checks but Lighthouse also offers some accessibility checking. The two tools use different methods, though, with Lighthouse using axe-core under the covers for accessibility. Vale I threw in because I've been curious about the state of our source.  

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `breaking-change`
- `deprecation`
- `bug`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->