### PR TITLE
docs: Edit active workflow end dates

### DIFF
--- a/site/guide/workflows/_abort-workflows.qmd
+++ b/site/guide/workflows/_abort-workflows.qmd
@@ -21,7 +21,7 @@ To cancel a run of a workflow:
 
 1. Click on the name of the workflow you'd like to abort to open that specific workflow's details.
 
-1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa ban >}} Abort Workflow**.
+1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
 
 1. On the confirmation page, make sure **[restart workflow after aborting]{.smallcaps}** is untoggled, then click **{{< fa arrow-right >}} Yes, Abort Workflow** to abort your workflow.
 
@@ -31,7 +31,7 @@ To cancel a run of a workflow:
 
 1. Click on the name of the workflow you'd like to abort to open that specific workflow's details.
 
-1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa ban >}} Abort Workflow**.
+1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
 
 1. On the confirmation page, make sure **[restart workflow after aborting]{.smallcaps}** is untoggled, then click **{{< fa arrow-right >}} Yes, Abort Workflow** to abort your workflow.
 
@@ -55,7 +55,7 @@ To cancel a run of a workflow:
 
 1. Click on the name of the workflow you'd like to abort to open that specific workflow's details.
 
-1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa ban >}} Abort Workflow**.
+1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
 
 1. On the confirmation page, make sure **[restart workflow after aborting]{.smallcaps}** is untoggled, then click **{{< fa arrow-right >}} Yes, Abort Workflow** to abort your workflow.
 
@@ -65,7 +65,7 @@ To cancel a run of a workflow:
 
 1. Click on the name of the workflow you'd like to abort to open that specific workflow's details.
 
-1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa ban >}} Abort Workflow**.
+1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
 
 1. On the confirmation page, make sure **[restart workflow after aborting]{.smallcaps}** is untoggled, then click **{{< fa arrow-right >}} Yes, Abort Workflow** to abort your workflow.
 

--- a/site/guide/workflows/_reset-workflows.qmd
+++ b/site/guide/workflows/_reset-workflows.qmd
@@ -21,7 +21,7 @@ To reset a workflow to the beginning:
 
 1. Click on the name of the workflow you'd like to reset to open that specific workflow's details.
 
-1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa ban >}} Abort Workflow**.
+1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
 
 1. On the confirmation page, toggle **[restart workflow after aborting]{.smallcaps}** on, then click **{{< fa arrow-right >}} Yes, Abort Workflow** to restart your workflow.
 
@@ -31,7 +31,7 @@ To reset a workflow to the beginning:
 
 1. Click on the name of the workflow you'd like to reset to open that specific workflow's details.
 
-1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa ban >}} Abort Workflow**.
+1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
 
 1. On the confirmation page, toggle **[restart workflow after aborting]{.smallcaps}** on, then click **{{< fa arrow-right >}} Yes, Abort Workflow** to restart your workflow.
 
@@ -55,7 +55,7 @@ To reset a workflow to the beginning:
 
 1. Click on the name of the workflow you'd like to reset to open that specific workflow's details.
 
-1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa ban >}} Abort Workflow**.
+1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
 
 1. On the confirmation page, toggle **[restart workflow after aborting]{.smallcaps}** on, then click **{{< fa arrow-right >}} Yes, Abort Workflow** to restart your workflow.
 
@@ -65,7 +65,7 @@ To reset a workflow to the beginning:
 
 1. Click on the name of the workflow you'd like to reset to open that specific workflow's details.
 
-1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa ban >}} Abort Workflow**.
+1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
 
 1. On the confirmation page, toggle **[restart workflow after aborting]{.smallcaps}** on, then click **{{< fa arrow-right >}} Yes, Abort Workflow** to restart your workflow.
 

--- a/site/guide/workflows/manage-workflows.qmd
+++ b/site/guide/workflows/manage-workflows.qmd
@@ -63,7 +63,9 @@ To manually resume a workflow in a {{< fa clock >}} Wait state:[^4]
 
 ::::
 
-## Update workflow versions
+## Update active workflows
+
+### Update workflow versions
 
 ::: {.callout-important}
 Applying the latest version of a workflow will reset the workflow to the beginning.
@@ -75,6 +77,30 @@ If you have updated a workflow's configuration and want to apply the newest vers
 1. Abort the existing execution of the workflow.[^8]
 
 2. Manually initiate the workflow again.[^9]
