### PR TITLE
Hotfix: Re-adding guides _sidebar.yaml

### DIFF
--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -3,6 +3,7 @@ project:
 
 metadata-files:
   - get-started/_sidebar.yaml
+  - guide/_sidebar.yaml
   - developer/_sidebar.yaml
   - training/_sidebar.yaml
   - validmind/_sidebar.yml
@@ -161,113 +162,6 @@ website:
         - text: "Software license agreement"
           file: about/fine-print/license-agreement.qmd
 
-    - title: "Guides"
-      contents:
-        - guide/guides.qmd
-        - text: "---"
-        - text: "Setup + Administration"
-        - file: guide/configuration/accessing-validmind.qmd
-          contents:
-            - guide/configuration/register-with-validmind.qmd
-            - guide/configuration/log-in-to-validmind.qmd
-        - file: guide/configuration/managing-your-organization.qmd
-          contents:
-            - guide/configuration/set-up-your-organization.qmd
-            - guide/configuration/configure-aws-privatelink.qmd
-            - guide/configuration/configure-google-private-service-connect.qmd
-            - guide/configuration/configure-azure-private-link.qmd
-        - file: guide/configuration/managing-users.qmd
-          contents:
-          - guide/configuration/manage-users.qmd
-          - guide/configuration/manage-groups.qmd
-          - guide/configuration/manage-roles.qmd
-          - guide/configuration/manage-model-stakeholder-types.qmd
-          - guide/configuration/manage-permissions.qmd
-        - file: guide/configuration/personalize-validmind.qmd
-          contents:
-          - guide/configuration/manage-your-profile.qmd
-          - guide/configuration/customize-your-dashboard.qmd
-        - text: "---"
-        - text: "Model Workflows"
-        - text: "Working with workflows"
-          file: guide/model-workflows/working-with-model-workflows.qmd
-          contents:
-          - text: "Customize lifecycle statuses"
-            file: guide/model-workflows/manage-model-stages.qmd
-          - text: "Set up workflows"
-            file: guide/model-workflows/configure-model-workflows.qmd
-        - text: "---"
-        - text: "Model Inventory"
-        - file: guide/model-inventory/working-with-model-inventory.qmd
-          contents:
-          - guide/model-inventory/register-models-in-inventory.qmd
-          - guide/model-inventory/customize-model-inventory-layout.qmd
-          - guide/model-inventory/edit-model-inventory-fields.qmd
-          - guide/model-inventory/customize-model-overview-page.qmd
-        - file: guide/model-inventory/managing-model-inventory.qmd
-          contents:
-          - guide/model-inventory/configure-model-interdependencies.qmd
-          - guide/model-inventory/manage-model-inventory-fields.qmd
-          - guide/model-inventory/archive-delete-models.qmd
-        - guide/model-inventory/view-model-activity.qmd
-        - text: "---"
-        - text: "Templates"
-        - file: guide/templates/working-with-templates.qmd
-          contents:
-          - guide/templates/view-documentation-templates.qmd
-          - guide/templates/customize-documentation-templates.qmd
-          - guide/templates/swap-documentation-templates.qmd
-        - guide/templates/manage-text-block-library.qmd
-        - text: "---"
-        - text: "Model Documentation"
-        - file: guide/model-documentation/working-with-model-documentation.qmd
-          contents:
-          - guide/model-documentation/view-documentation-guidelines.qmd
-          - guide/model-documentation/work-with-content-blocks.qmd
-          - guide/model-documentation/work-with-test-results.qmd
-          - text: "Assign section statuses"
-            file: guide/model-documentation/assign-documentation-section-statuses.qmd
-          - guide/model-documentation/collaborate-with-others.qmd
-          - guide/model-documentation/submit-for-approval.qmd
-        - text: "---"
-        - text: "Model Validation"
-        - guide/model-validation/manage-validation-guidelines.qmd
-        - file: guide/model-validation/preparing-validation-reports.qmd
-          contents:
-          - guide/model-validation/review-model-documentation.qmd
-          - guide/model-validation/assess-compliance.qmd
-          - guide/model-documentation/work-with-content-blocks.qmd
-          - guide/model-documentation/collaborate-with-others.qmd
-          - guide/model-documentation/submit-for-approval.qmd
-        - file: guide/model-validation/working-with-model-findings.qmd
-          contents:
-          - text: "View and filter findings"
-            file: guide/model-validation/view-filter-model-findings.qmd
-          - text: "Add and manage findings"
-            file: guide/model-validation/add-manage-model-findings.qmd
-        - text: "---"
-        - text: "Reporting"
-        - file: guide/reporting/working-with-analytics.qmd
-          contents:
-          - guide/reporting/view-report-data.qmd
-          - guide/reporting/manage-custom-reports.qmd
-        - guide/reporting/export-documentation.qmd
-        - text: "---"
-        - text: "Monitoring"
-        - file: guide/monitoring/ongoing-monitoring.qmd
-          contents:
-          - guide/monitoring/enable-monitoring.qmd
-          - guide/monitoring/review-monitoring-results.qmd
-          - text: "Metrics over time"
-            file: guide/monitoring/work-with-metrics-over-time.qmd
-        - text: "---"
-        - text: "Attestation"
-        - file: guide/attestation/working-with-attestations.qmd
-          contents:
-          - guide/attestation/set-up-attestations.qmd
-          - guide/attestation/complete-attestation-questionnaires.qmd
-          - guide/attestation/review-attestation-questionnaires.qmd
-
     - title: "Support"
       contents:
         - support/support.qmd
@@ -386,6 +280,7 @@ format:
   html:
     grid:
       body-width: 1000px
+      sidebar-width: 375px
     footnotes-hover: true
     reference-location: margin
     code-overflow: wrap


### PR DESCRIPTION
# Pull Request Description

## What and why?
The guides `_sidebar.yaml` was accidentally removed in https://github.com/validmind/documentation/pull/764, along with some sidebar width styling causing discrepancies in what was displayed in the sidenav for guides. Both have been re-added.

## How to test

Click the LIVE PREVIEW when it's ready: Guides

## What needs special review?
n/a

## Release notes
n/a

## Checklist
- [ ] What and why
- [ ] Screenshots or videos (Frontend)
- [ ] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [ ] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

