### PR TITLE
infra: Remove conditional execution for staging and prod

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -50,7 +50,6 @@ jobs:
 
       # If yes then create the dev.env file for use in execution step
       - name: Create dev.env file
-        if: steps.filter.outputs.notebooks == 'true'
         id: create_dev_env
         run: |
           touch dev.env
@@ -62,7 +61,6 @@ jobs:
 
       # If yes then create the valid.env file for use in execution step
       - name: Create valid.env file
-        if: steps.filter.outputs.notebooks == 'true'
         id: create_valid_env
         run: |
           touch valid.env

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -40,7 +40,6 @@ jobs:
 
       # If yes then create the dev.env file for use in execution step
       - name: Create dev.env file
-        if: steps.filter.outputs.notebooks == 'true'
         id: create_dev_env
         run: |
           touch dev.env
@@ -52,7 +51,6 @@ jobs:
 
       # If yes then create the valid.env file for use in execution step
       - name: Create valid.env file
-        if: steps.filter.outputs.notebooks == 'true'
         id: create_valid_env
         run: |
           touch valid.env


### PR DESCRIPTION
## Internal Notes for Reviewers

I forgot to remove the conditional steps for the staging and production workflows, which affected the execution for the notebooks out to staging and prod:

- [Staging workflow](https://github.com/validmind/documentation/actions/runs/15169920006/job/42657142575)
- [Production workflow](https://github.com/validmind/documentation/actions/runs/15174567966/job/42672177641)

I've removed the conditionals for a step that doesn't actually exist, and now staging and production should always execute the training notebooks as expected.