+
+### Edit workflow end dates
+
+
+
+::: {.panel-tabset}
+
+#### On models
+
+1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
+
+1. Select a model or find your model by applying a filter or searching for it.^[[Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)]
+
+1. On the landing page of your model, locate the [active workflows]{.smallcaps} section.
+
+1. Click on the name of the workflow you'd like to edit the end date for to open that specific workflow's details.
+
+1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
+
+#### On artifacts
+
+
+
+:::
 
 ## Abort workflows
 

--- a/site/guide/workflows/manage-workflows.qmd
+++ b/site/guide/workflows/manage-workflows.qmd
@@ -80,7 +80,7 @@ If you have updated a workflow's configuration and want to apply the newest vers
 
 ### Edit workflow end dates
 
-
+To adjust the expected end date for a workflow:
 
 ::: {.panel-tabset}
 
@@ -88,17 +88,29 @@ If you have updated a workflow's configuration and want to apply the newest vers
 
 1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
 
-1. Select a model or find your model by applying a filter or searching for it.^[[Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)]
+2. Select a model or find your model by applying a filter or searching for it.[^10]
 
-1. On the landing page of your model, locate the [active workflows]{.smallcaps} section.
+3. On the landing page of your model, locate the [active workflows]{.smallcaps} section.
 
-1. Click on the name of the workflow you'd like to edit the end date for to open that specific workflow's details.
+4. Click on the name of the workflow you'd like to edit the end date for to open that specific workflow's details.
 
-1. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
+5. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa calendar >}} Edit Expected End Date**.
+
+6. Enter in the new [expected end date]{.smallcaps} for the workflow.
+
+7. Click **Save Expected End Date** to apply the new date.
 
 #### On artifacts
 
+1. On the details page of your artifact,[^11] locate the [active workflows]{.smallcaps} section.
 
+2. Click on the name of the workflow you'd like to edit the end date for to open that specific workflow's details.
+
+3. On the workflow's detail modal, click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa calendar >}} Edit Expected End Date**.
+
+4. Enter in the new [expected end date]{.smallcaps} for the workflow.
+
+5. Click **Save Expected End Date** to apply the new date.
 
 :::
 
@@ -125,4 +137,8 @@ If you have updated a workflow's configuration and want to apply the newest vers
 
 [^8]: [Abort workflows](/guide/workflows/manage-workflows.qmd#abort-workflows)
 
-[^9]: [Initiate workflows](/guide/workflows/manage-workflows.qmd#initiate-workflows)  
+[^9]: [Initiate workflows](/guide/workflows/manage-workflows.qmd#initiate-workflows)
+
+[^10]: [Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)
+
+[^11]: [View and filter artifacts](/guide/model-validation/view-filter-artifacts.qmd#view-artifacts)

--- a/site/training/administrator-fundamentals/using-validmind-for-risk-management.qmd
+++ b/site/training/administrator-fundamentals/using-validmind-for-risk-management.qmd
@@ -391,7 +391,7 @@ As an administrator, you may need to reset or abort workflows as required:
 1. Select the name of your model you registered for this course to open up the model details page.
 2. On the landing page of your model, locate the [active workflows]{.smallcaps} section.
 3. Click on the name of the workflow you manually initiated earlier to open that workflow's details.
-4. Click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select **{{< fa ban >}} Abort Workflow**.
+4. Click on the **{{< fa ellipsis-vertical >}}** in the top-right hand corner and select [**{{< fa ban >}} Abort Workflow**]{.red}.
 5. Toggle **[restart workflow after aborting]{.smallcaps}** on, then click **{{< fa arrow-right >}} Yes, Abort Workflow** to restart your workflow.
 
 When you're done, click [{{< fa chevron-right >}}]() to continue.


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-15463

You can now edit the end dates for active workflows; docs updated to reflect this functionality.

## How to test

Click on the live previews and compare the before/afters: [**Manage workflows** ](https://docs-staging.validmind.ai/pr_previews/beck/sc-15463/documentation-ability-to-change-workflow/guide/workflows/manage-workflows.html#edit-workflow-end-dates)

| OLD | NEW |
|--|--|
| <img width="1275" height="404" alt="Screenshot 2026-04-07 at 1 19 38 PM" src="https://github.com/user-attachments/assets/f2fd14dc-840e-4d18-904b-b07e235c2e5b" /> | <img width="1139" height="861" alt="Screenshot 2026-04-07 at 1 37 22 PM" src="https://github.com/user-attachments/assets/5757eae5-3d8a-47da-9a2c-fb145dc5f0e7" />|

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

n/a

## Release notes

Covered in 26.04: **[Modify workflow execution end dates](https://docs.validmind.ai/releases/frontend/26.04/pr-2339.html)**

## Checklist
- [x] What and why
- [x] Screenshots or videos (Frontend)
- [x] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

