### PR TITLE
Nrichers/sc 11817/address docs login to directing to validmind

### DIFF
--- a/site/_quarto-development.yml
+++ b/site/_quarto-development.yml
@@ -1,3 +1,24 @@
+# Log in menu used in _quarto-development.yml, _quarto-staging.yml, and _quarto-production.yml
+website:
+  navbar:
+    right:
+      - text: "Log In"
+        menu:
+          - text: "Public Internet"
+          - text: "{{< var validmind.platform >}} · `US1` {{< fa right-to-bracket >}}"
+            href:  https://app.prod.validmind.ai/
+            target: _blank
+          - text: "{{< var validmind.platform >}} · `CA1` {{< fa right-to-bracket >}}"
+            href: https://app.ca1.validmind.ai
+            target: _blank
+          - text: "---"
+          - text: "Private Link"
+          - text: "{{< var validmind.vpv >}} (VPV)"
+            href: "guide/access/log-in-to-validmind.qmd#section"
+          - text: "---"
+          - text: "<small>Which login should I use?</small>"
+            href: "guide/access/log-in-to-validmind.qmd"
+
 format:
   html:
     include-in-header: 

--- a/site/_quarto-production.yml
+++ b/site/_quarto-production.yml
@@ -1,3 +1,23 @@
+website:
+  navbar:
+    right:
+      - text: "Log In"
+        menu:
+          - text: "Public Internet"
+          - text: "{{< var validmind.platform >}} · `US1` {{< fa right-to-bracket >}}"
+            href:  https://app.prod.validmind.ai/
+            target: _blank
+          - text: "{{< var validmind.platform >}} · `CA1` {{< fa right-to-bracket >}}"
+            href: https://app.ca1.validmind.ai
+            target: _blank
+          - text: "---"
+          - text: "Private Link"
+          - text: "{{< var validmind.vpv >}} (VPV)"
+            href: "guide/access/log-in-to-validmind.qmd#section"
+          - text: "---"
+          - text: "<small>Which login should I use?</small>"
+            href: "guide/access/log-in-to-validmind.qmd"
+
 format:
   html:
     include-in-header: 

--- a/site/_quarto-staging.yml
+++ b/site/_quarto-staging.yml
@@ -1,3 +1,23 @@
+website:
+  navbar:
+    right:
+      - text: "Log In"
+        menu:
+          - text: "Public Internet"
+          - text: "{{< var validmind.platform >}} · `US1` {{< fa right-to-bracket >}}"
+            href:  https://app.prod.validmind.ai/
+            target: _blank
+          - text: "{{< var validmind.platform >}} · `CA1` {{< fa right-to-bracket >}}"
+            href: https://app.ca1.validmind.ai
+            target: _blank
+          - text: "---"
+          - text: "Private Link"
+          - text: "{{< var validmind.vpv >}} (VPV)"
+            href: "guide/access/log-in-to-validmind.qmd#section"
+          - text: "---"
+          - text: "<small>Which login should I use?</small>"
+            href: "guide/access/log-in-to-validmind.qmd"
+
 format:
   html:
     include-in-header: 

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -35,52 +35,7 @@ website:
     background: white
     title: false
     pinned: true
-
     right:
-      # - text: "{{< fa cube >}} Documentation"
-      #   file: about/overview.qmd
-      # HOME BUTTON FOR DEVELOPER & TRAINING SECTIONS
-      # - text: "{{< fa house >}}"
-      #   file: index.qmd
-      # DOCUMENTATION MENU FOR DEVELOPER & TRAINING SECTIONS
-      - text: "{{< fa book-open >}} Documentation"
-        menu:
-        - text: "{{< fa circle-info >}} About {{< var vm.product >}}"
-          file: about/overview.qmd
-        - text: "{{< fa rocket >}} Get Started"
-          file: get-started/get-started.qmd
-        - text: "{{< fa book >}} Guides"
-          file: guide/guides.qmd
-        - text: "{{< fa envelope-open-text >}} Support"
-          file: support/support.qmd
-        - text: "{{< fa bullhorn >}} Releases"
-          file: releases/all-releases.qmd
-        - text: "---"
-        - text:  "{{< fa cube >}} Python Library"
-        - text: "{{< fa code >}} {{< var validmind.developer >}}"
-          file: developer/validmind-library.qmd
-        - text: "---"
-        - text:  "{{< fa graduation-cap >}} {{< var validmind.training >}}"
-        - text: "{{< fa building-columns >}} Training Courses"
-          file: training/training.qmd
-        # - text: "---"
-        # - text: "{{< fa square-check >}} validmind.com {{< fa external-link >}}"
-        #   file: https://validmind.com/
-        #   target: _blank
-      # TRAINING MENU FOR ACADEMY SECTION
-      # - text: "{{< fa graduation-cap >}} Training"
-      #   menu:
-      #   - text: "{{< fa house >}} ValidMind Academy"
-      #     file: training/training.qmd
-      #   - text: "---"
-      #   - text:  "{{< fa building-columns >}} Fundamentals"
-      #   - text: "{{< fa gear >}} For Administrators"
-      #     file: training/administrator-fundamentals/administrator-fundamentals-register.qmd
-      #   - text: "{{< fa code >}} For Developers"
-      #     file: training/developer-fundamentals/developer-fundamentals-register.qmd
-      #   - text: "{{< fa user-check >}} For Validators"
-      #     file: training/validator-fundamentals/validator-fundamentals-register.qmd
-
       - text: "{{< fa book-open >}} Documentation"
         menu:
         - text: "{{< fa circle-info >}} About {{< var vm.product >}}"

