### PR TITLE
docs: JSON theme customization

### DIFF
--- a/site/guide/_sidebar.yaml
+++ b/site/guide/_sidebar.yaml
@@ -35,6 +35,7 @@ website:
           contents:
           - guide/configuration/manage-your-profile.qmd
           - guide/configuration/customize-your-dashboard.qmd
+          - guide/configuration/customize-platform-theme.qmd
         - guide/configuration/manage-platform-notifications.qmd
         - text: "---"
         - text: "Integrations"

--- a/site/guide/_sidebar.yaml
+++ b/site/guide/_sidebar.yaml
@@ -35,7 +35,8 @@ website:
           contents:
           - guide/configuration/manage-your-profile.qmd
           - guide/configuration/customize-your-dashboard.qmd
-          - guide/configuration/customize-platform-theme.qmd
+          - text: "Customize platform theme"
+            file:  guide/configuration/customize-platform-theme.qmd
         - guide/configuration/manage-platform-notifications.qmd
         - text: "---"
         - text: "Integrations"

--- a/site/guide/configuration/customize-platform-theme.qmd
+++ b/site/guide/configuration/customize-platform-theme.qmd
@@ -9,6 +9,9 @@ date: last-modified
 
 Customize the look and feel of the {{< var validmind.platform >}} using a JSON theme override.
 
+
+The {{< var validmind.platform >}} is built with Chakra UI. Theme customization works by supplying a JSON **object** that describes only the parts of the Chakra theme you want to change—such as color scales (`colors`), typography (`fonts`), light/dark semantic mappings (`semanticTokens`), or per-component styles (`components`). When you save, that object is **merged** into the product’s default theme using Chakra’s `extendTheme`: anything you omit keeps the standard value, and nested keys are combined rather than replaced wholesale.
+
 ::: {.callout-important title="Theme overrides are stored locally in your browser."}
 
 - Theme overrides apply only in the browser where you save them. Log ins via other browsers, profiles, or devices do not inherit any theme overrides.
@@ -31,26 +34,20 @@ Customize the look and feel of the {{< var validmind.platform >}} using a JSON t
 
 2. Under {{< fa user >}} Your Account, select **Theme Customization**.
 
