### PR TITLE
[TESTING] Vendored Quarto version

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.github/quarto/quarto-1.8.24-linux-amd64.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/.github/actions/quarto-local/action.yml
+++ b/.github/actions/quarto-local/action.yml
@@ -1,0 +1,42 @@
+name: Setup Quarto (vendored Linux)
+description: Use a vendored Quarto tarball on Linux GitHub runners
+
+inputs:
+  version:
+    description: "Quarto version directory under .github/quarto"
+    required: true
+  root:
+    description: "Root folder where archives live"
+    required: false
+    default: ".github/quarto"
+
+runs:
+  using: composite
+  steps:
+    - name: Log selected Quarto version
+      shell: bash
+      run: |
+        echo "Using Quarto version: ${{ inputs.version }}"
+
+    - name: Extract Quarto
+      shell: bash
+      run: |
+        set -euo pipefail
+        ARCHIVE="${{ inputs.root }}/${{ inputs.version }}/quarto-linux-amd64.tar.gz"
+        if [ ! -f "$ARCHIVE" ]; then
+          echo "Missing $ARCHIVE"
+          exit 1
+        fi
+        DEST="${RUNNER_TEMP}/quarto"
+        mkdir -p "$DEST"
+        tar -xzf "$ARCHIVE" -C "$DEST"
+        BIN_DIR="$(find "$DEST" -maxdepth 2 -type d -name bin | head -n1)"
+        if [ ! -d "$BIN_DIR" ]; then
+          echo "Could not find bin dir"
+          exit 1
+        fi
+        echo "$BIN_DIR" >> "$GITHUB_PATH"
+
+    - name: Verify Quarto on PATH
+      shell: bash
+      run: quarto --version

--- a/.github/actions/quarto-local/action.yml
+++ b/.github/actions/quarto-local/action.yml
@@ -22,7 +22,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
-        ARCHIVE="${{ inputs.root }}/${{ inputs.version }}/quarto-linux-amd64.tar.gz"
+        ARCHIVE="${{ inputs.root }}/quarto-${{ inputs.version }}-linux-amd64.tar.gz"
         if [ ! -f "$ARCHIVE" ]; then
           echo "Missing $ARCHIVE"
           exit 1

--- a/.github/quarto/quarto-1.8.24-linux-amd64.tar.gz
+++ b/.github/quarto/quarto-1.8.24-linux-amd64.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b83c1c9b6f2ce6454798b42260bd2ee184551d74debe817b8aaf28b09ac22d0
+size 125021276

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -34,6 +34,7 @@ jobs:
         repository: validmind/installation
         path: site/_source/installation
         token: ${{ secrets.INSTALLATION_RO_PAT }}
+        lfs: true
 
     - name: Check out release-notes repository
       uses: actions/checkout@v4

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -43,7 +43,7 @@ jobs:
         token: ${{ secrets.RELEASE_NOTES_RO_PAT }}
 
     - name: Set up Quarto (vendored)
-      uses: ./.github/actions/setup-quarto-local
+      uses: ./.github/actions/quarto-local
       with:
         version: ${{ vars.QUARTO_VERSION }}
 

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Check out documentation repository
       uses: actions/checkout@v4
+      with:
+        lfs: true
 
     # Reclaim space + create a reserve for deterministic headroom
     - name: Free space + create reserve
@@ -34,7 +36,6 @@ jobs:
         repository: validmind/installation
         path: site/_source/installation
         token: ${{ secrets.INSTALLATION_RO_PAT }}
-        lfs: true
 
     - name: Check out release-notes repository
       uses: actions/checkout@v4

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -42,8 +42,10 @@ jobs:
         path: site/_source/release-notes
         token: ${{ secrets.RELEASE_NOTES_RO_PAT }}
 
-    - name: Set up Quarto
-      uses: quarto-dev/quarto-actions/setup@v2
+    - name: Set up Quarto (vendored)
+      uses: ./.github/actions/setup-quarto-local
+      with:
+        version: ${{ vars.QUARTO_VERSION }}
 
     - name: Setup R environment
       uses: ./.github/actions/setup-r


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-6641