--- a/site/_quarto.yml
+++ b/site/_quarto.yml
@@ -102,23 +102,7 @@ website:
         - text: "{{< fa building-columns >}} Training Courses"
           file: training/training.qmd
 
-      - text: "Log In"
-        menu:
-          - text: "Public Internet"
-          - text: "{{< var validmind.platform >}} · `US1` {{< fa right-to-bracket >}}"
-            href:  https://app.prod.validmind.ai/
-            target: _blank
-          - text: "{{< var validmind.platform >}} · `CA1` {{< fa right-to-bracket >}}"
-            href: https://app.ca1.validmind.ai
-            target: _blank
-          - text: "---"
-          - text: "Private Link"
-          - text: "{{< var validmind.vpv >}} (VPV)"
-            href: "guide/access/log-in-to-validmind.qmd#section"
-          - text: "---"
-          - text: "<small>Which login should I use?</small>"
-            href: "guide/access/log-in-to-validmind.qmd"
-        
+# The log in menu is defined in _quarto-development.yml, _quarto-staging.yml, and _quarto-production.yml as not all environments have the same login options.
 
 #  COMMENT THIS OUT WHEN DONE TESTING
       # - text: "{{< fa flask >}} Testing"

--- a/site/_variables.yml
+++ b/site/_variables.yml
@@ -22,7 +22,7 @@ validmind:
   api: "ValidMind Library Python API"
   legal: "ValidMind Inc."
   training: "ValidMind Academy"
-  customer: "Customer-managed ValidMind"
+  customer: "Customer-Managed ValidMind"
   admin: "ValidMind Admin UI"
   checker: "Document Checker"
 

--- a/site/developer/developer.css
+++ b/site/developer/developer.css
@@ -20,10 +20,6 @@
   display: none;
 }
 
