### PR TITLE
docs: Notes tracked on workflow transitions

### DIFF
--- a/site/guide/model-workflows/_review-active-workflows.qmd
+++ b/site/guide/model-workflows/_review-active-workflows.qmd
@@ -14,9 +14,18 @@ To review the details for workflows currently active on a specific model:
 1. Click on the tab you would like to review:
 
     - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
-    - **Activity** — History of updates to the workflow on that model.
+    - **Activity** — History of updates to the workflow on that model, including notes submitted during transitions.[^notes]
     - **Findings** — Findings for that model created within the duration of that workflow's runtime.
     - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted on this view.
+
+
+<!-- FOOTNOTES -->
+
+[^notes]:
+
+    Click **{{< fa chevron-down >}}** to reveal notes, and **{{< fa chevron-up >}}** to hide them.
+    <br><br>
+    [Transition model workflows](/guide/model-workflows/transition-model-workflows.qmd)
 
 ::::
 
@@ -34,7 +43,7 @@ To review the details for workflows currently active on a specific model:
 1. Click on the tab you would like to review:
 
     - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
-    - **Activity** — History of updates to the workflow on that model.
+    - **Activity** — History of updates to the workflow on that model, including notes submitted during transitions.
     - **Findings** — Findings for that model created within the duration of that workflow's runtime.
     - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted on this view.
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-11176

Notes submitted during workflow transitions are now tracked in the workflow activity panel. Docs have been updated to accommodate this change.

## How to test

Click on the LIVE PREVIEW and confirm the changes in the screencaps below: [**Manage model workflows**](https://docs-staging.validmind.ai/pr_previews/beck/sc-11176/documentation-updates-for-user-action-step/guide/model-workflows/manage-model-workflows.html#review-active-workflows)

| Updated section | Additional footnote |
|--|--|
|<img width="1239" height="664" alt="Screenshot 2025-08-01 at 11 10 48 AM" src="https://github.com/user-attachments/assets/d53ac14b-6394-438f-ba06-db775e3acb12" /> | <img width="1259" height="672" alt="Screenshot 2025-08-01 at 11 10 58 AM" src="https://github.com/user-attachments/assets/6109215a-5d0d-4cfc-8ba2-85db5c45a75a" />|

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

n/a

## Release notes

Should be covered by https://github.com/validmind/frontend/pull/1557.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

