### PR TITLE
+ IF condition for workflow success in deploy to staging & prod

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   deploy:
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   deploy:
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Internal Notes for Reviewers

> sc-10537

### Problem

Currently, deploy docs staging which relies on "Merge main into staging" runs even when that workflow fails, meaning that it doesn't actually deploy the changes:

- [Failed workflow](https://github.com/validmind/documentation/actions/runs/15306334463/job/43059925026) (Due to GitHub blip, re-running fixed the issue)
- [Deployment associated with failed workflow](https://github.com/validmind/documentation/actions/runs/15306346843)

### Solution

Deployment steps should only happen if a push or merge workflow is successful thanks to this IF condition at the job level:

https://github.com/validmind/documentation/blob/a2674f9a995c8682cef9668174a04748d8d83c28/.github/workflows/deploy-docs-prod.yaml#L15

```yaml
if: |
  github.event_name == 'push' ||
  (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
  github.event_name == 'workflow_dispatch'
```

I also applied the same logic to `prod`, even though we don't have a deploy prod workflow at the moment (but we may in the future when everything is more automated). 

### Testing

Unfortunately the only way to test this is to merge this PR and watch the workflows run.