### PR TITLE
Removing validmind version variable

### DIFF
--- a/site/_variables.yml
+++ b/site/_variables.yml
@@ -79,7 +79,7 @@ gcp:
 
 version:
   python: "≧3.8 and <3.11"
-  validmind: v2.5.19
+  # validmind: v2.5.19
 
 # OTHER
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-7174

We now pull in the production library version in the Python API docs, and don't reference the library version elsewhere. Removing the variable to reduce confusion/accidental usage.

(I considered populating the variable in the `_variables.yml` file with a script from the source, but we don't even use the variable anywhere for that much work to be put into that workaround . . .

## How to test

n/a

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

n/a

## Release notes

n/a

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [ ] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

