### PR TITLE
Add FAQ for attestation visibility before period starts & clarify callout

### DIFF
--- a/site/faq/_faq-attestations.qmd
+++ b/site/faq/_faq-attestations.qmd
@@ -1,0 +1,8 @@
+<!-- Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+Refer to the LICENSE file in the root of this repository for details.
+SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
+
+## Why don't I see attestations in the Attestations area right after I create them?
+
+- The {{< fa clipboard-check >}} Attestations area and attestation period selectors only show _active_ or _past_ periods. If the only periods you have configured are _future-dated_ (start date in the future), nothing appears there until the _start date_ — this is expected behavior, not a configuration error.
+- After you configure attestation templates and periods,[^4] participants are notified when the period begins. For where to access the dashboard and how timing works, see Working with attestations.[^5]

--- a/site/faq/faq-workflows.qmd
+++ b/site/faq/faq-workflows.qmd
@@ -17,7 +17,8 @@ listing:
     - ../guide/workflows/working-with-workflows.qmd
     - ../guide/workflows/manage-model-stages.qmd
     - ../guide/model-inventory/manage-model-inventory-fields.qmd
-categories: ["workflows", "model lifecycle", "lifecycle statuses", "validmind platform", "validmind library"]
+    - ../guide/attestation/working-with-attestations.qmd
+categories: ["workflows", "model lifecycle", "lifecycle statuses", "attestations", "validmind platform", "validmind library"]
 ---
 
 ## Can I customize workflows within {{< var vm.product >}}?
@@ -49,6 +50,8 @@ Yes, {{< var vm.product >}} supports disconnected workflows natively at the data
 You do not need to use the {{< var validmind.platform >}} while you are in the exploration or R&D phase of model development.
 :::
 
+{{< include _faq-attestations.qmd >}}
+
 {{< include _faq-tracking.qmd >}}
 
 ## Learn more
@@ -64,3 +67,7 @@ You do not need to use the {{< var validmind.platform >}} while you are in the e
 [^2]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
 
 [^3]: [{{< var validmind.developer >}}](/developer/validmind-library.qmd)
+
+[^4]: [Manage attestations](/guide/attestation/manage-attestations.qmd)
+
+[^5]: [Working with attestations](/guide/attestation/working-with-attestations.qmd)

--- a/site/guide/attestation/working-with-attestations.qmd
+++ b/site/guide/attestation/working-with-attestations.qmd
@@ -56,7 +56,7 @@ When an attestation period is active or has been completed in the past, **{{< fa
 Attestation participants can also access their individual tasks via **{{< fa inbox >}} My Inbox** in the left sidebar, where tasks appear under the Tasks tab with the current attestation status.
 
 ::: {.callout-note}
-The Attestations sidebar item only appears when there is at least one active or completed attestation period. If your organization has not yet configured attestations, this option is not visible. If you have configured attestations but every period has a _future_ start date, the Attestations area stays empty until the first period becomes active.
+The Attestations sidebar item appears only when there is _at least one_ active or completed attestation period. If your organization has not yet configured attestations, this option is not visible. If you have configured attestations but every period has a _future_ start date, the Attestations area stays empty until the first period becomes active.
 :::
 
 ### How does the attestation process work?

--- a/site/guide/attestation/working-with-attestations.qmd
+++ b/site/guide/attestation/working-with-attestations.qmd
@@ -56,7 +56,7 @@ When an attestation period is active or has been completed in the past, **{{< fa
 Attestation participants can also access their individual tasks via **{{< fa inbox >}} My Inbox** in the left sidebar, where tasks appear under the Tasks tab with the current attestation status.
 
 ::: {.callout-note}
-The Attestations sidebar item only appears when there is at least one active or completed attestation period. If your organization has not yet configured attestations, this option is not visible.
+The Attestations sidebar item only appears when there is at least one active or completed attestation period. If your organization has not yet configured attestations, this option is not visible. If you have configured attestations but every period has a _future_ start date, the Attestations area stays empty until the first period becomes active.
 :::
 
 ### How does the attestation process work?


### PR DESCRIPTION
# Pull Request Description

## What and why?

Addresses customer confusion where attestations are configured in **Settings** but nothing appears under **Attestations** until the scheduled period is active — expected behavior, not a bug.

**Changes:**

- Add [`site/faq/_faq-attestations.qmd`](site/faq/_faq-attestations.qmd) FAQ partial: the Attestations UI and period selectors only show _active_ or _past_ periods; future-dated periods stay hidden until the start date. 
- Include that partial from [`site/faq/faq-workflows.qmd`](site/faq/faq-workflows.qmd).
- Clarify the callout in [`site/guide/attestation/working-with-attestations.qmd`](site/guide/attestation/working-with-attestations.qmd) so future-dated-only periods are called out explicitly, with tightened wording for when the sidebar item appears.

**Shortcut:** [sc-15720](https://app.shortcut.com/validmind/story/15720) 

## How to test

<img width="767" height="242" alt="Capto_ 2026-04-10_11-53-27_am2" src="https://github.com/user-attachments/assets/da56cc49-3e09-460e-8590-be95d5621ca6" />

<img width="572" height="119" alt="Capto_ 2026-04-10_11-59-10_am" src="https://github.com/user-attachments/assets/613b9378-5802-4119-8f09-7eb58c1dce26" />


## What needs special review?

Optional: tone and placement under Workflows FAQ vs. another topic.

## Dependencies, breaking changes, and deployment notes

None. Docs-only.

## Release notes

`internal` — no user-facing release note required.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
