### PR TITLE
Workaround for Quarto render WARNING testing for notebook execution

### DIFF
--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -58,6 +58,16 @@ jobs:
           }
           make generate-sitemap
 
+    - name: Test for warnings or errors
+      run: |
+        if grep -q 'WARN\|WARNING\|ERROR:' site/render_errors.log; then
+          echo "Warnings or errors detected during Quarto render"
+          cat site/render_errors.log
+          exit 1
+        else
+          echo "No warnings or errors detected during Quarto render"
+        fi
+
     # See if site/notebooks/ has updates
     # Checks the current PR branch against the target branch
     - name: Filter changed files
@@ -102,16 +112,6 @@ jobs:
       with:
         dev_env: dev.env
         valid_env: valid.env
-
-    - name: Test for warnings or errors
-      run: |
-        if grep -q 'WARN\|WARNING\|ERROR:' site/render_errors.log; then
-          echo "Warnings or errors detected during Quarto render"
-          cat site/render_errors.log
-          exit 1
-        else
-          echo "No warnings or errors detected during Quarto render"
-        fi
 
     # Demo bucket is in us-east-1
     - name: Configure AWS credentials

--- a/site/_quarto-exe-demo.yml
+++ b/site/_quarto-exe-demo.yml
@@ -9,4 +9,3 @@ format:
 execute: 
   enabled: true
   freeze: auto
-filters: []

--- a/site/_quarto-exe-demo.yml
+++ b/site/_quarto-exe-demo.yml
@@ -9,3 +9,4 @@ format:
 execute: 
   enabled: true
   freeze: auto
+filters: []

--- a/site/notebooks/EXECUTED/test.ipynb
+++ b/site/notebooks/EXECUTED/test.ipynb
@@ -1,0 +1,19 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "4087f3c5",
+   "metadata": {},
+   "source": [
+    "# test"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-11680

https://github.com/validmind/documentation/pull/878 broke our PR preview when notebooks were included in the render (executed) as the output for some of the cells throw some `WARNINGS` that don't actually affect the final display of the page; they've been there since implementation.

I moved the test for errors/warn/warnings etc. step to BEFORE the notebook execution to sidestep this issue.

## How to test

Compare the workflow that was unsuccessful: https://github.com/validmind/documentation/actions/runs/16809938498

With the workflow that succeeds: https://github.com/validmind/documentation/actions/runs/16812671505/job/47621652045?pr=884

## What needs special review?

I merged this without review because we needed to get these patch release notes out on production and I needed to make sure the push to prod looked OK: https://github.com/validmind/release-notes/pull/18

I checked the executed notebooks to make sure they rendered as expected, of course.

## Release notes

n/a

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

