### PR TITLE
workaround: Disabling notebook execution

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -53,36 +53,35 @@ jobs:
             }
             make generate-sitemap
 
-      # If yes then create the dev.env file for use in execution step
-      - name: Create dev.env file
-        id: create_dev_env
-        run: |
-          touch dev.env
-          echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> dev.env
-          echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> dev.env
-          echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> dev.env
-          echo VM_API_MODEL=${{ secrets.PLATFORM_DEV_MODEL }} >> dev.env
-          cat dev.env
+      # - name: Create dev.env file
+      #   id: create_dev_env
+      #   run: |
+      #     touch dev.env
+      #     echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> dev.env
+      #     echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> dev.env
+      #     echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> dev.env
+      #     echo VM_API_MODEL=${{ secrets.PLATFORM_DEV_MODEL }} >> dev.env
+      #     cat dev.env
 
       # If yes then create the valid.env file for use in execution step
-      - name: Create valid.env file
-        id: create_valid_env
-        run: |
-          touch valid.env
-          echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> valid.env
-          echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> valid.env
-          echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> valid.env
-          echo VM_API_MODEL=${{ secrets.PLATFORM_VALID_MODEL }} >> valid.env
-          cat valid.env
+      # - name: Create valid.env file
+      #   id: create_valid_env
+      #   run: |
+      #     touch valid.env
+      #     echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> valid.env
+      #     echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> valid.env
+      #     echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> valid.env
+      #     echo VM_API_MODEL=${{ secrets.PLATFORM_VALID_MODEL }} >> valid.env
+      #     cat valid.env
 
       # Only execute the production notebooks for training if .env files are created
-      - name: Execute production ValidMind for model development and validation series
-        if: ${{ steps.create_dev_env.outcome == 'success' && steps.create_valid_env.outcome == 'success' }}
-        uses: ./.github/actions/prod-notebook
-        id: execute-prod-notebook
-        with:
-          dev_env: dev.env
-          valid_env: valid.env
+      # - name: Execute production ValidMind for model development and validation series
+      #   if: ${{ steps.create_dev_env.outcome == 'success' && steps.create_valid_env.outcome == 'success' }}
+      #   uses: ./.github/actions/prod-notebook
+      #   id: execute-prod-notebook
+      #   with:
+      #     dev_env: dev.env
+      #     valid_env: valid.env
 
       # Prod bucket is in us-east-1
       - name: Configure AWS credentials

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -43,36 +43,35 @@ jobs:
             }
             make generate-sitemap
 
-      # If yes then create the dev.env file for use in execution step
-      - name: Create dev.env file
-        id: create_dev_env
-        run: |
-          touch dev.env
-          echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> dev.env
-          echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> dev.env
-          echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> dev.env
-          echo VM_API_MODEL=${{ secrets.PLATFORM_DEV_MODEL }} >> dev.env
-          cat dev.env
+      # - name: Create dev.env file
+      #   id: create_dev_env
+      #   run: |
+      #     touch dev.env
+      #     echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> dev.env
+      #     echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> dev.env
+      #     echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> dev.env
+      #     echo VM_API_MODEL=${{ secrets.PLATFORM_DEV_MODEL }} >> dev.env
+      #     cat dev.env
 
       # If yes then create the valid.env file for use in execution step
-      - name: Create valid.env file
-        id: create_valid_env
-        run: |
-          touch valid.env
-          echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> valid.env
-          echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> valid.env
-          echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> valid.env
-          echo VM_API_MODEL=${{ secrets.PLATFORM_VALID_MODEL }} >> valid.env
-          cat valid.env
+      # - name: Create valid.env file
+      #   id: create_valid_env
+      #   run: |
+      #     touch valid.env
+      #     echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> valid.env
+      #     echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> valid.env
+      #     echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> valid.env
+      #     echo VM_API_MODEL=${{ secrets.PLATFORM_VALID_MODEL }} >> valid.env
+      #     cat valid.env
 
       # Only execute the staging notebooks for training if .env files are created
-      - name: Execute staging ValidMind for model development and validation series
-        if: ${{ steps.create_dev_env.outcome == 'success' && steps.create_valid_env.outcome == 'success' }}
-        uses: ./.github/actions/staging-notebook
-        id: execute-staging-notebook
-        with:
-          dev_env: dev.env
-          valid_env: valid.env
+      # - name: Execute staging ValidMind for model development and validation series
+      #   if: ${{ steps.create_dev_env.outcome == 'success' && steps.create_valid_env.outcome == 'success' }}
+      #   uses: ./.github/actions/staging-notebook
+      #   id: execute-staging-notebook
+      #   with:
+      #     dev_env: dev.env
+      #     valid_env: valid.env
 
       # Staging bucket is in us-west-2
       - name: Configure AWS credentials

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -47,50 +47,51 @@ jobs:
           exit 1;
           }
           make generate-sitemap
+
     # See if site/notebooks/ has updates
     # Checks the current PR branch against the target branch
