### PR TITLE
docs: Enabling org-wide track changes disables AI-content drafts

### DIFF
--- a/site/guide/configuration/managing-your-organization.qmd
+++ b/site/guide/configuration/managing-your-organization.qmd
@@ -71,7 +71,10 @@ By default, the [{{< fa hand >}} Customer Admin]{.bubble} role has these permiss
 ### Tracked changes
 
 ::: {.callout-important}
-Enabling tracked changes by default for your organization will disable content draft generation with AI.[^5]
+Enabling tracked changes by default for your organization will disable the following within simple text blocks:[^5]
+
+- The ability to reference field values in the form of variables
+- Content draft generation with AI
 
 :::
 
@@ -111,7 +114,7 @@ Enabling tracked changes by default for your organization will disable content d
 
 [^4]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
 
-[^5]: [Work with content blocks](/guide/model-documentation/work-with-content-blocks.qmd#generate-content)
+[^5]: [Work with content blocks](/guide/model-documentation/work-with-content-blocks.qmd#add-content-blocks)
 
 [^6]: [Collaborate with others](/guide/model-documentation/collaborate-with-others.qmd#tracking-changes)
 

--- a/site/guide/configuration/managing-your-organization.qmd
+++ b/site/guide/configuration/managing-your-organization.qmd
@@ -70,11 +70,16 @@ By default, the [{{< fa hand >}} Customer Admin]{.bubble} role has these permiss
 
 ### Tracked changes
 
+::: {.callout-important}
+Enabling tracked changes by default for your organization will disable content draft generation with AI.[^5]
+
+:::
+
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
 2. Under {{< fa building >}} Organization, select **Organization**.
 
-3. Under Document Defaults, toggle whether you would like to **Enable Track Changes by default**[^5] for all content blocks within documents for your current active organization.
+3. Under Document Defaults, toggle whether you would like to **Enable Track Changes by default**[^6] for all content blocks within documents for your current active organization.
 
 ### Numbered table and figure captions
 
@@ -82,7 +87,7 @@ By default, the [{{< fa hand >}} Customer Admin]{.bubble} role has these permiss
 
 2. Under {{< fa building >}} Organization, select **Organization**.
 
-3. Under Document Defaults, toggle whether you would like to **Enable numbered table and figure captions** for test results inserted within documents[^6] for your current active organization.
+3. Under Document Defaults, toggle whether you would like to **Enable numbered table and figure captions** for test results inserted within documents[^7] for your current active organization.
 
 
 :::
@@ -106,6 +111,8 @@ By default, the [{{< fa hand >}} Customer Admin]{.bubble} role has these permiss
 
 [^4]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
 
-[^5]: [Collaborate with others](/guide/model-documentation/collaborate-with-others.qmd#tracking-changes)
+[^5]: [Work with content blocks](/guide/model-documentation/work-with-content-blocks.qmd#generate-content)
 
-[^6]: [Work with test results](/guide/model-documentation/work-with-test-results.qmd)
+[^6]: [Collaborate with others](/guide/model-documentation/collaborate-with-others.qmd#tracking-changes)
+
+[^7]: [Work with test results](/guide/model-documentation/work-with-test-results.qmd)

--- a/site/guide/model-documentation/content_blocks/_reference-field-values.qmd
+++ b/site/guide/model-documentation/content_blocks/_reference-field-values.qmd
@@ -19,11 +19,6 @@ SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
    - **[model]{.smallcaps}** — Model inventory field values by field group.
    - **[{artifact type}]{.smallcaps}** — Artifact field values grouped by artifact type, where `{artifact type}` represents the name of your artifact type. Only types of artifacts already logged on the associated model will appear in this selection.
 
-   ::: {.callout}
-   Note that while you are able to select fields with empty values within available model inventory or artifact type fields, no value will be displayed in the content block until the field is populated.
-
-   :::
-
 1. Click away from the content block to apply your changes, and confirm that the correct variable value is displayed in the content block as expected.
 
 ::::

--- a/site/guide/model-documentation/work-with-content-blocks.qmd
+++ b/site/guide/model-documentation/work-with-content-blocks.qmd
@@ -96,6 +96,12 @@ Use {{< var vm.product >}} to assist you with generating content via AI!^[[Gener
 
 While editing a simple text block within documents, you can reference values in the form of variables from:
 
+::: {.callout}
+- To reference field values in the form of variables, your organization must not have tracked changes enabled by default.[^12]
+- Note that while you are able to select fields with empty values within available model inventory or artifact type fields, no value will be displayed in the content block until the field is populated.
+
+:::
+
 {{< include content_blocks/_reference-field-values.qmd >}}
 
 ### Insert mathematical formulas
@@ -111,8 +117,8 @@ While editing a simple text block within documents, you can insert math equation
 While editing a simple text block within documents, you can have {{< var vm.product >}} assist you with generating content drafts.
 
 ::: {.callout title="How can generate content drafts with AI?"}
-- To use the generate content drafts with AI feature, your organization must not have tracked changes enabled by default.[^12]
-- Generating content drafts works best after you've logged tests with the {{< var validmind.developer >}},[^13] as existing test descriptions and results provide more context for the {{< var vm.product >}} AI Content Builder to draw upon.
+- To use the generate content drafts with AI feature, your organization must not have tracked changes enabled by default.[^13]
+- Generating content drafts works best after you've logged tests with the {{< var validmind.developer >}},[^14] as existing test descriptions and results provide more context for the {{< var vm.product >}} AI Content Builder to draw upon.
 
 :::
 
@@ -121,7 +127,7 @@ To generate content drafts:
 
 {{< include content_blocks/_generate-with-ai.qmd >}}
 
-When generating content drafts with AI, accepted versions and edits are retained in your {{< fa wifi >}} Model Activity[^14] just like other updates to your documents.
+When generating content drafts with AI, accepted versions and edits are retained in your {{< fa wifi >}} Model Activity[^15] just like other updates to your documents.
 
 <br>
 
@@ -151,11 +157,11 @@ Test-driven or metric over time blocks can be re-added later on but **text block
 
 1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
 
-2. Select a model or find your model by applying a filter or searching for it.[^15]
+2. Select a model or find your model by applying a filter or searching for it.[^16]
 
-3. In the left sidebar that appears for your model, click **{{< fa file >}} Documents** and select the **Latest** tab.[^16]
+3. In the left sidebar that appears for your model, click **{{< fa file >}} Documents** and select the **Latest** tab.[^17]
 
-4. Click on the document file you want to remove a block from.[^17]
+4. Click on the document file you want to remove a block from.[^18]
 
 5. Click on a section header to expand that section and remove content.
 
@@ -192,12 +198,14 @@ Test-driven or metric over time blocks can be re-added later on but **text block
 
 [^12]: [Managing your organization](/guide/configuration/managing-your-organization.qmd#manage-document-defaults)
 
-[^13]: [Run tests and test suites](/developer/how-to/testing-overview.qmd)
+[^13]: [Managing your organization](/guide/configuration/managing-your-organization.qmd#manage-document-defaults)
 
-[^14]: [View model activity](/guide/model-inventory/view-model-activity.qmd)
+[^14]: [Run tests and test suites](/developer/how-to/testing-overview.qmd)
 
-[^15]: [Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)
+[^15]: [View model activity](/guide/model-inventory/view-model-activity.qmd)
 
-[^16]: [Work with document versions](/guide/model-documentation/work-with-document-versions.qmd)
+[^16]: [Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)
 
-[^17]: [Working with model documents](/guide/templates/working-with-model-documents.qmd)
+[^17]: [Work with document versions](/guide/model-documentation/work-with-document-versions.qmd)
+
+[^18]: [Working with model documents](/guide/templates/working-with-model-documents.qmd)

--- a/site/guide/model-documentation/work-with-content-blocks.qmd
+++ b/site/guide/model-documentation/work-with-content-blocks.qmd
@@ -110,8 +110,10 @@ While editing a simple text block within documents, you can insert math equation
 
 While editing a simple text block within documents, you can have {{< var vm.product >}} assist you with generating content drafts.
 
-::: {.callout title="Have you logged your tests?"}
-Generating content drafts works best after you've logged tests with the {{< var validmind.developer >}},[^12] as existing test descriptions and results provide more context for the {{< var vm.product >}} AI Content Builder to draw upon.
+::: {.callout title="How can generate content drafts with AI?"}
+- To use the generate content drafts with AI feature, your organization must not have tracked changes enabled by default.[^12]
+- Generating content drafts works best after you've logged tests with the {{< var validmind.developer >}},[^13] as existing test descriptions and results provide more context for the {{< var vm.product >}} AI Content Builder to draw upon.
+
 :::
 
 To generate content drafts:
@@ -119,7 +121,7 @@ To generate content drafts:
 
 {{< include content_blocks/_generate-with-ai.qmd >}}
 
-When generating content drafts with AI, accepted versions and edits are retained in your {{< fa wifi >}} Model Activity[^13] just like other updates to your documents.
+When generating content drafts with AI, accepted versions and edits are retained in your {{< fa wifi >}} Model Activity[^14] just like other updates to your documents.
 
 <br>
 
@@ -149,11 +151,11 @@ Test-driven or metric over time blocks can be re-added later on but **text block
 
 1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
 
-2. Select a model or find your model by applying a filter or searching for it.[^14]
+2. Select a model or find your model by applying a filter or searching for it.[^15]
 
-3. In the left sidebar that appears for your model, click **{{< fa file >}} Documents** and select the **Latest** tab.[^15]
+3. In the left sidebar that appears for your model, click **{{< fa file >}} Documents** and select the **Latest** tab.[^16]
 
-4. Click on the document file you want to remove a block from.[^16]
+4. Click on the document file you want to remove a block from.[^17]
 
 5. Click on a section header to expand that section and remove content.
 
@@ -188,12 +190,14 @@ Test-driven or metric over time blocks can be re-added later on but **text block
 
 [^11]: [Collaborate with others](/guide/model-documentation/collaborate-with-others.qmd)
 
-[^12]: [Run tests and test suites](/developer/how-to/testing-overview.qmd)
+[^12]: [Managing your organization](/guide/configuration/managing-your-organization.qmd#manage-document-defaults)
 
-[^13]: [View model activity](/guide/model-inventory/view-model-activity.qmd)
+[^13]: [Run tests and test suites](/developer/how-to/testing-overview.qmd)
 
-[^14]: [Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)
+[^14]: [View model activity](/guide/model-inventory/view-model-activity.qmd)
 
-[^15]: [Work with document versions](/guide/model-documentation/work-with-document-versions.qmd)
+[^15]: [Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd#search-filter-and-sort-models)
 
-[^16]: [Working with model documents](/guide/templates/working-with-model-documents.qmd)
+[^16]: [Work with document versions](/guide/model-documentation/work-with-document-versions.qmd)
+
+[^17]: [Working with model documents](/guide/templates/working-with-model-documents.qmd)

--- a/site/guide/templates/_add-text-blocks.qmd
+++ b/site/guide/templates/_add-text-blocks.qmd
@@ -18,22 +18,24 @@ To create a new text block via the block library:
     - (Optional) A **[description]{.smallcaps}** for your text block
     - The templated **[content]{.smallcaps}** for your text block
 
-::: {.panel-tabset}
 
-### Reference field values
+<!-- BC 2026 Apr 24: Seems like we removed the ability to reference field values in the form of variables in library text blocks, so hiding this info for now. -->
+
+<!-- ::: {.panel-tabset}
+
+#### Reference field values
 
 While composing content for a library text block, you can reference values in the form of variables from model inventory fields. When the text block is inserted into a document, values from the associated model's inventory fields will automatically be populated in the content block if not empty.
 
-{{< include /guide/model-documentation/content_blocks/_reference-field-values.qmd >}}
+{{< include /guide/model-documentation/content_blocks/_reference-field-values.qmd >}} -->
 
-### Insert mathematical formulas
+#### Insert mathematical formulas
 
 While composing content for a library text block, you can insert math equations using the formula editor:
 
 {{< include /guide/model-documentation/content_blocks/_insert-mathematical-formulas.qmd >}}
 
-
-:::
+<!-- ::: -->
 
 4. Select a **[sharing]{.smallcaps}** option:
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-15852

This has come up in a Support ticket and I noticed this quirk while testing — this is behaviour that is working as intended so I've documented it.

## How to test

Click on the live previews and compare the changes:

| page | OLD | NEW |
|--|--|--|
| [Managing your organization](https://docs-staging.validmind.ai/pr_previews/beck/sc-15852/documentation-track-changes-by-default-disables/guide/configuration/managing-your-organization.html#manage-document-defaults) |<img width="1131" height="361" alt="Screenshot 2026-04-23 at 2 16 19 PM" src="https://github.com/user-attachments/assets/a1870313-8218-44ab-9b58-92ad080d382f" /> |<img width="1251" height="437" alt="Screenshot 2026-04-23 at 2 16 44 PM" src="https://github.com/user-attachments/assets/ebf46d10-14ec-40c1-8fbf-9e81d4032677" /> |
| [Work with content blocks](https://docs-staging.validmind.ai/pr_previews/beck/sc-15852/documentation-track-changes-by-default-disables/guide/model-documentation/work-with-content-blocks.html#generate-content) |<img width="1247" height="849" alt="Screenshot 2026-04-23 at 2 16 35 PM" src="https://github.com/user-attachments/assets/e09bd50d-ed9f-4ad0-aa17-7befbafc6a55" /> |<img width="1216" height="914" alt="Screenshot 2026-04-23 at 2 16 51 PM" src="https://github.com/user-attachments/assets/19ef60e3-21a0-4006-8a7a-c147d16bec63" /> |

## What needs special review?

n/a
## Dependencies, breaking changes, and deployment notes

n/a

## Release notes

n/a

## Checklist
- [x] What and why
- [x] Screenshots or videos (Frontend)
- [x] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

