### PR TITLE
Switch LLM overview contact section from preview iframe to Quarto listing

### DIFF
--- a/site/about/overview-llm-features.qmd
+++ b/site/about/overview-llm-features.qmd
@@ -4,6 +4,17 @@
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
 title: "Large language model features"
 date: last-modified
+listing:
+  id: llm-whats-next
+  type: grid
+  grid-columns: 1
+  sort: false
+  contents:
+    - path: https://validmind.com/contact/
+      image: /assets/img/hero-platform.png
+      title: "Request a demo"
+      description: "Find out how {{< var vm.product >}}’s LLM-powered features can support your team by getting in touch."
+      author: validmind.com
 ---
 
 {{< var vm.product >}} offers several specialized features that use large language models (LLMs) to streamline model risk management and ensure regulatory compliance. Here's how we approach these features and what you need to know. 
@@ -105,9 +116,6 @@ Assesses each part of the model documentation for adherence to internal guidelin
 
 ## What's next
 
-<!-- :::{#llm-whats-next}
-::: -->
-
 :::: {.flex .flex-wrap .justify-around}
 
 ::: {.w-33-ns .pr3}
@@ -126,7 +134,7 @@ Discover how {{< var vm.product >}}’s LLM-powered platform, purpose-built for 
 
 ::: {.w-33-ns .mt3}
 
-::: {.preview source="https://validmind.com/contact/" height="240" width="430" offset="90"}
+:::{#llm-whats-next}
 :::
 
 :::


### PR DESCRIPTION
# Pull Request Description

## What and why?

### Summary of changes

- Replaces the embedded page preview (`::: {.preview source=...}`) on the **Large language model features** page with a standard Quarto **listing** tile, consistent with other docs (for example deployment pages that link to the contact URL).
- Adds front matter `listing` configuration (`id: llm-whats-next`) with a single grid item: contact link, hero image, **Request a demo** title, and an LLM-focused description.
- Wires the third **What's next** column to `:::{#llm-whats-next}` and removes the obsolete HTML comment placeholder.

**Before:** The contact call-to-action used an iframe-style preview of validmind.com/contact. **After:** The same destination is presented as a listing card (same pattern as multi-tenant / VPV "request a demo" tiles), which avoids embedding the live site and matches site-wide listing usage.

## How to test

Try the preview: 

https://docs-staging.validmind.ai/pr_previews/fix-cookie-consent-banner-preview/about/overview-llm-features.html#whats-next

<img width="1625" height="904" alt="Capto_ 2026-04-13_01-25-07_PM" src="https://github.com/user-attachments/assets/a62cfd0a-8560-4b8b-b656-b4c1fc973688" />

## What needs special review?

- Copy on the listing description (LLM-focused line) and whether `grid-columns: 1` in a narrow column looks acceptable on small viewports.

## Dependencies, breaking changes, and deployment notes

- None.

## Release notes

Documentation: the LLM features overview page now uses a contact **Request a demo** listing tile instead of an embedded page preview.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied
- [ ] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
