### PR TITLE
documentation: Save drafts for workflow user action submissions

### DIFF
--- a/site/guide/workflows/_transition-workflows.qmd
+++ b/site/guide/workflows/_transition-workflows.qmd
@@ -24,7 +24,7 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)]. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.[^submission-drafts]
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)]. To save a working copy of the entered information without transitioning the workflow into its next state, click **Save**.[^submission-drafts]
 
 1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
 
@@ -36,7 +36,7 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)]. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.[^submission-drafts]
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)]. To save a working copy of the entered information without transitioning the workflow into its next state, click **Save**.[^submission-drafts]
 
 1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
 
@@ -47,8 +47,9 @@ To transition a workflow into next steps:
 
 [^submission-drafts]:
 
-    - Saved drafts are tracked under model activity: [View model activity](/guide/model-inventory/view-model-activity.qmd)
-    - Saved drafts can be viewed, edited, and submitted by any other users with permissions to transition the workflow into its next state.
+    - Working copies are tracked under model activity: [View model activity](/guide/model-inventory/view-model-activity.qmd)
+    - Working copies can be viewed, edited, and submitted by any other users with permissions to transition the workflow into its next state.
+    - Fields values updated via working copies will reflect on the field itself.
 
 ::::
 
@@ -64,7 +65,7 @@ To transition a workflow into next steps on models:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action. To save a working copy of the entered information without transitioning the workflow into its next state, click **Save**.
 
 1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
 
@@ -86,7 +87,7 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action. To save a working copy of the entered information without transitioning the workflow into its next state, click **Save**.
 
 1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
 
@@ -98,7 +99,7 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action. To save a working copy of the entered information without transitioning the workflow into its next state, click **Save**.
 
 1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
 

--- a/site/guide/workflows/_transition-workflows.qmd
+++ b/site/guide/workflows/_transition-workflows.qmd
@@ -24,9 +24,10 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)].
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)]. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.[^submission-drafts]
 
-1. To save a draft of your submission, click **Save**, or click **{action}** where `action` is the name of your custom user action to submit.
+1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
+
 
 #### On artifacts
 
@@ -35,9 +36,9 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)].
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)]. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.[^submission-drafts]
 
-1. To save a draft of your submission, click **Save**,[^submission-drafts] or click **{action}** where `action` is the name of your custom user action to submit.
+1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
 
 :::
 
@@ -63,7 +64,10 @@ To transition a workflow into next steps on models:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action.
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.
+
+1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
+
 
 ::::
 
@@ -82,7 +86,10 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action.
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.
+
+1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
+
 
 #### On artifacts
 
@@ -91,7 +98,10 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action.
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields then click **{action}** where `action` is the name of your custom user action. To save a draft of the entered information without transitioning the workflow into its next state, click **Save**.
+
+1. Click **{action}** where `action` is the name of your custom user action to submit the entered information and transition the workflow into its next state.
+
 
 ::::
 

--- a/site/guide/workflows/_transition-workflows.qmd
+++ b/site/guide/workflows/_transition-workflows.qmd
@@ -24,7 +24,9 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)] then click **{action}** where `action` is the name of your custom user action.
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)].
+
+1. To save a draft of your submission, click **Save**, or click **{action}** where `action` is the name of your custom user action to submit.
 
 #### On artifacts
 
@@ -33,10 +35,19 @@ To transition a workflow into next steps:
 1. If an action is available to your role, you'll see it listed under that workflow:
 
     - Click **{{< fa arrow-right >}}** to open up the transition panel for your selected action. This arrow will be followed by the action name.
-    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)] then click **{action}** where `action` is the name of your custom user action.
+    - Enter your **[notes]{.smallcaps}** and/or any other additional inventory fields^[[Manage model inventory fields](/guide/model-inventory/manage-model-inventory-fields.qmd)].
+
+1. To save a draft of your submission, click **Save**,[^submission-drafts] or click **{action}** where `action` is the name of your custom user action to submit.
 
 :::
 
+
+<!-- ADDITIONAL FOOTNOTES -->
+
+[^submission-drafts]:
+
+    - Saved drafts are tracked under model activity: [View model activity](/guide/model-inventory/view-model-activity.qmd)
+    - Saved drafts can be viewed, edited, and submitted by any other users with permissions to transition the workflow into its next state.
 
 ::::
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-15382

You can now save drafts of the submission info when transitioning a workflow using a user action step. Docs updated to reflect this functionality.

## How to test

Click on the live previews:

- [Transition workflows](https://docs-staging.validmind.ai/pr_previews/beck/sc-15382/documentation-save-button-for-user-action/guide/workflows/transition-workflows.html#transition-workflows) (Click **On artifacts** as well) 
- Developer Fundamentals / [Finalizing Model Documentation](https://docs-staging.validmind.ai/pr_previews/beck/sc-15382/documentation-save-button-for-user-action/training/developer-fundamentals/finalizing-model-documentation.html#/section-7) (click the **Advance workflows** tab)
- Validator Fundamentals / [Finalizing Validation Reports](https://docs-staging.validmind.ai/pr_previews/beck/sc-15382/documentation-save-button-for-user-action/training/validator-fundamentals/finalizing-validation-reports.html#/section-14) (click the **Advance workflows** tab)

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

> [!NOTE]
> Wording for models > records are being covered in other Stories; trying to avoid fewer merge conflicts in this one.

## Release notes

Covered by https://github.com/validmind/frontend/pull/2413.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

