### PR TITLE
Change cookie consent to implied

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -17,7 +17,7 @@ website:
   favicon: validmind.png
   title: "ValidMind"
   cookie-consent:
-    type: express
+    type: implied
     style: simple
   google-analytics: 
     tracking-id: "G-S46CKWPNSS"


### PR DESCRIPTION
## Internal Notes for Reviewers

This PR changes our cookie consent from express to implied, meaning users can still change their cookie preferences but they do not get prompted. The purpose of this change is to test the impact on our accessibility score. 

Note the lighthouse check seems to be failing in some PRs, might need to fix.

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `breaking-change`
- `deprecation`
- `bug`
- `documentation`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## External Release Notes

<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->