### PR TITLE
docs: Export inventory

### DIFF
--- a/site/guide/_sidebar.yaml
+++ b/site/guide/_sidebar.yaml
@@ -116,8 +116,8 @@ website:
           - guide/reporting/manage-custom-reports.qmd
         - file: guide/reporting/generating-exports.qmd
           contents:
-          - guide/reporting/export-documents.qmd
           - guide/reporting/export-inventory.qmd
+          - guide/reporting/export-documents.qmd
           - guide/reporting/export-findings.qmd
         - text: "---"
         - text: "Monitoring"

--- a/site/guide/_sidebar.yaml
+++ b/site/guide/_sidebar.yaml
@@ -114,8 +114,11 @@ website:
           contents:
           - guide/reporting/view-report-data.qmd
           - guide/reporting/manage-custom-reports.qmd
-        - guide/reporting/export-documents.qmd
-        - guide/reporting/export-findings.qmd
+        - file: guide/reporting/generating-exports.qmd
+          contents:
+          - guide/reporting/export-documents.qmd
+          - guide/reporting/export-inventory.qmd
+          - guide/reporting/export-findings.qmd
         - text: "---"
         - text: "Monitoring"
         - file: guide/monitoring/ongoing-monitoring.qmd

--- a/site/guide/guides.qmd
+++ b/site/guide/guides.qmd
@@ -96,7 +96,7 @@ listing:
   - id: guides-reports
     contents: 
     - reporting/working-with-analytics.qmd
-    - reporting/export-documents.qmd
+    - reporting/generating-exports.qmd
     type: grid
     max-description-length: 250
     sort: false
@@ -203,7 +203,7 @@ Then, prepare validation reports, work with findings and evidence, and collabora
 
 ## Reporting
 
