### PR TITLE
Fix links in training faq

### DIFF
--- a/site/training/program/training-faq.qmd
+++ b/site/training/program/training-faq.qmd
@@ -170,7 +170,6 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](#){.button-small}
 [{{< fa book-open >}} docs](/guide/model-inventory/register-models-in-inventory.qmd){.button-small}
 :::
 

--- a/site/training/program/training-faq.qmd
+++ b/site/training/program/training-faq.qmd
@@ -170,7 +170,8 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training]<!--(https://docs.validmind.ai/training/developer-fundamentals/using-validmind-for-model-development.html#/section-4)-->{.button-small} [{{< fa book-open >}} docs](/guide/model-inventory/register-models-in-inventory.qmd){.button-small}
+[{{< fa graduation-cap >}} training](#){.button-small}
+[{{< fa book-open >}} docs](/guide/model-inventory/register-models-in-inventory.qmd){.button-small}
 :::
 
 ::::

--- a/site/training/program/training-faq.qmd
+++ b/site/training/program/training-faq.qmd
@@ -18,7 +18,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-inventory/managing-model-inventory.html){.button-small target="blank"}
+[{{< fa book-open >}} docs](/guide/model-inventory/configure-model-interdependencies.qmd){.button-small}
 :::
 
 ::::
@@ -30,7 +30,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-inventory/manage-inventory-custom-fields.html){.button-small target="blank"}
+[{{< fa book-open >}} docs](/guide/model-inventory/manage-model-inventory-fields.qmd){.button-small}
 :::
 
 ::::
@@ -44,7 +44,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-4){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/manage-users.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-4){.button-small} [{{< fa book-open >}} docs](/guide/configuration/manage-users.qmd){.button-small}
 :::
 
 ::::
@@ -56,7 +56,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-6){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/manage-users.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-6){.button-small} [{{< fa book-open >}} docs](/guide/configuration/manage-users.qmd){.button-small}
 :::
 
 ::::
@@ -68,7 +68,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-4){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/manage-roles.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-4){.button-small} [{{< fa book-open >}} docs](/guide/configuration/manage-roles.qmd){.button-small}
 :::
 
 ::::
@@ -80,7 +80,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-4){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/manage-groups.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-4){.button-small} [{{< fa book-open >}} docs](/guide/configuration/manage-groups.qmd){.button-small}
 :::
 
 ::::
@@ -94,7 +94,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-12){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-workflows/working-with-model-workflows.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-12){.button-small} [{{< fa book-open >}} docs](/guide/model-workflows/working-with-model-workflows.qmd){.button-small}
 :::
 
 ::::
@@ -106,7 +106,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-12){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-workflows/set-up-model-workflows.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/administrator-fundamentals/administrator-fundamentals.html#/section-12){.button-small} [{{< fa book-open >}} docs](/guide/model-workflows/set-up-model-workflows.qmd){.button-small}
 :::
 
 ::::
@@ -118,7 +118,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} docs](https://docs.validmind.ai/guide/manage-roles.html){.button-small target="blank"}
+[{{< fa book-open >}} docs](/guide/configuration/manage-roles.qmd){.button-small}
 :::
 
 ::::
@@ -132,7 +132,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-documentation/customize-documentation-templates.html){.button-small target="blank"}
+[{{< fa book-open >}} docs](/guide/templates/customize-documentation-templates.qmd){.button-small}
 :::
 
 ::::
@@ -144,7 +144,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-documentation/customize-documentation-templates.html){.button-small target="blank"}
+[{{< fa book-open >}} docs](/guide/templates/customize-documentation-templates.qmd){.button-small}
 :::
 
 ::::
@@ -156,7 +156,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-documentation/customize-documentation-templates.html){.button-small target="blank"}
+[{{< fa book-open >}} docs](/guide/templates/swap-documentation-templates.qmd){.button-small}
 :::
 
 ::::