-#nav-menu-fa-book-open--documentation, #nav-menu-log-in {
-  display: block !important;
-}
-
 .navbar-nav .nav-item > .nav-link:has(.fa-house) {
   display: block !important;
   color: #DE257E;

--- a/site/guide/access/log-in-to-validmind.qmd
+++ b/site/guide/access/log-in-to-validmind.qmd
@@ -25,7 +25,7 @@ Log in to {{< var validmind.platform >}} to work with your model documentation, 
 - [Private network endpoints](#private-network-endpoints) — requires additional configuration
 
 ::: {.content-visible when-profile="docker"}
-Additionally, when deployed as {{< var validmind.customer >}} ({{< var vm.customer >}}), {{< var validmind.platform >}} can be accessed through an intranet URL that must be configured.
+Additionally, when deployed as {{< var validmind.customer >}} ({{< var vm.customer >}}), the platform can be accessed through an intranet URL that must be configured.
 :::
 
 ::: {.attn}
@@ -108,11 +108,14 @@ To configure and log in through a private link for your company VPC using a supp
 ::: {.content-visible when-profile="docker"}
 ## {{< var validmind.customer >}} ({{< var vm.customer >}})
 
+::: {.callout-important}
+Requires `VALIDMIND_URL` to be configured by your IT department.[^1]
+:::
+
 1. In a browser, navigate to [{{< var url.us1 >}}]({{< var url.us1 >}}).
 
-   ::: {.callout-important}
-   Requires `VALIDMIND_URL` to be set.[^1]
-   :::
+
+
 
 2. Choose one of the supported login options:
 

--- a/site/guide/access/log-in-to-validmind.qmd
+++ b/site/guide/access/log-in-to-validmind.qmd
@@ -17,12 +17,16 @@ aliases:
   - /guide/configuration/log-in-to-validmind.html
 ---
 
-Log in to our cloud-hosted {{< var validmind.platform >}} to work with your model documentation, prepare validation reports, or to configure {{< var vm.product >}} for your organization.
+Log in to {{< var validmind.platform >}} to work with your model documentation, prepare validation reports, perform model governance tasks, or to configure {{< var vm.product >}} for your organization.
 
 {{< var vm.product >}} supports the following methods for logging in:
 
 - [Public internet](#public-internet) — minimal configuration needed
 - [Private network endpoints](#private-network-endpoints) — requires additional configuration
+
+::: {.content-visible when-profile="docker"}
+Additionally, when deployed as {{< var validmind.customer >}} ({{< var vm.customer >}}), {{< var validmind.platform >}} can be accessed through an intranet URL that must be configured.
+:::
 
 ::: {.attn}
 
@@ -97,7 +101,27 @@ Once you have the necessary access, you can work with models and workflows and p
 
 To configure and log in through a private link for your company VPC using a supported service:
 
-
 :::{#private-networks}
 :::
 
+
+::: {.content-visible when-profile="docker"}
+## {{< var validmind.customer >}} ({{< var vm.customer >}})
+
+1. In a browser, navigate to [{{< var url.us1 >}}]({{< var url.us1 >}}).
+
+   ::: {.callout-important}
+   Requires `VALIDMIND_URL` to be set.[^1]
+   :::
+
+2. Choose one of the supported login options:
+
+   - Enter your email address and password, and click **Continue**.
+   - Select one of the supported single sign-on (SSO) login options, such as Google, GitHub, or Microsoft, and complete the login steps. 
+
+    After successful login, you will be redirected to the main dashboard of the {{< var validmind.platform >}}.
+:::
+
+<!-- FOOTNOTES -->
+
+[^1]: [Create a rebranded docs site](https://github.com/validmind/documentation?tab=readme-ov-file#create-a-rebranded-docs-site)

--- a/site/styles.css
+++ b/site/styles.css
@@ -745,10 +745,6 @@ h2, .h2 {
   color: #196972;
 }
 
-#nav-menu-fa-book-open--documentation, #nav-menu-fa-graduation-cap--training, .navbar-nav .nav-item:has(.fa-house) > .nav-link {
-  display: none;
-}
-
 button.aa-DetachedSearchButton:hover svg path {
   /* fill: #AF1A62 !important; */
   display: none !important;

--- a/site/training/assets/training.css
+++ b/site/training/assets/training.css
@@ -142,10 +142,6 @@ a.dropdown-item:hover {
 display: none;
 }
 
-#nav-menu-fa-book-open--documentation, #nav-menu-fa-graduation-cap--training, #nav-menu-log-in {
-display: block !important;
-}
-
 .navbar-nav .nav-item > .nav-link:has(.fa-house) {
   display: block !important;
 }


### PR DESCRIPTION
# Pull Request Description

## What and why?
<!-- Briefly describe what changed and why — include behavior before and after if helpful -->
<!-- Frontend: Add screenshots or videos showing before/after -->

This PR:

- **Removes the "Log In" menu from the Docker image**: Because the information was specific to our environment and we do not know where customers deploy to, the menu has been removed globally.
- **Updates the "Log in to ValidMind" topic for the Docker image**: We now include guidance on supporting intranet URLs and points to where more details can be found. We can't be too specific here but we can include enough information to be helpful.  

Our public docs site remains unchanged.

Relates to [sc-11817](https://app.shortcut.com/validmind/story/11817/address-docs-login-to-directing-to-validmind-on-prod-instance-179)

## How to test
<!-- Describe how the change has been tested, and how a reviewer can test the change locally -->

**Removed "Log In" menu**

| Before | After |
|---------------------|--------------------|
| <img width="1216" height="389" alt="Capto_ 2025-08-19_12-19-25_pm" src="https://github.com/user-attachments/assets/a309bbb4-e6af-4f3d-9f6b-3f1b7abaebda" /> | <img width="1216" height="389" alt="image" src="https://github.com/user-attachments/assets/9883363d-8a5e-4497-8f0c-77adab580808" /> |

**Updated "Log in to ValidMind" topic**

<img width="1245" height="2246" alt="image" src="https://github.com/user-attachments/assets/bb89bea6-99db-47ab-a16f-33c11163171b" />

Or, check the preview link when it becomes available.

## What needs special review?
<!-- Optional: Call out specific areas needing detailed review -->

Under the covers, this PR:

- Moves the "Log In" menu from the global `_quarto.yml` file into the environment-specific Quarto profiles (`_quarto-development.yml`, `_quarto-staging.yml`, and `_quarto-production.yml`) which gives us control over where the menu should appear. Note you can't single source this menu with `metadata-files`, I tried and [it's not supported](https://quarto.org/docs/projects/profiles.html#profile-configuration).
- Fixes a long-standing CSS bug we had that required some duplicated YAML for our main navigation menu; we've worked around this bug for a while but it actually prevented me from pulling out the "Log In" menu cleanly, so I finally tracked down and fixed the bug.
- Fixed a casing issue in one of CMVM long-form product variables.

## Dependencies, breaking changes, and deployment notes
<!-- A list of links to pull requests that are depend on or are dependencies of this PR -->
<!-- Any special deployment considerations? -->
<!-- List any breaking changes -->

N/A 

## Release notes
<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `breaking-change`
- `deprecation`
- `documentation`
- `environment-variables`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## Checklist
- [x] What and why
- [x] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

