### PR TITLE
HTTP proxy guide for ValidMind Library

### DIFF
--- a/site/developer/_sidebar.yaml
+++ b/site/developer/_sidebar.yaml
@@ -23,6 +23,8 @@ website:
             - text: "Install and initialize the library for R"
               file: developer/model-documentation/install-and-initialize-validmind-for-r.qmd
         - developer/model-documentation/store-credentials-in-env-file.qmd
+        - text: "Use an HTTP proxy with the library"
+          file: developer/model-documentation/use-http-proxy-with-validmind-library.qmd
         - text: "---"
         - text: "End-to-End Tutorials"
         # USING THE VARIABLE IN THE LINK TEXT MESSES UP THE MOBILE VIEW & BREADCRUMB

--- a/site/developer/_sidebar.yaml
+++ b/site/developer/_sidebar.yaml
@@ -22,9 +22,9 @@ website:
               file: developer/model-documentation/install-and-initialize-validmind-library.qmd
             - text: "Install and initialize the library for R"
               file: developer/model-documentation/install-and-initialize-validmind-for-r.qmd
+            - text: "Use an HTTP proxy with the library"
+              file: developer/model-documentation/use-http-proxy-with-validmind-library.qmd
         - developer/model-documentation/store-credentials-in-env-file.qmd
-        - text: "Use an HTTP proxy with the library"
-          file: developer/model-documentation/use-http-proxy-with-validmind-library.qmd
         - text: "---"
         - text: "End-to-End Tutorials"
         # USING THE VARIABLE IN THE LINK TEXT MESSES UP THE MOBILE VIEW & BREADCRUMB