@@ -170,7 +170,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/developer-fundamentals/developer-fundamentals.html){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-inventory/register-models-in-inventory.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training]<!--(https://docs.validmind.ai/training/developer-fundamentals/using-validmind-for-model-development.html#/section-4)-->{.button-small} [{{< fa book-open >}} docs](/guide/model-inventory/register-models-in-inventory.qmd){.button-small}
 :::
 
 ::::
@@ -182,7 +182,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/developer-fundamentals/developer-fundamentals.html){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/developers/documenting-models.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/developer-fundamentals/learning-to-run-tests.html#/section-8){.button-small} [{{< fa book-open >}} docs](/guide/model-documentation/working-with-model-documentation.qmd){.button-small}
 :::
 
 ::::
@@ -194,7 +194,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/developer-fundamentals/developer-fundamentals.html){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-documentation/submit-for-approval.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/developer-fundamentals/finalizing-model-documentation.html#/section-4){.button-small} [{{< fa book-open >}} docs](/guide/model-documentation/submit-for-approval.qmd){.button-small}
 :::
 
 ::::
@@ -208,7 +208,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/developer-fundamentals/developer-fundamentals.html){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/developers/run-tests-and-test-suites.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/developer-fundamentals/implementing-custom-tests.html#/section-5){.button-small} [{{< fa book-open >}} docs](/guide/model-documentation/work-with-test-results.qmd){.button-small}
 :::
 
 ::::
@@ -220,7 +220,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/developer-fundamentals/developer-fundamentals.html){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/developers/run-tests-and-test-suites.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/developer-fundamentals/implementing-custom-tests.html#/section-9){.button-small} [{{< fa book-open >}} docs](/guide/model-documentation/work-with-test-results.qmd){.button-small}
 :::
 
 ::::
@@ -234,7 +234,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/validator-fundamentals/validator-fundamentals.html#/prepare-validation-reports){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-validation/working-with-model-findings.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/validator-fundamentals/using-validmind-for-model-validation.html#/section-7){.button-small} [{{< fa book-open >}} docs](/guide/model-validation/preparing-validation-reports.qmd){.button-small}
 :::
 
 ::::
@@ -246,7 +246,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/validator-fundamentals/validator-fundamentals.html#/submit-for-review-and-approval){.button-small target="blank"} [{{< fa book-open >}} docs](https://docs.validmind.ai/guide/model-documentation/submit-for-approval.html){.button-small target="blank"}
+[{{< fa graduation-cap >}} training](https://docs.validmind.ai/training/validator-fundamentals/finalizing-validation-reports.html#/section-12){.button-small} [{{< fa book-open >}} docs](/guide/model-documentation/submit-for-approval.qmd){.button-small}
 :::
 
 ::::
@@ -260,7 +260,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} docs](https://docs.validmind.ai/guide/monitoring/enable-monitoring.html){.button-small target="blank"}
+[{{< fa book-open >}} docs](/guide/monitoring/enable-monitoring.qmd){.button-small}
 :::
 
 ::::
@@ -272,7 +272,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} docs](https://docs.validmind.ai/guide/monitoring/ongoing-monitoring.html){.button-small target="blank"}
+[{{< fa book-open >}} docs](/guide/monitoring/ongoing-monitoring.qmd){.button-small}
 :::
 
 ::::
@@ -284,7 +284,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} docs](https://docs.validmind.ai/guide/monitoring/work-with-metrics-over-time.html){.button-small target="blank"}
+[{{< fa book-open >}} docs](/guide/monitoring/work-with-metrics-over-time.qmd){.button-small}
 :::
 
 ::::
@@ -298,7 +298,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa book-open >}} code sample](https://docs.validmind.ai/notebooks/code_samples/nlp_and_llm/llm_summarization_demo.html#initialize-the-python-environment){.button-small target="blank"}
+[{{< fa book-open >}} code sample](/notebooks/code_samples/nlp_and_llm/llm_summarization_demo.ipynb#initialize-the-python-environment){.button-small}
 :::
 
 ::::
@@ -310,7 +310,7 @@ Here's what we have been asked about {{< var vm.product >}} during training sess
 :::
 
 ::: {.w-40-ns .nb3 .pl2}
-[{{< fa brands python >}} pandas docs](https://pandas.pydata.org/docs/getting_started/intro_tutorials/02_read_write.html){.button-small target="blank"}
+[{{< fa brands python >}} pandas docs](https://pandas.pydata.org/docs/getting_started/intro_tutorials/02_read_write.html){.button-small}
 :::
 
 ::::


### PR DESCRIPTION
## Internal Notes for Reviewers
https://app.shortcut.com/validmind/story/10752/fix-links-in-training-faq
### **Summary**
I changed the HTML links in our page to QMD files.
Some buttons (both training and docs) are linked to the same pages (not sure if it was intended)

### How to test
Since the online preview won't display the notebook iFrames correctly (it pulls the relative link from the root of the docs-demo repo rather than the PR branch):

1. Grab this PR: gh pr checkout 747

2. Make sure you're in the site directory if you're not already: cd site

3. Pull up a live preview: quarto preview
Review the training FAQ homepage (you might need to add the path of it right after preview to access it easily)

