### PR TITLE
docs: Export document checker results

### DIFF
--- a/site/guide/model-documentation/_check-model-documents.qmd
+++ b/site/guide/model-documentation/_check-model-documents.qmd
@@ -97,7 +97,7 @@ To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Docume
 
 ::: {.panel-tabset}
 
-#### 1. Select a regulation
+#### 1. Select regulation
 
 a. In the {{< var vm.checker >}} modal, select a **[regulation]{.smallcaps}** and an associated **[assessment]{.smallcaps}** from the drop-down menus to check your document against:
 
@@ -109,7 +109,7 @@ a. Scroll to the bottom and click **Check Document**.
 
 The {{< var validmind.checker >}} analyzes your documentation, identifies gaps, and generates recommendations for specific questions that you review in the next step.
 
-#### 2. Review the observations
+#### 2. Review observations
 
 a. After the {{< var vm.checker >}} has completed its analysis, expand individual questions or click **Expand All** to look through the observations:
 
@@ -126,7 +126,7 @@ b. Review questions that require attention. Each question includes:
 
 Use the feedback provided by the {{< var validmind.checker >}} to review the appropriate sections of your documentation and decide what revisions should be made. Or, if you have run the {{< var vm.checker >}} before and were just checking that all documentation issues have been addressed, submit your model for validation.
 
-### 3. (Optional) Export results
+#### 3. (Optional) Export results
 
 To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**.
 
@@ -151,7 +151,7 @@ To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Docume
 
 ::: {.panel-tabset}
 
-#### 1. Select a regulation
+#### 1. Select regulation
 
 a. In the {{< var vm.checker >}} modal, select a **[regulation]{.smallcaps}** and an associated **[assessment]{.smallcaps}** from the drop-down menus to check your document against:
 
@@ -163,7 +163,7 @@ a. Scroll to the bottom and click **Check Validation Document**.
 
 The {{< var validmind.checker >}} analyzes your report, identifies gaps, and generates recommendations for specific questions that you review in the next step.
 
-#### 2. Review the observations
+#### 2. Review observations
 
 a. After the {{< var vm.checker >}} has completed its analysis, expand individual questions or click **Expand All** to look through the observations:
 
@@ -180,7 +180,7 @@ b. Review questions that require attention. Each question includes:
 
 Use the feedback provided by the {{< var validmind.checker >}} to review the appropriate sections of your report and decide what revisions should be made. Or, if you have run the {{< var vm.checker >}} before and were just checking that all report issues have been addressed, submit your report for review.
 
-### 3. (Optional) Export results
+#### 3. (Optional) Export results
 
 To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**.
 

--- a/site/guide/model-documentation/_check-model-documents.qmd
+++ b/site/guide/model-documentation/_check-model-documents.qmd
@@ -72,6 +72,10 @@ a. Review questions that require attention. Each question includes a(n):
 
 Use the feedback provided by the {{< var validmind.checker >}} to review the appropriate sections of your document and decide what revisions should be made.
 
+### 4. (Optional) Export results
+
+To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**.
+
 ::::
 
 
@@ -122,6 +126,10 @@ b. Review questions that require attention. Each question includes:
 
 Use the feedback provided by the {{< var validmind.checker >}} to review the appropriate sections of your documentation and decide what revisions should be made. Or, if you have run the {{< var vm.checker >}} before and were just checking that all documentation issues have been addressed, submit your model for validation.
 
+### 3. (Optional) Export results
+
+To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**.
+
 :::
 
 ::::
@@ -171,6 +179,10 @@ b. Review questions that require attention. Each question includes:
      - **Recommendation** — If suggested, guidance on how to revise the report to better address the question
 
 Use the feedback provided by the {{< var validmind.checker >}} to review the appropriate sections of your report and decide what revisions should be made. Or, if you have run the {{< var vm.checker >}} before and were just checking that all report issues have been addressed, submit your report for review.
+
+### 3. (Optional) Export results
+
+To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**.
 
 :::
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

 > sc-15470

You can now export the results of the Document Checker as a PDF file. Docs updated to reflect this functionality.

## How to test

Click on the live previews:

- [Check documents for compliance](https://docs-staging.validmind.ai/pr_previews/beck/sc-15470/documentation-export-document-checker-results/guide/model-documentation/check-documents-for-compliance.html)
- Developer Fundamentals / [Finalizing Model Documentation](https://docs-staging.validmind.ai/pr_previews/beck/sc-15470/documentation-export-document-checker-results/training/developer-fundamentals/finalizing-model-documentation.html#/section-5) (click the **(Optional) Export results** tab)
- Validator Fundamentals / [Finalizing Validation Reports](https://docs-staging.validmind.ai/pr_previews/beck/sc-15470/documentation-export-document-checker-results/training/validator-fundamentals/finalizing-validation-reports.html#/section-7) (click the **(Optional) Export results** tab)

## What needs special review?
n/a

## Dependencies, breaking changes, and deployment notes

n/a

## Release notes

Covered by https://github.com/validmind/frontend/pull/2363 in **["Ai-based automation."](https://docs.validmind.ai/releases/frontend/26.04/pr-ai-automation-highlights.html#export-document-checker-results-as-pdf)**

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

