### PR TITLE
Fix codeblock formatting issue and import as modular CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,26 @@ These directories may have sub-directories depending on their size and grouped s
 #### Supporting `site` directories
 - `_site` — This is where static files rendered by `quarto render` get placed.
 - `assets` — This is where general shared assets live (stylesheets, promotional images, all videos, etc.).
+- `css` — Modular CSS files organized by functionality and imported into the main stylesheet.
 - `internal` — For internal testing only.
 - `notebooks` — This is where notebooks retrieved from the [`validmind-library` repo](https://github.com/validmind/validmind-library) live.
 - `tests` — This is where test descriptions generated from the Python source in the [`validmind-library` repo](https://github.com/validmind/validmind-library) live.
+
+##### CSS organization (IN PROGRESS)
+
+The site uses a modular CSS architecture to maintain organized and maintainable styles:
+
+```
+site/
+├── css/
+│   ├── _bug-fixes.css      # Bug fixes and CSS conflict resolutions
+│   └── _codeblocks.css     # All code block and syntax highlighting styles  
+└── styles.css              # Main styles with modular imports
+```
+
+- **`styles.css`** — Main stylesheet that imports modular CSS files and contains site-wide styling
+- **`css/_bug-fixes.css`** — Isolated fixes for CSS conflicts and browser-specific issues
+- **`css/_codeblocks.css`** — All styling related to code blocks, syntax highlighting, and pre-formatted text
 
 ### Auxiliary `internal` directories
 

--- a/site/css/_bug-fixes.css
+++ b/site/css/_bug-fixes.css
@@ -1,0 +1,9 @@
+/* Bug fixes for various CSS conflicts and issues */
+
+/* Fix Tachyons .fl class conflict with syntax highlighting
+ * Issue: Tachyons .fl (float left) conflicts with Quarto's .fl (floating literal) 
+ * in syntax-highlighted code blocks, causing incorrect text positioning
+ */
+.sourceCode .fl {
+  float: none !important;
+}

--- a/site/css/_codeblocks.css
+++ b/site/css/_codeblocks.css
@@ -1,0 +1,13 @@
+/* Code block and syntax highlighting styles */
+
+/* General code styling */
+code {
+  color: #083E44;
+}
+
+/* Pre-formatted code blocks with language-specific styling */
+pre, pre.python, pre.bash, pre.yaml, pre.markdown {
+  background-color: #083E4420;
+  padding: 15px;
+  border-radius: 5px;
+}

--- a/site/guide/monitoring/set-thresholds-and-alerts.qmd
+++ b/site/guide/monitoring/set-thresholds-and-alerts.qmd
@@ -23,7 +23,8 @@ Together, thresholds and notifications improve your visibility into model perfor
 
 To programmatically evaluate whether a metric passes specific criteria, use a custom function:
 
-```
+
+```python
 gini = 0.75
 
 thresholds = {
@@ -58,7 +59,7 @@ In this example:
 
 To flag whether a metric value meets performance criteria, set the `passed` value explicitly:
 
-```
+```python
 log_metric(
    key="Test Coverage",
    value=0.85,

--- a/site/styles.css
+++ b/site/styles.css
@@ -1,3 +1,7 @@
+/* Import modular CSS files */
+@import url('css/_bug-fixes.css');
+@import url('css/_codeblocks.css');
+
 /* Fix ValidMind logo size and alignment */
 @font-face {
   font-family: 'Inter';
@@ -76,9 +80,7 @@ a.dropdown-item:not(nav#TOC a.dropdown-item):hover::before {
   background-color: white;
 }
 
-code {
-  color: #083E44;
-}
+
 
 .navbar-brand img {
   height: 100%;
@@ -164,11 +166,7 @@ div.callout.callout {
   border: 1px solid #083E44;
 }
 
-pre, pre.python, pre.bash, pre.yaml, pre.markdown {
-  background-color: #083E4420;
-  padding: 15px;
-  border-radius: 5px;
-}
+
 
 .hero {
   position: relative;


### PR DESCRIPTION
# Pull Request Description

## What and why?
<!-- Briefly describe what changed and why — include behavior before and after if helpful -->
<!-- Frontend: Add screenshots or videos showing before/after -->

This PR:

- Fixes the codeblock formatting issue when a language is specified to highlight syntax
- Puts the bug fix and CSS for codeblocks into modular CSS files

| Source | Output BEFORE | Output AFTER |
|--------|--------|-------|
|  <img width="300" height="439" alt="Capto_ 2025-08-19_04-20-37_pm2" src="https://github.com/user-attachments/assets/e8cebf96-e60f-4d03-8b3e-019a9d1bad04" /> | <img width="269" height="333" alt="Capto_ 2025-08-19_04-10-56_pm2" src="https://github.com/user-attachments/assets/908aee01-fdbe-415f-a910-44ce252fce81" /> | <img width="269" height="333" alt="Capto_ 2025-08-19_04-11-14_pm" src="https://github.com/user-attachments/assets/6f171a1b-8ad2-4a38-9913-2b706cb591f8" /> |

Relates to [sc-11359](https://app.shortcut.com/validmind/story/11359/investigate-python-codeblock-formatting-issues)

## How to test
<!-- Describe how the change has been tested, and how a reviewer can test the change locally -->

The underlying issue is that Tachyons' `.fl { float: left; }` class conflicts with Quarto's syntax highlighting. Quarto uses `.fl` to mark floating-point literals in codeblocks, but Tachyons applies `float: left` to these spans, disrupting the layout.

You can verify the fix by disabling the `css/_bug-fixes.css` import locally or the `.sourceCode .fl` rule in your browser developer tools by inspecting the output: the formatting issue returns without the fix.

Course slides suffer from the same issue. The fix works for them, too:

| Before | After |
|---------------------|--------------------|
| <img width="1479" height="838" alt="image" src="https://github.com/user-attachments/assets/2ab79341-6e52-4cbf-945a-bfe3332fb351" /> |  <img width="1479" height="838" alt="image" src="https://github.com/user-attachments/assets/f55018c4-97eb-4d85-9ee3-debd36482cf8" /> |

If I have time tomorrow, I might propose a fix for Tachyons CSS or at least open an issue. 

## What needs special review?
<!-- Optional: Call out specific areas needing detailed review -->

This PR is also a proof of concept for refactoring our CSS by structuring it better. If we agree that this approach is useful, we can start making our CSS more modular in preparation for cleaning up our CSS mess. 

The general approach is to group related CSS and put it into files that get imported. In the future, all the CSS for buttons would go into one file, all the CSS for links into another, etc. 

After refactoring is complete, the site would uses a modular CSS file structure to maintain organized and maintainable styles:

```
site/
├── css/                    # Modular CSS files
│   ├── _bug-fixes.css
│   ├── _buttons.css
│   ├── _codeblocks.css
│   ├── _links.css
│   └── ...
│── styles.css              # Global styles with modular imports
│── theme.scss              # Light theme styles with modular imports
└── theme-dark.scss         # Dark theme styles with modular imports
```

## Dependencies, breaking changes, and deployment notes
<!-- A list of links to pull requests that are depend on or are dependencies of this PR -->
<!-- Any special deployment considerations? -->
<!-- List any breaking changes -->

N/A

## Release notes
<!--- REPLACE THIS COMMENT WITH YOUR DESCRIPTION --->

We fixed an issue with codeblock formatting that caused incorrect text positioning when a language such as Python was specified. Codeblocks now use the correct formatting and text positioning. 

<!--
PR instructions for release notes:

1. Pick at least one label:

- `internal` (skip Step 2, no release notes required)
- `highlight`
- `enhancement`
- `bug`
- `breaking-change`
- `deprecation`
- `documentation`
- `environment-variables`

2. In the next section, describe the changes so that an external user can understand them. Keep it simple and link to the docs with [Learn more ...](<relative-link>), if available.
-->

## Checklist
- [x] What and why
- [x] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