-3. In **[theme override (json)]{.smallcaps}**, enter a single JSON object (not an array) describing the parts of the Chakra UI theme you want to change. The object is merged into the default theme using `extendTheme` (see the [Chakra UI theme documentation](https://chakra-ui.com/docs/styled-system/theme)).
+3. In **[theme override (json)]{.smallcaps}**, enter one JSON **object** (not an array) in the Chakra theme shape described in the introduction. For field names, nesting, and component style patterns, use the [Chakra UI v2 customize theme guide](https://v2.chakra-ui.com/docs/styled-system/customize-theme).
 
     Fix any errors shown under the field until the helper text indicates valid JSON.
 
 4. Click **Save Changes** to apply the override immediately across the {{< var vm.platform >}} in your browser.
 
-<!-- ::: {.callout}
-
-**Save Changes** stays disabled while JSON is invalid or when the editor matches what is already saved. **Reset to Default** is disabled when no override is stored.
-
-So: cache-only or cookies-only is usually safe for the theme; anything that explicitly clears site data or local storage for the ValidMind app URL can clear it. If you want this spelled out in customize-platform-theme.qmd, say the word and we can add a short callout.
-
-::: -->
+## Limitations
 
 - Incorrect or extreme values can make parts of the UI hard to read or interact with; keep a known-good JSON copy before experimenting.
 - This workflow does **not** replace your personal light or dark preference on the Profile screen. See [Manage your profile](/guide/configuration/manage-your-profile.qmd).
 
-### JSON schema reference
+## JSON schema reference
 
-Overrides follow the shape of a [Chakra UI theme](https://chakra-ui.com/docs/styled-system/theme) object. You can supply any subset of keys; unspecified values keep the product defaults.
+Overrides follow the shape of a [Chakra UI theme](https://v2.chakra-ui.com/docs/styled-system/customize-theme) object. You can supply any subset of keys; unspecified values keep the product defaults.
 
 | Top-level key | Typical use |
 | --- | --- |

--- a/site/guide/configuration/customize-platform-theme.qmd
+++ b/site/guide/configuration/customize-platform-theme.qmd
@@ -7,52 +7,50 @@ title: "Customize ValidMind Platform theme"
 date: last-modified
 ---
 
-Tune colors, fonts, and Chakra UI component styles on the {{< var validmind.platform >}} using a JSON theme override. Changes apply immediately in this browser and stay in local storage—not your profile. Theme Customization appears under Settings only when your organization enables it.
+Customize the look and feel of the {{< var validmind.platform >}} using a JSON theme override.
 
-::: {.callout-important}
+<!-- ::: {.callout-important}
 
 ## Local storage only
 
+Access to theme customization is set by your organization and will only appear when enabled.
+
+Changes apply immediately in your browser and stay in local storage — not your profile.
+
 Unlike most options under [Personalize ValidMind](/guide/configuration/personalize-validmind.qmd), theme overrides are **not** saved to your account. They stay in this browser until you reset them or clear site data. Backend persistence may be added later.
 
-:::
+::: -->
 
 ::: {.attn}
 
 ## Prerequisites
 
 - [x] {{< var link.login >}}
-- [x] Access to **Theme Customization** in Settings (if the menu item is missing, contact your administrator—the feature is enabled per deployment).
+- [x] Theme customization has been enabled by your organization's administrators.^
 
 :::
 
-## Open Theme Customization
+## Apply a JSON theme override
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-2. Under **YOUR ACCOUNT**, select **Theme Customization**.
+2. Under {{< fa user >}} Your Account, select **Theme Customization**.
 
-   If you do not see **Theme Customization**, the feature is not enabled for your environment.
+3. In **[theme override (json)]{.smallcaps}**, enter a single JSON object (not an array) describing the parts of the Chakra UI theme you want to change. The object is merged into the default theme using `extendTheme` (see the [Chakra UI theme documentation](https://chakra-ui.com/docs/styled-system/theme)).
 
-## Edit and save a theme override
+    Fix any errors shown under the field until the helper text indicates valid JSON.
 
-1. In **[theme override (json)]{.smallcaps}**, enter a single JSON **object** (not an array) describing the parts of the Chakra UI theme you want to change. The object is merged into the default theme using `extendTheme` (see the [Chakra UI theme documentation](https://chakra-ui.com/docs/styled-system/theme)).
+4. Click **Save Changes** to apply the override immediately across the {{< var vm.platform >}} in your browser.
 
-2. Fix any errors shown under the field until the helper text indicates valid JSON.
-
-3. Optional: Click **Show Example** to view a full sample override, then **Hide Example** when you are done.
-
-4. Click **Save Changes** to apply the override immediately across the {{< var vm.platform >}} in this browser.
-
-5. To discard customizations and return to defaults, click **Reset to Default**.
-
-::: {.callout}
+<!-- ::: {.callout}
 
 **Save Changes** stays disabled while JSON is invalid or when the editor matches what is already saved. **Reset to Default** is disabled when no override is stored.
 
-:::
+So: cache-only or cookies-only is usually safe for the theme; anything that explicitly clears site data or local storage for the ValidMind app URL can clear it. If you want this spelled out in customize-platform-theme.qmd, say the word and we can add a short callout.
 
-## Schema reference
+::: -->
+
+### JSON schema reference
 
 Overrides follow the shape of a [Chakra UI theme](https://chakra-ui.com/docs/styled-system/theme) object. You can supply any subset of keys; unspecified values keep the product defaults.
 

--- a/site/guide/configuration/customize-platform-theme.qmd
+++ b/site/guide/configuration/customize-platform-theme.qmd
@@ -9,13 +9,14 @@ date: last-modified
 
 Customize the look and feel of the {{< var validmind.platform >}} using a JSON theme override.
 
-Theme customization does not replace your personal light or dark preference set under your personal profile.^*
+Theme overrides allow you to supply a JSON object describing parts of the theme you want to change. Your customizations are merged into the default theme — anything you omit keeps the standard value, and nested keys are combined rather than replaced wholesale.
 
-::: {.callout-important title="Theme overrides are stored locally in your browser."}
+Note that theme customization does not replace your personal light or dark mode settings under your profile.[^1]
 
-- Custom themes apply only to you and do not affect other users.
-- Theme overrides apply only in the browser where you save them. Log ins via other browsers, profiles, or devices do not inherit any theme overrides.
-- Clearing site data or local storage for the {{< var validmind.platform >}} removes any applied theme overrides.
+::: {.callout-important title="Custom themes apply only to you and do not affect other users."}
+
+- Theme overrides are stored locally in your browser. Log ins via other browsers, profiles, or devices do not inherit any theme overrides.
+- Clearing site data or local storage for the {{< var validmind.platform >}} removes any applied theme overrides. We recommend keeping backups of custom working JSON.
 
 :::
 
@@ -24,13 +25,11 @@ Theme customization does not replace your personal light or dark preference set 
 ## Prerequisites
 
 - [x] {{< var link.login >}}
-- [x] Theme customization has been enabled by your organization's administrators.^
+- [x] Theme customization has been enabled by your organization's administrators.
 
 :::
 
 ## Apply JSON theme overrides
-
-Powered by Chakra UI,^ custom theming allows you to supply a JSON object describing parts of the theme you want to override. Your customizations are merged into the product's default theme — anything you omit keeps the standard value, and nested keys are combined rather than replaced wholesale.
 
 To apply a JSON theme override:
 
@@ -38,23 +37,17 @@ To apply a JSON theme override:
 
 2. Under {{< fa user >}} Your Account, select **Theme Customization**.
 
-3. In **[theme override (json)]{.smallcaps}**, enter one root JSON **object** (not an array) following the shape of a [Chakra UI theme](https://v2.chakra-ui.com/docs/styled-system/customize-theme) object.^
+3. In **[theme override (json)]{.smallcaps}**, enter one root JSON object (not an array) following the shape of a Chakra UI theme object.[^2]
 
-    <!-- Fix any errors shown under the field until the helper text indicates valid JSON. -->
-
-4. Click **Save Changes** to apply the override immediately across the {{< var vm.platform >}} in your browser.^
-
-<br>
+4. Click **Save Changes** to apply the override immediately across the {{< var validmind.platform >}} in your browser.[^3]
 
 ::: {.callout-button .pl4 .nt4}
 ::: {.callout collapse="true" appearance="minimal"}
 ### What are best practices for creating theme overrides?
 
-- Keep a known-good JSON copy before experimenting with overrides.
-- Incorrect or extreme values can make parts of the UI hard to read or interact with.
-- Keep your overrides small and focused.
-- Use the smallest possible change set to achieve your desired effect.
-
+- Keep a known-good JSON copy before experimenting with new overrides.
+- Keep your overrides small and focused. Use the smallest possible change set to achieve your desired effect.
+- Avoid extreme values as they can make the interface hard to read or interact with.
 
 :::
 :::
@@ -62,19 +55,28 @@ To apply a JSON theme override:
 ## Troubleshooting
 
 I cannot locate Theme Customization under **{{< fa gear >}} Settings**.
-: Your organization may not have enabled the feature. Confirm with an administrator whether or not you should have access.
+: Your organization may not have enabled theme customization. Confirm with an administrator whether or not you should have access.
 
 **Save Changes** is grayed out.
-: Either your JSON is invalid, or the inputted override already matches the saved override. Resolve any error messages, or change the JSON and try again.
+: Either your JSON is invalid, or the input already matches the saved override. Resolve any error messages, or change the JSON and try again.
 
 I receive error messages regarding my input.
 : Ensure the document parses as JSON (double quotes on keys, no trailing commas) and that the root value is an object `{ ... }`, not an array.
 
-My theme looks wrong after saving.
-: Click **Reset to Default**, reload the page, and reapply a smaller change set.
+My theme looks wrong after saving. How do I undo the changes?
+: Click **Reset to Default**, and reload the page to revert to the default theme.
 
 Other users in my organization still see the default theme.
-: Expected. Overrides are stored locally in your browser only, not for the whole organization.
+: This is as expected — overrides are stored locally in your browser, not applied across the whole organization.
 
 My theme overrides disappeared.
 : Local storage may have been cleared, or you are using a different browser or device. Re-enter or restore your JSON from a backup.
+
+
+<!-- FOOTNOTES -->
+
+[^1]: [Manage your profile](/guide/configuration/manage-your-profile.qmd#user-interface-preferences)
+
+[^2]: **Chakra UI**: [Customize Theme](https://v2.chakra-ui.com/docs/styled-system/customize-theme)
+
+[^3]: If there are errors in your JSON, the **Save Changes** button will be grayed out.

--- a/site/guide/configuration/customize-platform-theme.qmd
+++ b/site/guide/configuration/customize-platform-theme.qmd
@@ -9,11 +9,11 @@ date: last-modified
 
 Customize the look and feel of the {{< var validmind.platform >}} using a JSON theme override.
 
-
-The {{< var validmind.platform >}} is built with Chakra UI. Theme customization works by supplying a JSON **object** that describes only the parts of the Chakra theme you want to change—such as color scales (`colors`), typography (`fonts`), light/dark semantic mappings (`semanticTokens`), or per-component styles (`components`). When you save, that object is **merged** into the product’s default theme using Chakra’s `extendTheme`: anything you omit keeps the standard value, and nested keys are combined rather than replaced wholesale.
+Theme customization does not replace your personal light or dark preference set under your personal profile.^*
 
 ::: {.callout-important title="Theme overrides are stored locally in your browser."}
 
+- Custom themes apply only to you and do not affect other users.
 - Theme overrides apply only in the browser where you save them. Log ins via other browsers, profiles, or devices do not inherit any theme overrides.
 - Clearing site data or local storage for the {{< var validmind.platform >}} removes any applied theme overrides.
 
@@ -28,76 +28,53 @@ The {{< var validmind.platform >}} is built with Chakra UI. Theme customization 
 
 :::
 
-## Apply a JSON theme override
+## Apply JSON theme overrides
+
+Powered by Chakra UI,^ custom theming allows you to supply a JSON object describing parts of the theme you want to override. Your customizations are merged into the product's default theme — anything you omit keeps the standard value, and nested keys are combined rather than replaced wholesale.
+
+To apply a JSON theme override:
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
 2. Under {{< fa user >}} Your Account, select **Theme Customization**.
 
-3. In **[theme override (json)]{.smallcaps}**, enter one JSON **object** (not an array) in the Chakra theme shape described in the introduction. For field names, nesting, and component style patterns, use the [Chakra UI v2 customize theme guide](https://v2.chakra-ui.com/docs/styled-system/customize-theme).
+3. In **[theme override (json)]{.smallcaps}**, enter one root JSON **object** (not an array) following the shape of a [Chakra UI theme](https://v2.chakra-ui.com/docs/styled-system/customize-theme) object.^
 
-    Fix any errors shown under the field until the helper text indicates valid JSON.
+    <!-- Fix any errors shown under the field until the helper text indicates valid JSON. -->
 
-4. Click **Save Changes** to apply the override immediately across the {{< var vm.platform >}} in your browser.
+4. Click **Save Changes** to apply the override immediately across the {{< var vm.platform >}} in your browser.^
 
-## Limitations
+<br>
 
-- Incorrect or extreme values can make parts of the UI hard to read or interact with; keep a known-good JSON copy before experimenting.
-- This workflow does **not** replace your personal light or dark preference on the Profile screen. See [Manage your profile](/guide/configuration/manage-your-profile.qmd).
+::: {.callout-button .pl4 .nt4}
+::: {.callout collapse="true" appearance="minimal"}
+### What are best practices for creating theme overrides?
 
-## JSON schema reference
+- Keep a known-good JSON copy before experimenting with overrides.
+- Incorrect or extreme values can make parts of the UI hard to read or interact with.
+- Keep your overrides small and focused.
+- Use the smallest possible change set to achieve your desired effect.
 
-Overrides follow the shape of a [Chakra UI theme](https://v2.chakra-ui.com/docs/styled-system/customize-theme) object. You can supply any subset of keys; unspecified values keep the product defaults.
 
-| Top-level key | Typical use |
-| --- | --- |
-| `colors` | Scales such as `brand`, `brandSecondary`, and `neutral` (for example `500`, `base`, `950`). |
-| `fonts` | `heading` and `body` font stacks. |
-| `radii` | Corner radii (for example `sm`, `md`). |
-| `semanticTokens` | Light and dark mappings for semantic colors (for example `background.page`, `text.primary`, `border.base`). |
-| `components` | `baseStyle`, `variants`, and sizes for Chakra components (for example `Button`). |
-
-Minimal example:
-
-```json
-{
-  "colors": {
-    "brand": {
-      "500": "#6B3077",
-      "base": "#6B3077"
-    }
-  },
-  "fonts": {
-    "heading": "Roboto, system-ui, sans-serif",
-    "body": "Roboto, system-ui, sans-serif"
-  }
-}
-```
-
-The in-app **Show Example** demonstrates a larger override (including `semanticTokens` and `components`) you can copy and adapt.
+:::
+:::
 
 ## Troubleshooting
 
-**I do not see Theme Customization under Settings.**
+I cannot locate Theme Customization under **{{< fa gear >}} Settings**.
+: Your organization may not have enabled the feature. Confirm with an administrator whether or not you should have access.
 
-: Your organization may not have enabled the feature. Ask an administrator to confirm it is turned on for your environment.
+**Save Changes** is grayed out.
+: Either your JSON is invalid, or the inputted override already matches the saved override. Resolve any error messages, or change the JSON and try again.
 
-**Save Changes is grayed out.**
-
-: Either the JSON is invalid, or the textarea already matches the saved override. Resolve any error message under the field, or change the JSON and try again.
-
-**I see “Invalid JSON” or “Theme override must be a JSON object.”**
-
+I receive error messages regarding my input.
 : Ensure the document parses as JSON (double quotes on keys, no trailing commas) and that the root value is an object `{ ... }`, not an array.
 
-**My theme looks wrong after saving.**
+My theme looks wrong after saving.
+: Click **Reset to Default**, reload the page, and reapply a smaller change set.
 
-: Click **Reset to Default**, reload the page, and reapply a smaller change set. Compare with the **Show Example** structure and the schema table above.
-
-**Colleagues still see the default theme.**
-
+Other users in my organization still see the default theme.
 : Expected. Overrides are stored locally in your browser only, not for the whole organization.
 
-**Overrides disappeared.**
-
+My theme overrides disappeared.
 : Local storage may have been cleared, or you are using a different browser or device. Re-enter or restore your JSON from a backup.

--- a/site/guide/configuration/customize-platform-theme.qmd
+++ b/site/guide/configuration/customize-platform-theme.qmd
@@ -9,17 +9,12 @@ date: last-modified
 
 Customize the look and feel of the {{< var validmind.platform >}} using a JSON theme override.
 
-<!-- ::: {.callout-important}
+::: {.callout-important title="Theme overrides are stored locally in your browser."}
 
-## Local storage only
+- Theme overrides apply only in the browser where you save them. Log ins via other browsers, profiles, or devices do not inherit any theme overrides.
+- Clearing site data or local storage for the {{< var validmind.platform >}} removes any applied theme overrides.
 
-Access to theme customization is set by your organization and will only appear when enabled.
-
-Changes apply immediately in your browser and stay in local storage — not your profile.
-
-Unlike most options under [Personalize ValidMind](/guide/configuration/personalize-validmind.qmd), theme overrides are **not** saved to your account. They stay in this browser until you reset them or clear site data. Backend persistence may be added later.
-
-::: -->
+:::
 
 ::: {.attn}
 
@@ -49,6 +44,9 @@ Unlike most options under [Personalize ValidMind](/guide/configuration/personali
 So: cache-only or cookies-only is usually safe for the theme; anything that explicitly clears site data or local storage for the ValidMind app URL can clear it. If you want this spelled out in customize-platform-theme.qmd, say the word and we can add a short callout.
 
 ::: -->
+
+- Incorrect or extreme values can make parts of the UI hard to read or interact with; keep a known-good JSON copy before experimenting.
+- This workflow does **not** replace your personal light or dark preference on the Profile screen. See [Manage your profile](/guide/configuration/manage-your-profile.qmd).
 
 ### JSON schema reference
 
@@ -80,20 +78,6 @@ Minimal example:
 ```
 
 The in-app **Show Example** demonstrates a larger override (including `semanticTokens` and `components`) you can copy and adapt.
-
-## Use cases
-
-- Piloting brand colors or typography before asking administrators for a wider rollout
-- Demos or training environments where a distinct palette improves recognition
-- Tweaking semantic tokens for contrast or readability while staying within the supported theme system
-
-## Limitations
-
-- Overrides apply **only in the browser** where you save them; other browsers, profiles, or devices do not inherit them.
-- Clearing site data or local storage for the {{< var vm.platform >}} removes the override.
-- The feature is controlled per environment; not every deployment shows **Theme Customization**.
-- Incorrect or extreme values can make parts of the UI hard to read or interact with; keep a known-good JSON copy before experimenting.
-- This workflow does **not** replace your personal light or dark preference on the Profile screen. See [Manage your profile](/guide/configuration/manage-your-profile.qmd).
 
 ## Troubleshooting
 

--- a/site/guide/configuration/customize-platform-theme.qmd
+++ b/site/guide/configuration/customize-platform-theme.qmd
@@ -7,3 +7,118 @@ title: "Customize ValidMind Platform theme"
 date: last-modified
 ---
 
+Tune colors, fonts, and Chakra UI component styles on the {{< var validmind.platform >}} using a JSON theme override. Changes apply immediately in this browser and stay in local storage—not your profile. Theme Customization appears under Settings only when your organization enables it.
+
+::: {.callout-important}
+
+## Local storage only
+
+Unlike most options under [Personalize ValidMind](/guide/configuration/personalize-validmind.qmd), theme overrides are **not** saved to your account. They stay in this browser until you reset them or clear site data. Backend persistence may be added later.
+
+:::
+
+::: {.attn}
+
+## Prerequisites
+
+- [x] {{< var link.login >}}
+- [x] Access to **Theme Customization** in Settings (if the menu item is missing, contact your administrator—the feature is enabled per deployment).
+
+:::
+
+## Open Theme Customization
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+2. Under **YOUR ACCOUNT**, select **Theme Customization**.
+
+   If you do not see **Theme Customization**, the feature is not enabled for your environment.
+
+## Edit and save a theme override
+
+1. In **[theme override (json)]{.smallcaps}**, enter a single JSON **object** (not an array) describing the parts of the Chakra UI theme you want to change. The object is merged into the default theme using `extendTheme` (see the [Chakra UI theme documentation](https://chakra-ui.com/docs/styled-system/theme)).
+
+2. Fix any errors shown under the field until the helper text indicates valid JSON.
+
+3. Optional: Click **Show Example** to view a full sample override, then **Hide Example** when you are done.
+
+4. Click **Save Changes** to apply the override immediately across the {{< var vm.platform >}} in this browser.
+
+5. To discard customizations and return to defaults, click **Reset to Default**.
+
+::: {.callout}
+
+**Save Changes** stays disabled while JSON is invalid or when the editor matches what is already saved. **Reset to Default** is disabled when no override is stored.
+
+:::
+
+## Schema reference
+
+Overrides follow the shape of a [Chakra UI theme](https://chakra-ui.com/docs/styled-system/theme) object. You can supply any subset of keys; unspecified values keep the product defaults.
+
+| Top-level key | Typical use |
+| --- | --- |
+| `colors` | Scales such as `brand`, `brandSecondary`, and `neutral` (for example `500`, `base`, `950`). |
+| `fonts` | `heading` and `body` font stacks. |
+| `radii` | Corner radii (for example `sm`, `md`). |
+| `semanticTokens` | Light and dark mappings for semantic colors (for example `background.page`, `text.primary`, `border.base`). |
+| `components` | `baseStyle`, `variants`, and sizes for Chakra components (for example `Button`). |
+
+Minimal example:
+
+```json
+{
+  "colors": {
+    "brand": {
+      "500": "#6B3077",
+      "base": "#6B3077"
+    }
+  },
+  "fonts": {
+    "heading": "Roboto, system-ui, sans-serif",
+    "body": "Roboto, system-ui, sans-serif"
+  }
+}
+```
+
+The in-app **Show Example** demonstrates a larger override (including `semanticTokens` and `components`) you can copy and adapt.
+
+## Use cases
+
+- Piloting brand colors or typography before asking administrators for a wider rollout
+- Demos or training environments where a distinct palette improves recognition
+- Tweaking semantic tokens for contrast or readability while staying within the supported theme system
+
+## Limitations
+
+- Overrides apply **only in the browser** where you save them; other browsers, profiles, or devices do not inherit them.
+- Clearing site data or local storage for the {{< var vm.platform >}} removes the override.
+- The feature is controlled per environment; not every deployment shows **Theme Customization**.
+- Incorrect or extreme values can make parts of the UI hard to read or interact with; keep a known-good JSON copy before experimenting.
+- This workflow does **not** replace your personal light or dark preference on the Profile screen. See [Manage your profile](/guide/configuration/manage-your-profile.qmd).
+
+## Troubleshooting
+
+**I do not see Theme Customization under Settings.**
+
+: Your organization may not have enabled the feature. Ask an administrator to confirm it is turned on for your environment.
+
+**Save Changes is grayed out.**
+
+: Either the JSON is invalid, or the textarea already matches the saved override. Resolve any error message under the field, or change the JSON and try again.
+
+**I see “Invalid JSON” or “Theme override must be a JSON object.”**
+
+: Ensure the document parses as JSON (double quotes on keys, no trailing commas) and that the root value is an object `{ ... }`, not an array.
+
+**My theme looks wrong after saving.**
+
+: Click **Reset to Default**, reload the page, and reapply a smaller change set. Compare with the **Show Example** structure and the schema table above.
+
+**Colleagues still see the default theme.**
+
+: Expected. Overrides are stored locally in your browser only, not for the whole organization.
+
+**Overrides disappeared.**
+
+: Local storage may have been cleared, or you are using a different browser or device. Re-enter or restore your JSON from a backup.

--- a/site/guide/configuration/customize-platform-theme.qmd
+++ b/site/guide/configuration/customize-platform-theme.qmd
@@ -1,0 +1,9 @@
+---
+# Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+# Refer to the LICENSE file in the root of this repository for details.
+# SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
+# USING THE VARIABLE IN THE TITLE MESSES UP THE BREADCRUMB
+title: "Customize ValidMind Platform theme"
+date: last-modified
+---
+

--- a/site/guide/configuration/personalize-validmind.qmd
+++ b/site/guide/configuration/personalize-validmind.qmd
@@ -8,13 +8,14 @@ date: last-modified
 listing:
   - id: personalize-validmind
     type: grid
-    grid-columns: 2
+    grid-columns: 3
     max-description-length: 250
     sort: false
     fields: [title, description]
     contents:
       - manage-your-profile.qmd
       - customize-your-dashboard.qmd
+      - customize-platform-theme.qmd
 ---
 
 Configure the look and functionality of your instance of the {{< var validmind.platform>}}. Changes are automatically saved to your account and do not affect other users.


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-15578

Users can now override their personal instance of the ValidMind Platform if the functionality is enabled by organization administrators. Docs updated to reflect this feature.

## How to test

Click on the live previews:

- [Personalize ValidMind](https://docs-staging.validmind.ai/pr_previews/beck/sc-15578/documentation-theme-customization/guide/configuration/personalize-validmind.html):
  - [**Customize ValidMind Platform theme**](https://docs-staging.validmind.ai/pr_previews/beck/sc-15578/documentation-theme-customization/guide/configuration/customize-platform-theme.html) (net-new page)

## What needs special review?

Not entirely sure we want these docs to be user-facing yet. Someone will have to confirm as the original frontend feature PR was labelled as `internal` but I see it on production for my test org.

## Dependencies, breaking changes, and deployment notes

n/a

## Release notes

Customize the look and feel of the {{< var validmind.platform >}} using a JSON theme override. Theme overrides allow you to supply a JSON object describing parts of the theme you want to change. Your customizations are merged into the default theme — anything you omit keeps the standard value, and nested keys are combined rather than replaced wholesale.

[Customize {{< var validmind.platform >} theme](https://docs-staging.validmind.ai/guide/configuration/customize-platform-theme.html)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