-    - name: Filter changed files
-      uses: dorny/paths-filter@v2
-      id: filter
-      with:
-        base: ${{ github.event.pull_request.base_ref }}
-        ref: ${{ github.head_ref }}
-        filters: |
-          notebooks:
-            - 'site/notebooks/EXECUTED/**'
+    # - name: Filter changed files
+    #   uses: dorny/paths-filter@v2
+    #   id: filter
+    #   with:
+    #     base: ${{ github.event.pull_request.base_ref }}
+    #     ref: ${{ github.head_ref }}
+    #     filters: |
+    #       notebooks:
+    #         - 'site/notebooks/EXECUTED/**'
 
     # If yes then create the dev.env file for use in execution step
-    - name: Create dev.env file
-      if: steps.filter.outputs.notebooks == 'true'
-      id: create_dev_env
-      run: |
-        touch dev.env
-        echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> dev.env
-        echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> dev.env
-        echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> dev.env
-        echo VM_API_MODEL=${{ secrets.PLATFORM_DEV_MODEL }} >> dev.env
-        cat dev.env
+    # - name: Create dev.env file
+    #   if: steps.filter.outputs.notebooks == 'true'
+    #   id: create_dev_env
+    #   run: |
+    #     touch dev.env
+    #     echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> dev.env
+    #     echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> dev.env
+    #     echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> dev.env
+    #     echo VM_API_MODEL=${{ secrets.PLATFORM_DEV_MODEL }} >> dev.env
+    #     cat dev.env
 
     # If yes then create the valid.env file for use in execution step
-    - name: Create valid.env file
-      if: steps.filter.outputs.notebooks == 'true'
-      id: create_valid_env
-      run: |
-        touch valid.env
-        echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> valid.env
-        echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> valid.env
-        echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> valid.env
-        echo VM_API_MODEL=${{ secrets.PLATFORM_VALID_MODEL }} >> valid.env
-        cat valid.env
+    # - name: Create valid.env file
+    #   if: steps.filter.outputs.notebooks == 'true'
+    #   id: create_valid_env
+    #   run: |
+    #     touch valid.env
+    #     echo VM_API_HOST=${{ secrets.PLATFORM_API_HOST }} >> valid.env
+    #     echo VM_API_KEY=${{ secrets.PLATFORM_API_KEY }} >> valid.env
+    #     echo VM_API_SECRET=${{ secrets.PLATFORM_API_SECRET }} >> valid.env
+    #     echo VM_API_MODEL=${{ secrets.PLATFORM_VALID_MODEL }} >> valid.env
+    #     cat valid.env
 
     # Only execute the demo notebooks for training if .env files are created
-    - name: Execute demo ValidMind for model development and validation series
-      if: ${{ vars.ENABLE_DEMO_NOTEBOOK == 'true' && steps.create_dev_env.outcome == 'success' && steps.create_valid_env.outcome == 'success' }}
-      uses: ./.github/actions/demo-notebook
-      id: execute-demo-notebook
-      with:
-        dev_env: dev.env
-        valid_env: valid.env
+    # - name: Execute demo ValidMind for model development and validation series
+    #   if: ${{ vars.ENABLE_DEMO_NOTEBOOK == 'true' && steps.create_dev_env.outcome == 'success' && steps.create_valid_env.outcome == 'success' }}
+    #   uses: ./.github/actions/demo-notebook
+    #   id: execute-demo-notebook
+    #   with:
+    #     dev_env: dev.env
+    #     valid_env: valid.env
 
     - name: Test for warnings or errors
       run: |


### PR DESCRIPTION
## Internal Notes for Reviewers

Workflow for executing notebooks is throwing weird dependency errors I haven't been able to resolve in 2+ days, so in the meantime let's turn them off so we can unbreak our staging and prod pushes.

The notebooks will still display, just won't have the widget outputs. Proof:

### Development series

- [One](https://docs-demo.vm.validmind.ai/pr_previews/beck/turning-off-execution/notebooks/EXECUTED/model_development/1-set_up_validmind.html)
- [Two](https://docs-demo.vm.validmind.ai/pr_previews/beck/turning-off-execution/notebooks/EXECUTED/model_development/2-start_development_process.html)
- [Three](https://docs-demo.vm.validmind.ai/pr_previews/beck/turning-off-execution/notebooks/EXECUTED/model_development/3-integrate_custom_tests.html)
- [Four](https://docs-demo.vm.validmind.ai/pr_previews/beck/turning-off-execution/notebooks/EXECUTED/model_development/4-finalize_testing_documentation.html)

### Validation series

- [One](https://docs-demo.vm.validmind.ai/pr_previews/beck/turning-off-execution/notebooks/EXECUTED/model_validation/1-set_up_validmind_for_validation.html)
- [Two](https://docs-demo.vm.validmind.ai/pr_previews/beck/turning-off-execution/notebooks/EXECUTED/model_validation/2-start_validation_process.html)
- [Three](https://docs-demo.vm.validmind.ai/pr_previews/beck/turning-off-execution/notebooks/EXECUTED/model_validation/3-developing_challenger_model.html)
- [Four](https://docs-demo.vm.validmind.ai/pr_previews/beck/turning-off-execution/notebooks/EXECUTED/model_validation/4-finalize_validation_reporting.html)