Playing around with how we can host a static version of Quarto, since sometimes (honestly, only once or twice that I can remember since we implemented workflow `quarto render` . . .), and here are some test results.

## How to test

Here is a workflow that completed with a Quarto install from the tarball we "uploaded"* to our repo: https://github.com/validmind/documentation/actions/runs/17778687016/job/50532704523?pr=948

It works based on finding the file uploaded to `.github/quarto/` that matches the version we indicate in our Actions variable: [`QUARTO_VERSION` ](https://github.com/validmind/documentation/settings/variables/actions/QUARTO_VERSION)

> [!NOTE]
> *Refer to the special review section below for more details.

## What needs special review?

There are some catches here; I'll try to explain the best I can with my limited knowledge of how this all actually works . . .

### Quarto installation tarball size

We "vendor" (keep a copy) of the file in our repo, but the installation tarball provided by Quarto actually exceeds the size limit allowed to be hosted in its original format within GitHub repos. 

So technically, what we _actually_ do is use [Git LFS](https://git-lfs.com/) to track the installation tarball file via `.gitattributes`: https://github.com/validmind/documentation/blob/29944f7d9a395aa7883f689a210ad948b2a33aca/.gitattributes

This is actually quite an annoying process. You see:

- Everyone that uses the repo going forward needs to have GIt LFS installed (The validate workflow used to test now also calls `lfs` when we checkout the documentation repo) — Not the annoying part in itself, but another dependency:

  ```bash
  brew install git-lfs   # macOS
  git lfs install
  ```

- To push updates to Quarto versions (for example, if we manually update the version by adding a different installation tarball to the repo, then updating the variable to look for this version), you'll need to perform the special Git LFS tracking process that updates the `.gitattributes` file before adding to and sending a commit:

  ```bash
  git lfs track "*.tar.gz" # track tarball files
  ```

  (If you accidentally tried to commit the too-large tarball file normally (like I did), you'll need to migrate the file first:
  
    ```bash
    git lfs migrate import --include=".github/quarto/quarto-1.8.24-linux-amd64.tar.gz"
    ```
  )

### Updating the Quarto version

Right now it's manual, as explained by the process above. In theory, we could automate it with another reusable workflow and an additional variable (for example: `QUARTO_AUTO_SYNC`) . . . probably? Here's a suggestion from our bestie GenAI I haven't tested, but could:

> Creates/updates the vendored tarball only when `vars.QUARTO_AUTO_SYNC` is "true" and the hosted file’s version doesn’t match `vars.QUARTO_VERSION`. It opens a PR with the new tarball (tracked via LFS).

```yaml
# .github/workflows/quarto-tarball-sync.yml
name: Quarto tarball sync
on:
  workflow_dispatch: {}
  schedule:
    - cron: "0 10 * * 1"   # Mondays 10:00 UTC

permissions:
  contents: write
  pull-requests: write

jobs:
  sync:
    if: ${{ vars.QUARTO_AUTO_SYNC == 'true' }}
    runs-on: ubuntu-latest
    env:
      DESIRED_VERSION: ${{ vars.QUARTO_VERSION }}
      QUARTO_DIR: .github/quarto
      PLATFORM: linux-amd64
    steps:
      - name: Checkout (LFS)
        uses: actions/checkout@v4
        with:
          lfs: true

      - name: Ensure LFS available & hydrated
        run: |
          git lfs version
          git lfs fetch --all
          git lfs checkout

      - name: Determine hosted version (if any)
        id: hosted
        shell: bash
        run: |
          set -euo pipefail
          mkdir -p "$QUARTO_DIR"
          shopt -s nullglob
          files=("$QUARTO_DIR"/quarto-*-${PLATFORM}.tar.gz)
          if (( ${#files[@]} )); then
            fname="$(basename "${files[0]}")"
            # extract X.Y.Z from "quarto-X.Y.Z-linux-amd64.tar.gz"
            if [[ "$fname" =~ ^quarto-([0-9.]+)-${PLATFORM}\.tar\.gz$ ]]; then
              echo "version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
              echo "file=${files[0]}" >> "$GITHUB_OUTPUT"
            fi
          else
            echo "version=" >> "$GITHUB_OUTPUT"
            echo "file=" >> "$GITHUB_OUTPUT"
          fi

      - name: Quick report
        run: |
          echo "Desired: ${DESIRED_VERSION}"
          echo "Hosted : ${{ steps.hosted.outputs.version:-'(none)' }}"

      - name: Exit early if already up to date
        if: ${{ steps.hosted.outputs.version == env.DESIRED_VERSION }}
        run: echo "Already up to date."

      - name: Download desired Quarto tarball
        if: ${{ steps.hosted.outputs.version != env.DESIRED_VERSION }}
        run: |
          set -euo pipefail
          url="https://github.com/quarto-dev/quarto-cli/releases/download/v${DESIRED_VERSION}/quarto-${DESIRED_VERSION}-${PLATFORM}.tar.gz"
          dest="${QUARTO_DIR}/quarto-${DESIRED_VERSION}-${PLATFORM}.tar.gz"
          echo "Fetching $url"
          curl -fL "$url" -o "$dest"
          file "$dest" | grep -qi 'gzip compressed' || { echo "Not a gzip"; exit 1; }

      - name: Track via Git LFS (if not already)
        run: |
          set -euo pipefail
          if ! grep -q '\*\.tar\.gz' .gitattributes 2>/dev/null; then
            git lfs track "*.tar.gz"
            git add .gitattributes
          fi

      - name: Remove old tarballs (keep only desired)
        if: ${{ steps.hosted.outputs.version != env.DESIRED_VERSION }}
        run: |
          set -euo pipefail
          find "$QUARTO_DIR" -maxdepth 1 -type f -name "quarto-*-${PLATFORM}.tar.gz" \
            ! -name "quarto-${DESIRED_VERSION}-${PLATFORM}.tar.gz" -print -delete

      - name: Commit changes
        if: ${{ steps.hosted.outputs.version != env.DESIRED_VERSION }}
        run: |
          set -euo pipefail
          git config user.name "github-actions[bot]"
          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
          git add -A
          git commit -m "chore(quarto): vendor ${DESIRED_VERSION} (${PLATFORM})" || echo "No changes to commit"

      - name: Open PR
        if: ${{ steps.hosted.outputs.version != env.DESIRED_VERSION }}
        uses: peter-evans/create-pull-request@v6
        with:
          branch: chore/quarto-${{ env.DESIRED_VERSION }}
          title: "Vendor Quarto ${DESIRED_VERSION} (${PLATFORM})"
          body: |
            - Desired: `${{ env.DESIRED_VERSION }}`
            - Replaces: `${{ steps.hosted.outputs.version || 'none' }}`
          commit-message: "chore(quarto): vendor ${{ env.DESIRED_VERSION }} (${{ env.PLATFORM }})"
```

> [!CAUTION]
> The issue is when we would run this workflow, and how we can slot it into the deployment workflows, since you can't access Actions variables within composite actions (so the workflow would need to run in parallel, or the deployment workflows should only run AFTER the Quarto version check succeeds). 
> 
> Again, just more tedious complexity, to fix an issue that is usually easily fixed by just re-running the workflow.

## Dependencies, breaking changes, and deployment notes

My suggestion is actually not to go with this complexity. Our Quarto download doesn't fail very often, but we do notice some inconsistencies between Quarto versions rendered by the workflows. For example, I'm locally running a much older version of Quarto but the deployment workflows have successfully run on the most recent version that is indicated in [`QUARTO_VERSION` ](https://github.com/validmind/documentation/settings/variables/actions/QUARTO_VERSION).

My suggestion is to keep that variable and instead use it to dynamically install the desired pinned version in our workflows like this:

```yaml
- name: Set up Quarto
  uses: quarto-dev/quarto-actions/setup@v2
  with:
    version: ${{ vars.QUARTO_VERSION }}
```

Again, the download has maybe failed twice (easily fixed by a workflow re-run), whereas version mismatches have caused a bit more confusion and we currently don't have a way to control which version the workflows render with.

## Release notes

n/a

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [ ] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [ ] Documentation updated (if required)
- [x] Environment variable additions/changes documented (if required)