-Review reports or export your documentation for external records:
+Review analytics or export your documents, model inventoru, and findings for external records:
 
 :::{#guides-reports}
 :::

--- a/site/guide/reporting/export-documents.qmd
+++ b/site/guide/reporting/export-documents.qmd
@@ -57,7 +57,7 @@ Export model documentation, validation reports, and ongoing monitoring reports a
 
 6. Click **{{< fa file-arrow-down >}} Download File** to download the file locally on your machine.
 
-## Export ongoing monitoring documentation
+## Export ongoing monitoring reports
 
 1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
 

--- a/site/guide/reporting/export-documents.qmd
+++ b/site/guide/reporting/export-documents.qmd
@@ -6,7 +6,7 @@ aliases:
   - /guide/model-documentation/export-documentation.html
 ---
 
-Export your model documentation, validation reports, and ongoing monitoring documentation as Microsoft Word files (`.docx`) for use outside of the {{< var validmind.platform >}}.
+Export model documentation, validation reports, and ongoing monitoring reports as Microsoft Word files (`.docx`).
 
 ::: {.callout}
 {{< var vm.product >}} supports Word 365, Word 2019, Word 2016, and Word 2013.

--- a/site/guide/reporting/export-findings.qmd
+++ b/site/guide/reporting/export-findings.qmd
@@ -3,7 +3,7 @@ title: "Export findings"
 date: last-modified
 ---
 
-Export your tracked model findings as comma-delimited tables (`.csv`) for use outside of the {{< var validmind.platform >}}.
+Export tracked model findings as comma-delimited tables (`.csv`).
 
 ::: {.attn}
 

--- a/site/guide/reporting/export-inventory.qmd
+++ b/site/guide/reporting/export-inventory.qmd
@@ -1,0 +1,62 @@
+---
+title: "Export inventory"
+date: last-modified
+---
+
+Export your tracked model findings as comma-delimited tables (`.csv`) for use outside of the {{< var validmind.platform >}}.
+
+::: {.attn}
+
+## Prerequisites
+
+- [x] {{< var link.login >}}
+- [x] There are models registered in the model inventory.[^1]
+- [x] There are findings logged on any model.[^2]
+
+:::
+
+## Export findings by type
+
+1. In the left sidebar, click **{{< fa triangle-exclamation >}} Findings** for the list of all model findings.
+
+2. Select a finding type[^3] to export from the tabs:
+
+   - Validation Issue
+   - Policy Exception
+   - Model Limitation
+
+3. (Optional) Apply any filters[^4] to the list of findings to narrow down results.
+
+4. Click **{{< fa download >}} Export** to export a list of your selected finding type with your filters applied.
+
+    A `.csv` file will be automatically downloaded with the default column headers.[^5]
+
+
+<!-- FOOTNOTES -->
+
+[^1]: [Register models in the inventory](/guide/model-inventory/register-models-in-inventory.qmd)
+
+[^2]: [Add and manage model findings](/guide/model-validation/add-manage-model-findings.qmd)
+
+[^3]: [Manage finding types](/guide/model-validation/manage-finding-types.qmd)
+
+[^4]: [View and filter model findings](/guide/model-validation/view-filter-model-findings.qmd#filter-and-sort-model-findings)
+
+[^5]:
+
+    - Finding ID
+    - Title
+    - Description
+    - Finding Type
+    - Status
+    - Severity
+    - [Risk Area](/guide/model-validation/manage-validation-guidelines.qmd#set-up-validation-guidelines)
+    - [Business Unit](/guide/configuration/set-up-your-organization.qmd#manage-business-units)
+    - [Model](/guide/model-inventory/working-with-model-inventory.qmd)
+    - Reporter
+    - Owner
+    - Due Date
+    - Created At
+    - Updated At
+
+

--- a/site/guide/reporting/export-inventory.qmd
+++ b/site/guide/reporting/export-inventory.qmd
@@ -14,7 +14,7 @@ Export lists of models tracked in the inventory as comma-delimited tables (`.csv
 
 :::
 
-## Export findings by type
+## Export lists of models
 
 1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
 

--- a/site/guide/reporting/export-inventory.qmd
+++ b/site/guide/reporting/export-inventory.qmd
@@ -3,7 +3,7 @@ title: "Export inventory"
 date: last-modified
 ---
 
-Export your tracked model findings as comma-delimited tables (`.csv`) for use outside of the {{< var validmind.platform >}}.
+Export lists of models tracked in the inventory as comma-delimited tables (`.csv`).
 
 ::: {.attn}
 
@@ -11,52 +11,28 @@ Export your tracked model findings as comma-delimited tables (`.csv`) for use ou
 
 - [x] {{< var link.login >}}
 - [x] There are models registered in the model inventory.[^1]
-- [x] There are findings logged on any model.[^2]
 
 :::
 
 ## Export findings by type
 
-1. In the left sidebar, click **{{< fa triangle-exclamation >}} Findings** for the list of all model findings.
+1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
 
-2. Select a finding type[^3] to export from the tabs:
+2. (Optional) Narrow down and organize the list of models and column headers you want to export by:
 
-   - Validation Issue
-   - Policy Exception
-   - Model Limitation
+    - Filtering and sorting models[^2]
+    - Toggling visibility of and reordering column headers[^3]
 
-3. (Optional) Apply any filters[^4] to the list of findings to narrow down results.
+3. Click **{{< fa download >}} Export** to export a list of your models with your adjustments applied.
 
-4. Click **{{< fa download >}} Export** to export a list of your selected finding type with your filters applied.
-
-    A `.csv` file will be automatically downloaded with the default column headers.[^5]
+    A `.csv` file will be automatically downloaded with your configuration.
 
 
 <!-- FOOTNOTES -->
 
 [^1]: [Register models in the inventory](/guide/model-inventory/register-models-in-inventory.qmd)
 
-[^2]: [Add and manage model findings](/guide/model-validation/add-manage-model-findings.qmd)
+[^2]: [Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)
 
-[^3]: [Manage finding types](/guide/model-validation/manage-finding-types.qmd)
-
-[^4]: [View and filter model findings](/guide/model-validation/view-filter-model-findings.qmd#filter-and-sort-model-findings)
-
-[^5]:
-
-    - Finding ID
-    - Title
-    - Description
-    - Finding Type
-    - Status
-    - Severity
-    - [Risk Area](/guide/model-validation/manage-validation-guidelines.qmd#set-up-validation-guidelines)
-    - [Business Unit](/guide/configuration/set-up-your-organization.qmd#manage-business-units)
-    - [Model](/guide/model-inventory/working-with-model-inventory.qmd)
-    - Reporter
-    - Owner
-    - Due Date
-    - Created At
-    - Updated At
-
+[^3]: [Customize model inventory layout](/guide/model-inventory/customize-model-inventory-layout.qmd#customize-table-view)
 

--- a/site/guide/reporting/generating-exports.qmd
+++ b/site/guide/reporting/generating-exports.qmd
@@ -1,0 +1,17 @@
+---
+title: "Generating exports"
+date: last-modified
+listing:
+  - id: reports
+    type: grid
+    max-description-length: 250
+    sort: false
+    grid-columns: 3
+    fields: [title, description]
+    contents:
+      - export-documents.qmd
+      - export-inventory.qmd
+      - export-findings.qmd
+---
+
+Export your documents, model inventory, and findings for use outside of the {{< var validmind.platform >}}.

--- a/site/guide/reporting/generating-exports.qmd
+++ b/site/guide/reporting/generating-exports.qmd
@@ -9,8 +9,8 @@ listing:
     grid-columns: 3
     fields: [title, description]
     contents:
-      - export-documents.qmd
       - export-inventory.qmd
+      - export-documents.qmd
       - export-findings.qmd
 ---
 

--- a/site/releases/2025/2025-jan-31/release-notes.qmd
+++ b/site/releases/2025/2025-jan-31/release-notes.qmd
@@ -204,7 +204,7 @@ Several enhancements to the {{< var validmind.developer >}} focus on ongoing mon
 
 - **New notebook**: Learn how to use ongoing monitoring with credit risk datasets in this step-by-step guide for the {{< var validmind.developer >}}.
 
-    - Use our new metrics for data and model drift, and populate the ongoing monitoring documentation for a scorecard model.[^1]
+    - Use our new metrics for data and model drift, and populate the ongoing monitoring report for a scorecard model.[^1]
 
 ::: {.column-margin}
 :::{#ongoing-monitoring}


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-12117

We were missing information on how to export the list of models in the inventory as this feature is now available on production.

## How to test

Click the LIVE PREVIEW: [**Export inventory**](https://docs-staging.validmind.ai/pr_previews/beck/sc-12117/add-export-model-inventory-topic/guide/reporting/export-inventory.html)

## What needs special review?

- I also added a new high-level topic for exporting: [**Generating exports**](https://docs-staging.validmind.ai/pr_previews/beck/sc-12117/add-export-model-inventory-topic/guide/reporting/generating-exports.html)
- Listing tile on guides has been updated as well: [**Guides > Reporting**](https://docs-staging.validmind.ai/pr_previews/beck/sc-12117/add-export-model-inventory-topic/guide/guides.html#reporting)

## Dependencies, breaking changes, and deployment notes

n/a

## Release notes

You can now export lists of models tracked in the {{< var validmind.platform >}} as `.csv` files. Product documentation has been updated to reflect this functionality.

Learn more: [**Export inventory**](https://docs.validmind.ai/guide/reporting/export-inventory.html)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