--- a/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
+++ b/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
@@ -1,0 +1,86 @@
+---
+# Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+# Refer to the LICENSE file in the root of this repository for details.
+# SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
+title: "Use an HTTP proxy with the ValidMind Library"
+date: last-modified
+listing:
+  - id: whats-next
+    type: grid
+    max-description-length: 250
+    sort: false
+    fields: [title, description]
+    grid-columns: 2
+    contents:
+    - ../how-to/testing-overview.qmd
+    - ../how-to/feature-overview.qmd
+---
+
+The {{< var validmind.developer >}} does not provide a `proxy` argument on `vm.init()`. Outbound HTTPS traffic to the ValidMind API relies on standard Python HTTP clients that honor proxy-related environment variables, which lets you work behind corporate or regional proxies without custom library configuration.
+
+::: {.attn}
+
+## Prerequisites
+
+- [x] {{< var link.login >}}
+- [x] You can set environment variables for the user or service account that runs Python or Jupyter.[^1]
+- [x] You have proxy connection details from your network administrator (host, port, and authentication rules if required).
+
+:::
+
+## 1. Set proxy environment variables
+
+Set the variables **before** you start the Python process or Jupyter kernel so the process inherits them when the library opens HTTP connections.
+
+Common variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `HTTP_PROXY` | Proxy URL for `http` requests. |
+| `HTTPS_PROXY` | Proxy URL for `https` requests (typical for the ValidMind API). |
+| `ALL_PROXY` | Fallback when a scheme-specific variable is not set (behavior depends on the client library). |
+| `NO_PROXY` | Comma-separated hostnames, domains, or IP ranges that should **not** use the proxy (for example `localhost`, `127.0.0.1`, or an internal API hostname). |
+
+Example for a POSIX shell:
+
+```bash
+export HTTPS_PROXY=http://proxy.example.com:8080
+export HTTP_PROXY=http://proxy.example.com:8080
+export NO_PROXY=localhost,127.0.0.1,.corp.example.com
+```
+
+If your organization assigns these values automatically when you log in, confirm they are visible in the same environment where you launch Jupyter or your IDE.
+
+## 2. Restart your notebook or Python session
+
+If you change proxy variables after a session has already started, restart the kernel or Python interpreter so every library reload sees the updated environment.
+
+## What do I need to know?
+
+### Other outbound traffic
+
+Features that generate text with OpenAI or Azure OpenAI use those vendors’ Python SDKs. Those clients usually respect the same `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` values, but authentication, regional endpoints, and enterprise policies can add requirements. Consult your provider’s documentation when something works for the ValidMind API but not for LLM calls.[^2]
+
+### Underlying behavior
+
+Proxy handling is implemented by the underlying HTTP stacks (including aiohttp and requests for ValidMind API traffic, and httpx in some third-party clients). Precedence between `ALL_PROXY` and scheme-specific variables, and exact `NO_PROXY` matching rules, can vary by library version. If results differ from what you expect, refer to the documentation for those libraries or your HTTP client.[^3]
+
+## Troubleshooting
+
+- You see connection timeouts or “connection refused” when calling `vm.init()` or logging results — verify `HTTPS_PROXY` matches your proxy URL and that the host running Python can reach the proxy host and port.
+- Traffic should bypass the proxy for a specific API host — add that host or domain to `NO_PROXY` and restart the session.
+- Variables do not appear to apply — in a notebook, run `import os` and `print(os.environ.get("HTTPS_PROXY"))` in a fresh cell after restart; if it is empty, the variables were not set for that process (for example, they were only set in a different terminal).
+
+## What's next
+
+:::{#whats-next}
+:::
+
+
+<!-- FOOTNOTES -->
+
+[^1]: If you have not installed the library yet, start with [Install and initialize the {{< var validmind.developer >}}](/developer/model-documentation/install-and-initialize-validmind-library.qmd).
+
+[^2]: See for example [OpenAI](https://platform.openai.com/docs/guides/production-best-practices) and [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/) for service-specific networking guidance.
+
+[^3]: For example, [aiohttp client advanced topics](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support), [Requests proxies](https://requests.readthedocs.io/en/latest/user/advanced/#proxies), and [HTTPX proxies](https://www.python-httpx.org/advanced/proxies/).

--- a/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
+++ b/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
@@ -24,7 +24,7 @@ Outbound HTTPS traffic to the ValidMind API relies on standard Python HTTP clien
 
 - [x] {{< var link.login >}}
 - [x] You can set environment variables for the user or service account that runs Python or Jupyter.[^1]
-- [x] You have proxy connection details from your network administrator (host, port, and authentication rules if required).
+- [x] You have proxy connection details from your network administrator, such as the host, port, and authentication rules.
 
 :::
 
@@ -32,34 +32,38 @@ Outbound HTTPS traffic to the ValidMind API relies on standard Python HTTP clien
 
 ### Underlying behavior
 
-The {{< var validmind.developer >}} does not provide a way to set a proxy on `vm.init()`. Instead, proxy handling is implemented by the underlying HTTP stacks, including aiohttp and requests for ValidMind API traffic, and httpx in some third-party clients. Precedence between `ALL_PROXY` and scheme-specific variables, and exact `NO_PROXY` matching rules, can vary by library version. 
+Proxy handling is implemented by the underlying HTTP stacks, including aiohttp and requests for ValidMind API traffic, and httpx in some third-party clients. The {{< var validmind.developer >}} itself does not provide a way to set a proxy on `vm.init()`. 
 
-If results differ from what you expect, refer to the documentation for those libraries or your HTTP client.[^2]
+Precedence between `ALL_PROXY` and scheme-specific variables, and exact `NO_PROXY` matching rules, can vary by library version. If results differ from what you expect, refer to the documentation for those libraries or your HTTP client.[^2]
 
 ### Other outbound traffic
 
-Features that generate text with OpenAI or Azure OpenAI use those vendors’ Python SDKs. Those clients usually respect the same `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` values, but authentication, regional endpoints, and enterprise policies can add requirements. 
+Features that generate text with OpenAI or Azure OpenAI use the Python SDKs provided by those vendors. These clients usually respect the same `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` values, but authentication, regional endpoints, and enterprise policies can add requirements. 
 
 Consult your provider’s documentation when something works for the ValidMind API but not for LLM calls.[^3]
 
 ## Step 1: Set proxy environment variables
 
-Set the variables **before** you start the Python process or Jupyter kernel so the process inherits them when the library opens HTTP connections.
+Set the variables before you start the Python process or Jupyter kernel, so that the process inherits them when the library opens HTTP connections.
 
-Common variables:
+Common variables include:
 
 | Variable | Purpose |
 |----------|---------|
 | `HTTP_PROXY` | Proxy URL for `http` requests. |
-| `HTTPS_PROXY` | Proxy URL for `https` requests (typical for the ValidMind API). |
-| `ALL_PROXY` | Fallback when a scheme-specific variable is not set (behavior depends on the client library). |
-| `NO_PROXY` | Comma-separated hostnames, domains, or IP ranges that should **not** use the proxy (for example `localhost`, `127.0.0.1`, or an internal API hostname). |
+| `HTTPS_PROXY` | Proxy URL for `https` requests typically used for the ValidMind API. |
+| `ALL_PROXY` | Fallback when a scheme-specific variable is not set. Behavior depends on the client library. |
+| `NO_PROXY` | Comma-separated hostnames, domains, or IP ranges that should NOT use the proxy. For example: `localhost`, `127.0.0.1`, or an internal API hostname. |
+
+Many tools and Linux environments use lowercase names, such as `http_proxy` or `https_proxy`. On Unix-like systems, Python and common HTTP clients often treat uppercase and lowercase as equivalent for these variables, but some scripts or containers only read one convention. 
+
+If your organization assigns these values automatically when you log in, confirm they are visible in the same environment where you launch Jupyter or your IDE.
 
 ::: {.callout}
-Many tools and Linux environments use lowercase names instead: `http_proxy`, `https_proxy`, and `no_proxy`. On Unix-like systems, Python and common HTTP clients often treat uppercase and lowercase as equivalent for these variables, but some scripts or containers only read one convention. Use the names your organization or image already exports, or standardize on a single case for your team.
+**Tip**: Use the names your organization or image already exports, or standardize on a single case for your team.
 :::
 
-Example for a POSIX shell:
+### Example for a POSIX shell
 
 ```bash
 export HTTPS_PROXY=http://proxy.example.com:8080
@@ -67,11 +71,9 @@ export HTTP_PROXY=http://proxy.example.com:8080
 export NO_PROXY=localhost,127.0.0.1,.corp.example.com
 ```
 
-If your organization assigns these values automatically when you log in, confirm they are visible in the same environment where you launch Jupyter or your IDE.
-
 ## Step 2: Restart your notebook or Python session
 
-If you change proxy variables after a session has already started, restart the kernel or Python interpreter so every library reload sees the updated environment.
+If you change proxy variables after a session has already started, restart the kernel or Python interpreter, so that every library reload sees the updated environment.
 
 ## Troubleshooting
 

--- a/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
+++ b/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
@@ -32,7 +32,7 @@ Outbound HTTPS traffic to the ValidMind API relies on standard Python HTTP clien
 
 ### Underlying behavior
 
-The {{< var validmind.developer >}} does not provide a `proxy` argument on `vm.init()`: proxy handling is implemented by the underlying HTTP stacks (including aiohttp and requests for ValidMind API traffic, and httpx in some third-party clients). Precedence between `ALL_PROXY` and scheme-specific variables, and exact `NO_PROXY` matching rules, can vary by library version. 
+The {{< var validmind.developer >}} does not provide a way to set a proxy on `vm.init()`. Instead, proxy handling is implemented by the underlying HTTP stacks, including aiohttp and requests for ValidMind API traffic, and httpx in some third-party clients. Precedence between `ALL_PROXY` and scheme-specific variables, and exact `NO_PROXY` matching rules, can vary by library version. 
 
 If results differ from what you expect, refer to the documentation for those libraries or your HTTP client.[^2]
 

--- a/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
+++ b/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
@@ -12,11 +12,11 @@ listing:
     fields: [title, description]
     grid-columns: 2
     contents:
-    - ../how-to/testing-overview.qmd
-    - ../how-to/feature-overview.qmd
+    - ../../notebooks/quickstart/quickstart_model_documentation.ipynb
+    - ../../notebooks/quickstart/quickstart_model_validation.ipynb
 ---
 
-The {{< var validmind.developer >}} does not provide a `proxy` argument on `vm.init()`. Outbound HTTPS traffic to the ValidMind API relies on standard Python HTTP clients that honor proxy-related environment variables, which lets you work behind corporate or regional proxies without custom library configuration.
+Outbound HTTPS traffic to the ValidMind API relies on standard Python HTTP clients that honor proxy-related environment variables, which lets you work behind corporate or regional proxies without custom library configuration.
 
 ::: {.attn}
 
@@ -28,7 +28,21 @@ The {{< var validmind.developer >}} does not provide a `proxy` argument on `vm.i
 
 :::
 
-## 1. Set proxy environment variables
+## What do I need to know?
+
+### Underlying behavior
+
+The {{< var validmind.developer >}} does not provide a `proxy` argument on `vm.init()`: proxy handling is implemented by the underlying HTTP stacks (including aiohttp and requests for ValidMind API traffic, and httpx in some third-party clients). Precedence between `ALL_PROXY` and scheme-specific variables, and exact `NO_PROXY` matching rules, can vary by library version. 
+
+If results differ from what you expect, refer to the documentation for those libraries or your HTTP client.[^2]
+
+### Other outbound traffic
+
+Features that generate text with OpenAI or Azure OpenAI use those vendors’ Python SDKs. Those clients usually respect the same `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` values, but authentication, regional endpoints, and enterprise policies can add requirements. 
+
+Consult your provider’s documentation when something works for the ValidMind API but not for LLM calls.[^3]
+
+## Step 1: Set proxy environment variables
 
 Set the variables **before** you start the Python process or Jupyter kernel so the process inherits them when the library opens HTTP connections.
 
@@ -51,19 +65,9 @@ export NO_PROXY=localhost,127.0.0.1,.corp.example.com
 
 If your organization assigns these values automatically when you log in, confirm they are visible in the same environment where you launch Jupyter or your IDE.
 
-## 2. Restart your notebook or Python session
+## Step 2: Restart your notebook or Python session
 
 If you change proxy variables after a session has already started, restart the kernel or Python interpreter so every library reload sees the updated environment.
-
-## What do I need to know?
-
-### Other outbound traffic
-
-Features that generate text with OpenAI or Azure OpenAI use those vendors’ Python SDKs. Those clients usually respect the same `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` values, but authentication, regional endpoints, and enterprise policies can add requirements. Consult your provider’s documentation when something works for the ValidMind API but not for LLM calls.[^2]
-
-### Underlying behavior
-
-Proxy handling is implemented by the underlying HTTP stacks (including aiohttp and requests for ValidMind API traffic, and httpx in some third-party clients). Precedence between `ALL_PROXY` and scheme-specific variables, and exact `NO_PROXY` matching rules, can vary by library version. If results differ from what you expect, refer to the documentation for those libraries or your HTTP client.[^3]
 
 ## Troubleshooting
 
@@ -81,6 +85,6 @@ Proxy handling is implemented by the underlying HTTP stacks (including aiohttp a
 
 [^1]: If you have not installed the library yet, start with [Install and initialize the {{< var validmind.developer >}}](/developer/model-documentation/install-and-initialize-validmind-library.qmd).
 
-[^2]: See for example [OpenAI](https://platform.openai.com/docs/guides/production-best-practices) and [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/) for service-specific networking guidance.
+[^2]: For example, [aiohttp client advanced topics](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support), [Requests proxies](https://requests.readthedocs.io/en/latest/user/advanced/#proxies), and [HTTPX proxies](https://www.python-httpx.org/advanced/proxies/).
 
-[^3]: For example, [aiohttp client advanced topics](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support), [Requests proxies](https://requests.readthedocs.io/en/latest/user/advanced/#proxies), and [HTTPX proxies](https://www.python-httpx.org/advanced/proxies/).
+[^3]: See for example [OpenAI](https://platform.openai.com/docs/guides/production-best-practices) and [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/) for service-specific networking guidance.

--- a/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
+++ b/site/developer/model-documentation/use-http-proxy-with-validmind-library.qmd
@@ -55,6 +55,10 @@ Common variables:
 | `ALL_PROXY` | Fallback when a scheme-specific variable is not set (behavior depends on the client library). |
 | `NO_PROXY` | Comma-separated hostnames, domains, or IP ranges that should **not** use the proxy (for example `localhost`, `127.0.0.1`, or an internal API hostname). |
 
+::: {.callout}
+Many tools and Linux environments use lowercase names instead: `http_proxy`, `https_proxy`, and `no_proxy`. On Unix-like systems, Python and common HTTP clients often treat uppercase and lowercase as equivalent for these variables, but some scripts or containers only read one convention. Use the names your organization or image already exports, or standardize on a single case for your team.
+:::
+
 Example for a POSIX shell:
 
 ```bash
@@ -71,9 +75,10 @@ If you change proxy variables after a session has already started, restart the k
 
 ## Troubleshooting
 
-- You see connection timeouts or “connection refused” when calling `vm.init()` or logging results — verify `HTTPS_PROXY` matches your proxy URL and that the host running Python can reach the proxy host and port.
-- Traffic should bypass the proxy for a specific API host — add that host or domain to `NO_PROXY` and restart the session.
-- Variables do not appear to apply — in a notebook, run `import os` and `print(os.environ.get("HTTPS_PROXY"))` in a fresh cell after restart; if it is empty, the variables were not set for that process (for example, they were only set in a different terminal).
+- If you see SSL or certificate verification errors when calling `vm.init()` behind a proxy: refer to our troubleshooting guide.[^4]
+- If you see connection timeouts or “connection refused” when calling `vm.init()` or logging results: verify `HTTPS_PROXY` matches your proxy URL and that the host running Python can reach the proxy host and port.
+- If traffic should bypass the proxy for a specific API host: add that host or domain to `NO_PROXY` and restart the session.
+- If variables do not appear to apply: in a notebook, run `import os` and `print(os.environ.get("HTTPS_PROXY"))` in a fresh cell after restart; if it is empty, the variables were not set for that process (for example, they were only set in a different terminal).
 
 ## What's next
 
@@ -85,6 +90,8 @@ If you change proxy variables after a session has already started, restart the k
 
 [^1]: If you have not installed the library yet, start with [Install and initialize the {{< var validmind.developer >}}](/developer/model-documentation/install-and-initialize-validmind-library.qmd).
 
-[^2]: For example, [aiohttp client advanced topics](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support), [Requests proxies](https://requests.readthedocs.io/en/latest/user/advanced/#proxies), and [HTTPX proxies](https://www.python-httpx.org/advanced/proxies/).
+[^2]: For example, refer to [aiohttp client advanced topics](https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support), [Requests proxies](https://requests.readthedocs.io/en/latest/user/advanced/#proxies), and [HTTPX proxies](https://www.python-httpx.org/advanced/proxies/).
 
-[^3]: See for example [OpenAI](https://platform.openai.com/docs/guides/production-best-practices) and [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/) for service-specific networking guidance.
+[^3]: For example, refer to [OpenAI](https://platform.openai.com/docs/guides/production-best-practices) and [Azure OpenAI](https://learn.microsoft.com/azure/ai-services/openai/) for service-specific networking guidance.
+
+[^4]: Refer to [SSL verification errors when initializing the library](/support/troubleshooting.qmd#ssl-verification-when-initializing-library).

--- a/site/support/troubleshooting.qmd
+++ b/site/support/troubleshooting.qmd
@@ -68,7 +68,7 @@ Make sure that you are using the correct initialization credentials for the mode
 
 Follow the steps in [Install and initialize the {{< var validmind.developer >}}](/developer/model-documentation/install-and-initialize-validmind-library.qmd) for detailed instructions on how to integrate the {{< var vm.developer >}} and upload to the {{< var vm.platform >}}.
 
-## SSL verification errors when initializing the {{< var validmind.developer >}}
+## SSL verification errors when initializing the {{< var validmind.developer >}} {#ssl-verification-when-initializing-library} 
 
 ### Issue
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

This change adds a developer guide, **Use an HTTP proxy with the ValidMind Library**, that explains how to route outbound HTTPS traffic through a corporate or regional proxy when using the Python library. 

The ValidMind library does not expose a `proxy` argument on `vm.init()`; the page documents the standard `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` environment variables, when to restart kernels after changes, how this interacts with other outbound calls (for example LLM SDKs), and troubleshooting steps. 

## How to test

Try the live preview: [Use an HTTP proxy with the ValidMind Library](https://docs-staging.validmind.ai/pr_previews/library-proxy-mockup/developer/model-documentation/use-http-proxy-with-validmind-library.html) — **Allow time for the PR preview deploy with the latest edits to finish**

<img alt="image" src="https://github.com/user-attachments/assets/bf71315d-176f-4a94-a363-daea2ab2a672" />

## What needs special review?

None.

## Dependencies, breaking changes, and deployment notes

None.

## Release notes

Documentation: added a guide for using HTTP proxy environment variables with the ValidMind Library. [Learn more …](developer/model-documentation/use-http-proxy-with-validmind-library.qmd)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [ ] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
