### PR TITLE
docs: Manage model finding fields

### DIFF
--- a/site/guide/_sidebar.yaml
+++ b/site/guide/_sidebar.yaml
@@ -81,6 +81,7 @@ website:
         - file: guide/model-validation/managing-model-validation.qmd
           contents:
           - guide/model-validation/manage-validation-guidelines.qmd
+          - guide/model-validation/manage-model-finding-fields.qmd
           - guide/model-validation/manage-finding-statuses.qmd
         - file: guide/model-validation/preparing-validation-reports.qmd
           contents:

--- a/site/guide/model-inventory/_add-edit-inventory-fields.qmd
+++ b/site/guide/model-inventory/_add-edit-inventory-fields.qmd
@@ -9,7 +9,7 @@ To add a new field, click **{{< fa plus >}} Add Field**:
 a. Fields require a [type]{.smallcaps},^[[Field types](#field-types)] a [name]{.smallcaps}, and a [description]{.smallcaps}.
 
     - (Optional) You can also choose to indicate that a field is **[required on registration]{.smallcaps}**.
-    - (Optional) You can also assign **[write permissions]{.smallcaps}** to allow granular access to editing this field gated by model stakeholder types.[^edit-fields]
+    - Assign **[write permissions]{.smallcaps}** to allow granular access to editing this field gated by model stakeholder types.[^edit-fields]
 
 a. When you are satisfied with the setup of your field, click **Save**.
 
@@ -31,8 +31,8 @@ a. Make your desired changes to your field, then click **Save**.
 [^edit-fields]:
 
     ::: {.callout title="Leave this field blank to leave permissions as default."}
-    - By default, model owners and validators have write access. 
-    - Model developers have read-only access. 
+    - By default, only the <br>[{{< fa hand >}} Customer Admin]{.bubble} role has write access.
+    - All other users will have read-only access unless specified under the **[write permissions]{.smallcaps}** as a model stakeholder type.
 
     ::: {.tc}
     [Manage model stakeholder types](/guide/configuration/manage-model-stakeholder-types.qmd)
@@ -54,7 +54,7 @@ a. Make your desired changes to your field, then click **Save**.
 1. Fields require a [type]{.smallcaps}, a [name]{.smallcaps}, and a [description]{.smallcaps}.
 
     - (Optional) You can also choose to indicate that a field is **[required on registration]{.smallcaps}**.
-    - (Optional) You can also assign **[write permissions]{.smallcaps}** to allow granular access to editing this field gated by model stakeholder types.
+    - Assign **[write permissions]{.smallcaps}** to allow granular access to editing this field gated by model stakeholder types.
 
 1. When you are satisfied with the setup of your field, click **Save**.
 

--- a/site/guide/model-inventory/_add-edit-inventory-fields.qmd
+++ b/site/guide/model-inventory/_add-edit-inventory-fields.qmd
@@ -2,22 +2,24 @@
 
 ::: {.panel-tabset}
 
-#### Add inventory field
+#### Add field
+
 To add a new field, click **{{< fa plus >}} Add Field**:
 
-a. Fields require a [type]{.smallcaps},^[[Inventory field types](/guide/model-inventory/manage-model-inventory-fields.qmd#inventory-field-types)] a [name]{.smallcaps}, and a [description]{.smallcaps}.
+a. Fields require a [type]{.smallcaps},^[[Field types](#field-types)] a [name]{.smallcaps}, and a [description]{.smallcaps}.
 
     - (Optional) You can also choose to indicate that a field is **[required on registration]{.smallcaps}**.
     - (Optional) You can also assign **[write permissions]{.smallcaps}** to allow granular access to editing this field gated by model stakeholder types.[^edit-fields]
 
 a. When you are satisfied with the setup of your field, click **Save**.
 
-#### Edit inventory field
+#### Edit field
+
 To edit an existing field:
 
 a. Hover over the field you would like to edit.
 
-a. When the **{{< fa ellipsis-vertical >}}** appears under the Actions column,, select **{{< fa pencil >}} Edit**.
+a. When the **{{< fa ellipsis-vertical >}}** appears under the Actions column, select **{{< fa pencil >}} Edit Details**.
 
 a. Make your desired changes to your field, then click **Save**.
 

--- a/site/guide/model-inventory/manage-model-inventory-fields.qmd
+++ b/site/guide/model-inventory/manage-model-inventory-fields.qmd
@@ -28,6 +28,7 @@ aliases:
 {{< include /guide/model-inventory/_add-edit-inventory-fields.qmd >}}
 
 #### Inventory field types
+<span id="field-types"></span>
 
 {{< include /guide/model-inventory/_inventory-field-types.qmd >}}
 

--- a/site/guide/model-validation/manage-model-finding-fields.qmd
+++ b/site/guide/model-validation/manage-model-finding-fields.qmd
@@ -1,0 +1,50 @@
+---
+title: "Manage model finding fields"
+date: last-modified
+---
+
+{{< include /guide/model-inventory/_model-inventory-fields.qmd >}}
+
+::: {.attn}
+
+## Prerequisites
+
+- [x] {{< var link.login >}}
+- [x] You are a [{{< fa hand >}} Customer Admin]{.bubble} or assigned another role with sufficient permissions to perform the tasks in this guide.[^1]
+
+:::
+
+## Add or edit inventory fields
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+2. Under Models, select **Model Inventory Fields**.
+
+    Here you can edit existing inventory fields, or add a new one:
+
+{{< include /guide/model-inventory/_add-edit-inventory-fields.qmd >}}
+
+#### Inventory field types
+
+{{< include /guide/model-inventory/_inventory-field-types.qmd >}}
+
+## Delete inventory fields
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+2. Under Models, select **Model Inventory Fields**.
+
+3. Hover over the field you would like to delete.
+
+4. When the **{{< fa ellipsis-vertical >}}** appears under the Actions column, click on it and select [**{{< fa trash-can >}} Delete Field**]{.red}.
+
+5. After you confirm, the field will be removed.
+
+## What's next
+
+- [Working with the model inventory](working-with-model-inventory.qmd)
+
+
+<!-- FOOTNOTES -->
+
+[^1]: [Manage permissions](/guide/configuration/manage-permissions.qmd)

--- a/site/guide/model-validation/manage-model-finding-fields.qmd
+++ b/site/guide/model-validation/manage-model-finding-fields.qmd
@@ -18,21 +18,79 @@ Create and edit the fields that appear on findings logged on your models. Choose
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-2. Under Models, select **Model Inventory Fields**.
+2. Under Findings, select **Finding Fields**.
 
-    Here you can edit existing inventory fields, or add a new one:
+    Here you can edit existing finding fields, or add a new one:
 
 {{< include /guide/model-inventory/_add-edit-inventory-fields.qmd >}}
 
 #### Finding field types
+<span id="field-types"></span>
 
-{{< include /guide/model-inventory/_inventory-field-types.qmd >}}
+Single Line Text
+: Simple text value.
+
+Attachments
+: Upload supporting files for your model.^[[Manage supporting documentation](/guide/model-inventory/edit-model-inventory-fields.qmd#manage-supporting-documentation)] Files must be less than 50 MB each in size.
+
+Long Text
+: Toggle **Enable rich text formatting** to create a template using the rich text editor.
+
+Single Select
+: Click **{{< fa plus >}} Add Option** to define a list of options.
+
+Multiple Select
+: Click **{{< fa plus >}} Add Option** to define a list of options. 
+
+Checkbox
+: A `true`/`false` value set by a toggle.
+
+Number
+: Text value in valid number format. Number display (comma, fullstop, etc.) is determined by your browser's locale. Select a **[number type]{.smallcaps}**:
+
+- **Simple** — Define the [decimal places]{.smallcaps} that the number should be displayed up to and any [large number abbreviation]{.smallcaps}s.
+- **Currency** — Define the [currency]{.smallcaps} you would like the field to display in, as well as the [decimal places]{.smallcaps} that the number should be displayed up to and any [large number abbreviation]{.smallcaps}s.
+
+:::: {.flex .flex-wrap .justify-around}
+
+::: {.w-50-ns}
+![Simple number field type](/guide/model-inventory/number-simple.png){fig-alt="A screenshot showing a simple number field type" .screenshot group="number"} 
+
+:::
+
+::: {.w-40-ns}
+![Currency number field type](/guide/model-inventory/number-currency.png){fig-alt="A screenshot showing a currency number field type" .screenshot group="number"}
+
+:::
+
+::::
+
+URL
+: Text value in valid URL format.
+
+Date
+: - Date value in `yyyy-mm-dd` format. 
+- Selection is in the current user's timezone; other users viewing this field will see the value automatically in their timezone. 
+- Set the [date format]{.smallcaps} for date fields under your profile.^[[Manage your profile](/guide/configuration/manage-your-profile.qmd#localization)]
+
+Date Time
+: - Date value in `yyyy-mm-dd, 24hr` format.
+- Selection is in the current user's timezone; other users viewing this field will see the value automatically in their timezone. 
+- Set the [date format]{.smallcaps} for date time fields under your profile.^[[Manage your profile](/guide/configuration/manage-your-profile.qmd#localization)]
+
+Email
+: Text value in valid email (`user@domain.com`) format.
+
+User
+: 
+- Select list pre-populated with users from your {{< fa book-open >}} User Directory.^[[Manage users](/guide/configuration/manage-users.qmd)]
+- Toggle [allow linking to multiple records]{.smallcaps} on to allow multi-selection of users.
 
 ## Delete finding fields
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-2. Under Models, select **Model Inventory Fields**.
+2. Under Findings, select **Finding Fields**.
 
 3. Hover over the field you would like to delete.
 

--- a/site/guide/model-validation/manage-model-finding-fields.qmd
+++ b/site/guide/model-validation/manage-model-finding-fields.qmd
@@ -3,7 +3,7 @@ title: "Manage model finding fields"
 date: last-modified
 ---
 
-{{< include /guide/model-inventory/_model-inventory-fields.qmd >}}
+Create and edit the fields that appear on findings logged on your models. Choose from an array of field types with different properties and use cases.
 
 ::: {.attn}
 
@@ -14,7 +14,7 @@ date: last-modified
 
 :::
 
-## Add or edit inventory fields
+## Add or edit finding fields
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
@@ -24,11 +24,11 @@ date: last-modified
 
 {{< include /guide/model-inventory/_add-edit-inventory-fields.qmd >}}
 
-#### Inventory field types
+#### Finding field types
 
 {{< include /guide/model-inventory/_inventory-field-types.qmd >}}
 
-## Delete inventory fields
+## Delete finding fields
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
@@ -42,7 +42,7 @@ date: last-modified
 
 ## What's next
 
-- [Working with the model inventory](working-with-model-inventory.qmd)
+- [Working with model findings](working-with-model-findings.qmd)
 
 
 <!-- FOOTNOTES -->

--- a/site/guide/model-validation/managing-model-validation.qmd
+++ b/site/guide/model-validation/managing-model-validation.qmd
@@ -4,12 +4,13 @@ date: last-modified
 listing:
   - id: validation
     type: grid
-    grid-columns: 2
+    grid-columns: 3
     max-description-length: 250
     sort: false
     fields: [title, description]
     contents:
     - manage-validation-guidelines.qmd
+    - manage-model-finding-fields.qmd
     - manage-finding-statuses.qmd
 ---
 


### PR DESCRIPTION
# Pull Request Description

## What and why?
> sc-11050

We can now add custom findings fields, which needs documentation.

## How to test

- [x] Simply click on the LIVE PREVIEW here: [**Manage model finding fields**](https://docs-staging.validmind.ai/pr_previews/beck/sc-11050/documentation-add-custom-fields-for-findings/guide/model-validation/manage-model-finding-fields.html)
- [x] It was also added as a tile to the top-level "Managing model validation" page: [**Managing model validation**](https://docs-staging.validmind.ai/pr_previews/beck/sc-11050/documentation-add-custom-fields-for-findings/guide/model-validation/managing-model-validation.html)

## What needs special review?

- [x] Modifying finding fields layout is already covered in the existing docs (it didn't seem like the logic changed): [View and filter model findings > **Customize model findings layout**
](https://docs.validmind.ai/guide/model-validation/view-filter-model-findings.html#customize-model-findings-layout)
- [x] I didn't have access to test the feature, so I could only go off of what was in the frontend demo video. **Someone please make sure the included field types still function the same as finding fields.**

## Release notes

Release notes should be covered in the feature release https://github.com/validmind/frontend/pull/1506.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend) — N/A
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend) — N/A
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required) — N/A

