### PR TITLE
Hotfix: troubleshooting.qmd render

### DIFF
--- a/site/support/troubleshooting.qmd
+++ b/site/support/troubleshooting.qmd
@@ -64,6 +64,7 @@ Make sure that you are using the correct initialization credentials for the mode
 Follow the steps in [Install and initialize the {{< var validmind.developer >}}](/developer/model-documentation/install-and-initialize-validmind-library.qmd) for detailed instructions on how to integrate the {{< var vm.developer >}} and upload to the {{< var vm.platform >}}.
 
 <span id="how-to-upgrade"><span>
+
 {{< include /releases/_how-to-upgrade.qmd >}}
 
 ## Additional resources


### PR DESCRIPTION
# Pull Request Description

We were missing space before our include file on `support/troubleshooting.qmd` causing a warning when that page was rendered. This is outlined as a requirement by Quarto:

![Screenshot 2025-07-02 at 1 32 05 PM](https://github.com/user-attachments/assets/008d7768-bfa8-488e-a421-b36f387d446b)

**Before:**

![Screenshot 2025-07-02 at 1 30 20 PM](https://github.com/user-attachments/assets/c7f341e9-4e97-436f-889e-fa36b9b81ef2)

**After:**

![Screenshot 2025-07-02 at 1 30 33 PM](https://github.com/user-attachments/assets/a7787f19-8d0c-417b-a361-33e0235e276c)
