### PR TITLE
hotfix: -`include-after-body` in execution profiles

### DIFF
--- a/site/_quarto-exe-demo.yml
+++ b/site/_quarto-exe-demo.yml
@@ -5,8 +5,6 @@ format:
     code-tools: true
     include-in-header: 
       - environments/heap-development.html
-    include-after-body: 
-      - https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js
 execute: 
   enabled: true
   freeze: auto

--- a/site/_quarto-exe-prod.yml
+++ b/site/_quarto-exe-prod.yml
@@ -5,8 +5,6 @@ format:
     code-tools: true
     include-in-header: 
       - environments/heap-production.html
-    include-after-body: 
-      - https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js
 execute: 
   enabled: true
   freeze: auto

--- a/site/_quarto-exe-staging.yml
+++ b/site/_quarto-exe-staging.yml
@@ -5,8 +5,6 @@ format:
     code-tools: true
     include-in-header: 
       - environments/heap-staging.html
-    include-after-body: 
-      - https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js
 execute: 
   enabled: true
   freeze: auto


### PR DESCRIPTION
## Internal Notes for Reviewers

The latest version of Quarto breaks our existing notebook execution workflow, as it fixed a workaround dependency with the `jupyter-widgets` package:

```bash
FATAL (/opt/quarto/share/filters/main.lua:3977) An error occurred:
Error resolving include-after- unable to open file https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js
```

> **[Broken workflow run](https://github.com/validmind/documentation/actions/runs/14936423749/job/41964785160?pr=712)** — Attached to this attempt to merge `staging` to `prod` last week: https://github.com/validmind/documentation/pull/712

Removing this explicit embed from the execution profiles solves the issue in my testing:

```yaml
    include-after-body: 
      - https://unpkg.com/@jupyter-widgets/html-manager@*/dist/embed-amd.js
```

> **[Fixed workflow run](https://github.com/validmind/documentation/actions/runs/14981402313)** — This is attached to the draft PR https://github.com/validmind/documentation/pull/713 where [these fixes were also applied](https://github.com/validmind/documentation/pull/713/files#diff-23f8df4233eb132dac56e98e22ec17a8564998869c941258331bbc2ab3ce2759). 
 
