### PR TITLE
docs: Workflow draft state

### DIFF
--- a/site/guide/shared/_work-with-filters.qmd
+++ b/site/guide/shared/_work-with-filters.qmd
@@ -55,7 +55,12 @@ Value editor
 
 ::::
 
-:::: {.content-visible when-format="html" when-meta="includes.both"}
+:::: {.content-visible when-format="html" when-meta="includes.workflows"}
+- **[workflow fields]{.smallcaps}** — Workflow properties, such as the workflow status, trigger, workflow target (type of workflow), or target type (subcategory of workflow target).
+
+::::
+
+:::: {.content-visible when-format="html" when-meta="includes.all"}
 :::: {.columns}
 
 ::: {.column width="50%" .pl4 .pr2}
@@ -67,16 +72,23 @@ Value editor
 :::
 
 ::: {.column width="50%" .pl4 .pr3}
-
 [Artifact Filters]{.small-text}
 
 - **[artifact information]{.smallcaps}** — One of the artifact fields always created by {{< var vm.product >}}, such as the Business Unit.
 - **[assignees]{.smallcaps}** — User assigned to the Validation Issue type artifact.
 - **[artifact fields]{.smallcaps}** — One of the organization-specific artifact fields you added for your own use.
+
 :::
 
 
 ::::
+
+::: {.column width="100%" .pl4 .pr3}
+[Workflow Filters]{.small-text}
+
+- **[workflow fields]{.smallcaps}** — Workflow properties, such as the workflow status, trigger, workflow target (type of workflow), or target type (subcategory of workflow target).
+
+:::
 
 ::::
 

--- a/site/guide/shared/work-with-filters.qmd
+++ b/site/guide/shared/work-with-filters.qmd
@@ -5,8 +5,8 @@
 title: "Work with filters"
 date: last-modified
 includes:
-    both: true
-aliases: 
+    all: true
+aliases:
   - select-your-filters.html
 # NR This page exists only to provide a page we can link to from the filter modal in the product.
 # The page is intentionally not included in the sidebar because the docs for the filter modal are already embedded in the correct context:

--- a/site/guide/workflows/_add-new-workflows.qmd
+++ b/site/guide/workflows/_add-new-workflows.qmd
@@ -84,49 +84,49 @@ vi. Click **Save Draft** to save your blank workflow, and then [configure your w
 
 
 :::: {.content-hidden unless-format="revealjs"}
-1. In the left sidebar, click **{{< fa gear >}} Settings**.
+a. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-1. Under {{< fa shield >}} Governance, select **Workflows**.
+b. Under {{< fa shield >}} Governance, select **Workflows**.
 
-1. Click **{{< fa plus >}} Add Workflow**.
+c. Click **{{< fa plus >}} Add Workflow**.
 
-1. Select the [workflow target]{.smallcaps} type to add:
+d. Select the [workflow target]{.smallcaps} type to add:
 
     - **Inventory Model** — Workflows that apply to models in your inventory.
     - **Artifact** — Workflows that apply to logged artifacts.
 
 #### Add Model Workflows
 
-a. Click **{{< fa plus >}} Add Model Workflow**.
+i. Click **{{< fa plus >}} Add Model Workflow**.
 
-a. On the Add New Model Workflow modal, enter in a **[title]{.smallcaps}** and a **[description]{.smallcaps}** the workflow.
+ii. On the Add New Model Workflow modal, enter in a **[title]{.smallcaps}** and a **[description]{.smallcaps}** the workflow.
 
-a. Under **[workflow start]{.smallcaps}**, select when the workflow should be initiated:
+iii. Under **[workflow start]{.smallcaps}**, select when the workflow should be initiated:
 
-    - **Manually** — Start this workflow manually.
-    - **On Model Registration** — Start this workflow when a model is registered in your model inventory.
-    - **On Field Change** — Start this workflow on a change to a specific model inventory field. To configure, select a field under **[model field to monitor]{.smallcaps}**.
-    - **Via Webhook** — Start this workflow when a webhook event is received.
+- **Manually** — Start this workflow manually.
+- **On Model Registration** — Start this workflow when a model is registered in your model inventory.
+- **On Field Change** — Start this workflow on a change to a specific model inventory field. To configure, select a field under **[model field to monitor]{.smallcaps}**.
+- **Via Webhook** — Start this workflow when a webhook event is received.
 
-a. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
+iv. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
 
-a. Click **Save Draft** to save your blank workflow, and then configure your workflow steps.
+v. Click **Save Draft** to save your blank workflow, and then configure your workflow steps.
 
 #### Add Artifact Workflows
 
-a. Click **{{< fa plus >}} Add Artifact Workflow**.
+i. Click **{{< fa plus >}} Add Artifact Workflow**.
 
-a. On the Add New Artifact Workflow modal, enter in a **[title]{.smallcaps}** and a **[description]{.smallcaps}** the workflow.
+ii. On the Add New Artifact Workflow modal, enter in a **[title]{.smallcaps}** and a **[description]{.smallcaps}** the workflow.
 
-a. Under **[workflow start]{.smallcaps}**, select when the workflow should be initiated:
+iii. Under **[workflow start]{.smallcaps}**, select when the workflow should be initiated:
 
-    - **Manually** — Start this workflow manually.
-    - **On Artifact Registration** — Start this workflow when a artifact is logged on a model.
+- **Manually** — Start this workflow manually.
+- **On Artifact Registration** — Start this workflow when a artifact is logged on a model.
 
-a. Select the **[artifact type]{.smallcaps}**
+iv. Select the **[artifact type]{.smallcaps}**
 
-a. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
+v. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
 
-a. Click **Save Draft** to save your blank workflow, and then configure your workflow steps.
+vi. Click **Save Draft** to save your blank workflow, and then configure your workflow steps.
 
 ::::

--- a/site/guide/workflows/_add-new-workflows.qmd
+++ b/site/guide/workflows/_add-new-workflows.qmd
@@ -62,7 +62,7 @@ vi. Click **Save Draft** to save your blank workflow, and then [configure your w
 
     ::: {.callout title="Please note that only one workflow can be configured to initiate on model registration."}
     <br>
-    [Register models in the inventory](/guide/model-inventory/register-models-in-inventory.qmd)
+    [Register models in the inventory](/guide/model-inventory/register-models-in-inventory.qmd){.button}
 
     :::
 
@@ -70,7 +70,7 @@ vi. Click **Save Draft** to save your blank workflow, and then [configure your w
 
     ::: {.callout title="Please note that only one workflow can be configured to initiate on registration for each type of artifact."}
     <br>
-    [Add and manage artifacts](/guide/model-validation/add-manage-artifacts.qmd)
+    [Add and manage artifacts](/guide/model-validation/add-manage-artifacts.qmd){.button}
 
     :::
 

--- a/site/guide/workflows/_add-new-workflows.qmd
+++ b/site/guide/workflows/_add-new-workflows.qmd
@@ -5,13 +5,13 @@ SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 :::: {.content-visible unless-format="revealjs"}
 To add a new blank workflow:
 
-1. In the left sidebar, click **{{< fa gear >}} Settings**.
+a. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-1. Under {{< fa shield >}} Governance, select **Workflows**.
+b. Under {{< fa shield >}} Governance, select **Workflows**.
 
-1. Click **{{< fa plus >}} Add Workflow**.
+c. Click **{{< fa plus >}} Add Workflow**.
 
-1. Select the [workflow target]{.smallcaps} type to add:
+d. Select the [workflow target]{.smallcaps} type to add:
 
     - **Inventory Model** — Workflows that apply to models in your inventory.^[[Working with the model inventory](/guide/model-inventory/working-with-model-inventory.qmd)]
     - **Artifact** — Workflows that apply to logged artifacts.^[[Working with artifacts](/guide/model-validation/working-with-artifacts.qmd)]
@@ -20,38 +20,38 @@ To add a new blank workflow:
 
 #### Add Model Workflows
 
-a. Click **{{< fa plus >}} Add Model Workflow**.
+i. Click **{{< fa plus >}} Add Model Workflow**.
 
-a. On the Add New Model Workflow modal, enter in a **[title]{.smallcaps}** and a **[description]{.smallcaps}** the workflow.
+ii. On the Add New Model Workflow modal, enter in a **[title]{.smallcaps}** and a **[description]{.smallcaps}** the workflow.
 
-a. Under **[workflow start]{.smallcaps}**, select when the workflow should be initiated:
+iii. Under **[workflow start]{.smallcaps}**, select when the workflow should be initiated:
 
-    - **Manually** — Start this workflow manually.^[[Initiate workflows](/guide/workflows/manage-workflows.qmd#initiate-workflows)]
-    - **On Model Registration** — Start this workflow when a model is registered in your model inventory.[^on-model-registration]
-    - **On Field Change** — Start this workflow on a change to a specific model inventory field.[^on-field-change] To configure, select a field under **[model field to monitor]{.smallcaps}**.
-    - **Via Webhook** — Start this workflow when a webhook event is received.
+- **Manually** — Start this workflow manually.^[[Initiate workflows](/guide/workflows/manage-workflows.qmd#initiate-workflows)]
+- **On Model Registration** — Start this workflow when a model is registered in your model inventory.[^on-model-registration]
+- **On Field Change** — Start this workflow on a change to a specific model inventory field.[^on-field-change] To configure, select a field under **[model field to monitor]{.smallcaps}**.
+- **Via Webhook** — Start this workflow when a webhook event is received.
 
-a. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
+iv. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
 
-a. Click **Save Draft** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
+v. Click **Save Draft** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
 
 #### Add Artifact Workflows
 
-a. Click **{{< fa plus >}} Add Artifact Workflow**.
+i. Click **{{< fa plus >}} Add Artifact Workflow**.
 
-a. On the Add New Artifact Workflow modal, enter in a **[title]{.smallcaps}** and a **[description]{.smallcaps}** the workflow.
+ii. On the Add New Artifact Workflow modal, enter in a **[title]{.smallcaps}** and a **[description]{.smallcaps}** the workflow.
 
-a. Under **[workflow start]{.smallcaps}**, select when the workflow should be initiated:
+iii. Under **[workflow start]{.smallcaps}**, select when the workflow should be initiated:
 
-    - **Manually** — Start this workflow manually.^[[Initiate workflows](/guide/workflows/manage-workflows.qmd#initiate-workflows)]
-    - **On Artifact Registration** — Start this workflow when a artifact is logged on a model.[^on-artifact-registration]
-    - **Via Webhook** — Start this workflow when a webhook event is received.
+- **Manually** — Start this workflow manually.^[[Initiate workflows](/guide/workflows/manage-workflows.qmd#initiate-workflows)]
+- **On Artifact Registration** — Start this workflow when a artifact is logged on a model.[^on-artifact-registration]
+- **Via Webhook** — Start this workflow when a webhook event is received.
 
-a. Select the **[artifact type]{.smallcaps}**^[[Manage artifact types](/guide/model-validation/manage-artifact-types.qmd)] this workflow applies to.
+iv. Select the **[artifact type]{.smallcaps}**^[[Manage artifact types](/guide/model-validation/manage-artifact-types.qmd)] this workflow applies to.
 
-a. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
+v. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
 
-a. Click **Save Draft** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
+vi. Click **Save Draft** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
 
 :::
 

--- a/site/guide/workflows/_add-new-workflows.qmd
+++ b/site/guide/workflows/_add-new-workflows.qmd
@@ -33,7 +33,7 @@ a. Under **[workflow start]{.smallcaps}**, select when the workflow should be in
 
 a. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
 
-a. Click **Add Model Workflow** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
+a. Click **Save Draft** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
 
 #### Add Artifact Workflows
 
@@ -51,7 +51,7 @@ a. Select the **[artifact type]{.smallcaps}**^[[Manage artifact types](/guide/mo
 
 a. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
 
-a. Click **Add Artifact Workflow** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
+a. Click **Save Draft** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
 
 :::
 
@@ -110,7 +110,7 @@ a. Under **[workflow start]{.smallcaps}**, select when the workflow should be in
 
 a. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
 
-a. Click **Add Model Workflow** to save your blank workflow, and then configure your workflow steps.
+a. Click **Save Draft** to save your blank workflow, and then configure your workflow steps.
 
 #### Add Artifact Workflows
 
@@ -127,6 +127,6 @@ a. Select the **[artifact type]{.smallcaps}**
 
 a. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
 
-a. Click **Add Artifact Workflow** to save your blank workflow, and then configure your workflow steps.
+a. Click **Save Draft** to save your blank workflow, and then configure your workflow steps.
 
 ::::

--- a/site/guide/workflows/_configure-workflow-steps.qmd
+++ b/site/guide/workflows/_configure-workflow-steps.qmd
@@ -5,19 +5,19 @@ SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 :::: {.content-visible unless-format="revealjs"}
 To add or edit workflow steps:
 
-1. In the left sidebar, click **{{< fa gear >}} Settings**.
+a. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-1. Under {{< fa shield >}} Governance, select **Workflows**.
+b. Under {{< fa shield >}} Governance, select **Workflows**.
 
-1. Click on the workflow you'd like to modify, then:
+c. Click on the workflow you'd like to modify, then:
 
     - For workflows that start when a webhook is received, double-click the **Start** node to configure the webhook.[^on-webhook]
     - To add a step, drag and drop a new step onto the canvas.
     - Double-click the new step to open up the configuration modal.
 
-1. After you're finished with step configuration, click **Update Step** to apply your changes.
+d. After you're finished with step configuration, click **Update Step** to apply your changes.
 
-1. After you've configured a step,^[To delete a step, refer to: [Delete workflow steps](/guide/workflows/configure-workflows.qmd#delete-workflow-steps)] you can then [link your workflow together](/guide/workflows/configure-workflows.qmd#link-workflow-together).
+e. After you've configured a step,^[To delete a step, refer to: [Delete workflow steps](/guide/workflows/configure-workflows.qmd#delete-workflow-steps)] you can then [link your workflow together](/guide/workflows/configure-workflows.qmd#link-workflow-together).
 
 ::: {.callout}
 Refer to [Introduction to workflows](/guide/workflows/introduction-to-workflows.qmd#workflow-elements) for information on available step types and details on how to set up conditional requirements.

--- a/site/guide/workflows/_link-workflow-together.qmd
+++ b/site/guide/workflows/_link-workflow-together.qmd
@@ -6,17 +6,17 @@ SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 
 ::: {.panel-tabset}
 
-#### 1. Start the workflow
+#### a. Start the workflow
 
 To initiate the beginning of your workflow:^[After you’ve [configured your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps), you can then link your workflow together.]
 
-a. Locate the [**Start**]{.bubble .green .green-bg} of your workflow.
+i. Locate the [**Start**]{.bubble .green .green-bg} of your workflow.
 
-a. Drag from the **{{< fa circle >}}** at the bottom of [**Start**]{.bubble .green .green-bg} to the top **{{< fa circle >}}** on the first step of your workflow.
+ii. Drag from the **{{< fa circle >}}** at the bottom of [**Start**]{.bubble .green .green-bg} to the top **{{< fa circle >}}** on the first step of your workflow.
 
-a. Continue with linking the rest your steps together.
+iii. Continue with linking the rest your steps together.
 
-#### 2. Link steps together
+#### b. Link steps together
 
 To link subsequent steps together:
 
@@ -31,27 +31,27 @@ Hover over a workflow step to view an animation of the steps connecting to and f
 
 {{< fa users >}} Approval steps need to be subsequently linked to both a [Rejected]{.bubble .red .red-bg} and an [Approved]{.bubble .green .green-bg} {{< fa cube >}} Model Stage Change step:^[[Workflow step types](/guide/workflows/workflow-step-types.qmd)]
 
-a. First, configure an **{{< fa users >}} Approval** step.
+i. First, configure an **{{< fa users >}} Approval** step.
 
-a. Then, drag two **{{< fa cube >}} Model Stage Change** steps onto the canvas:
+ii. Then, drag two **{{< fa cube >}} Model Stage Change** steps onto the canvas:
 
     - Assign a stage associated with rejection to one in the **[set model stage to]{.smallcaps}** field.
     - Assign a stage associated with approval to the other in the **[set model stage to]{.smallcaps}** field.
 
-a. Then, from the bottom of your **{{< fa users >}} Approval** step:
+iii. Then, from the bottom of your **{{< fa users >}} Approval** step:
 
-    a. Connect the left [**{{< fa circle >}}**]{.red} (red) to your rejection step.^[When complete, the workflow arrow will display as [Rejected]{.bubble .red .red-bg}.]
-    b. Connect the right [**{{< fa circle >}}**]{.green} (green) to your approval step.^[When complete, the workflow arrow will display as [Approved]{.bubble .green .green-bg}.]
+- Connect the left [**{{< fa circle >}}**]{.red} (red) to your rejection step.^[When complete, the workflow arrow will display as [Rejected]{.bubble .red .red-bg}.]
+- Connect the right [**{{< fa circle >}}**]{.green} (green) to your approval step.^[When complete, the workflow arrow will display as [Approved]{.bubble .green .green-bg}.]
 
-#### 3. End the workflow
+#### c. End the workflow
 
 When all your workflow steps have been linked together:
 
-a. Designate the end of your workflow by dragging an **{{< fa circle-stop >}} End** step onto the canvas.
+i. Designate the end of your workflow by dragging an **{{< fa circle-stop >}} End** step onto the canvas.
 
-a. Link relevant previous steps to the **{{< fa circle-stop >}} End** step by clicking on the bottom **{{< fa circle >}}** of those steps, and dragging to the top **{{< fa circle >}}** of the **{{< fa circle-stop >}} End** step.
+ii. Link relevant previous steps to the **{{< fa circle-stop >}} End** step by clicking on the bottom **{{< fa circle >}}** of those steps, and dragging to the top **{{< fa circle >}}** of the **{{< fa circle-stop >}} End** step.
 
-a. When you are finished configuring your workflow, click **Save** to apply your changes.
+iii. When you are finished configuring your workflow, click **Save** to apply your changes.
 
 :::
 

--- a/site/guide/workflows/_publish-workflows.qmd
+++ b/site/guide/workflows/_publish-workflows.qmd
@@ -18,7 +18,7 @@ b. Under {{< fa shield >}} Governance, select **Workflows**.
 
 c. Hover over the workflow you want to publish.
 
-d. Under the **[actions]{.smallcaps}** column, click **{{< fa ellipsis-vertical >}}** and select **{{< fa circle-check >}} Publish Workflow**.
+d. Under the [actions]{.smallcaps} column, click **{{< fa ellipsis-vertical >}}** and select **{{< fa circle-check >}} Publish Workflow**.
 
 e. Click **Yes, Publish** to confirm the publication of the workflow.
 

--- a/site/guide/workflows/_publish-workflows.qmd
+++ b/site/guide/workflows/_publish-workflows.qmd
@@ -1,0 +1,3 @@
+<!-- Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+Refer to the LICENSE file in the root of this repository for details.
+SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->

--- a/site/guide/workflows/_publish-workflows.qmd
+++ b/site/guide/workflows/_publish-workflows.qmd
@@ -1,3 +1,20 @@
 <!-- Copyright © 2023-2026 ValidMind Inc. All rights reserved.
 Refer to the LICENSE file in the root of this repository for details.
 SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
+
+::: {.callout-important title="Once a workflow is published, it cannot be reverted to draft status."}
+You can continue to make changes to published workflows by creating new versions of workflows.^[[Edit existing workflows](/guide/workflows/configure-workflows.qmd#edit-existing-workflows)]
+
+:::
+
+Once you are satisfied with the setup of your workflow, publish the workflow for use:
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+1. Under {{< fa shield >}} Governance, select **Workflows**.
+
+1. Hover over the workflow you want to publish.
+
+1. Under the **[actions]{.smallcaps}** column, click **{{< fa ellipsis-vertial >}}** and select **{{< fa circle-check >}} Publish Workflow**.
+
+1. Click **Yes, Publish** to confirm the publication of the workflow.

--- a/site/guide/workflows/_publish-workflows.qmd
+++ b/site/guide/workflows/_publish-workflows.qmd
@@ -2,6 +2,7 @@
 Refer to the LICENSE file in the root of this repository for details.
 SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 
+:::: {.content-visible unless-format="revealjs"}
 ::: {.callout-important title="Once a workflow is published, it cannot be reverted to draft status."}
 You can continue to make changes to published workflows by creating new versions of workflows.^[[Edit existing workflows](/guide/workflows/configure-workflows.qmd#edit-existing-workflows)]
 
@@ -9,12 +10,36 @@ You can continue to make changes to published workflows by creating new versions
 
 Once you are satisfied with the setup of your workflow, publish the workflow for use:
 
-1. In the left sidebar, click **{{< fa gear >}} Settings**.
+a. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-1. Under {{< fa shield >}} Governance, select **Workflows**.
+b. Under {{< fa shield >}} Governance, select **Workflows**.
 
-1. Hover over the workflow you want to publish.
+c. Hover over the workflow you want to publish.
 
-1. Under the **[actions]{.smallcaps}** column, click **{{< fa ellipsis-vertial >}}** and select **{{< fa circle-check >}} Publish Workflow**.
+d. Under the **[actions]{.smallcaps}** column, click **{{< fa ellipsis-vertical >}}** and select **{{< fa circle-check >}} Publish Workflow**.
 
-1. Click **Yes, Publish** to confirm the publication of the workflow.
+e. Click **Yes, Publish** to confirm the publication of the workflow.
+
+::::
+
+
+
+:::: {.content-hidden unless-format="revealjs"}
+::: {.callout-important title="Once a workflow is published, it cannot be reverted to draft status."}
+You can continue to make changes to published workflows by creating new versions of workflows.^[[Edit existing workflows](/guide/workflows/configure-workflows.qmd#edit-existing-workflows)]
+
+:::
+
+Once you are satisfied with the setup of your workflow, publish the workflow for use:
+
+a. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+b. Under {{< fa shield >}} Governance, select **Workflows**.
+
+c. Hover over the workflow you want to publish.
+
+d. Under the **[actions]{.smallcaps}** column, click **{{< fa ellipsis-vertical >}}** and select **{{< fa circle-check >}} Publish Workflow**.
+
+e. Click **Yes, Publish** to confirm the publication of the workflow.
+
+::::

--- a/site/guide/workflows/_publish-workflows.qmd
+++ b/site/guide/workflows/_publish-workflows.qmd
@@ -8,6 +8,8 @@ You can continue to make changes to published workflows by creating new versions
 
 :::
 
+::::
+
 Once you are satisfied with the setup of your workflow, publish the workflow for use:
 
 a. In the left sidebar, click **{{< fa gear >}} Settings**.
@@ -19,27 +21,14 @@ c. Hover over the workflow you want to publish.
 d. Under the **[actions]{.smallcaps}** column, click **{{< fa ellipsis-vertical >}}** and select **{{< fa circle-check >}} Publish Workflow**.
 
 e. Click **Yes, Publish** to confirm the publication of the workflow.
-
-::::
-
 
 
 :::: {.content-hidden unless-format="revealjs"}
-::: {.callout-important title="Once a workflow is published, it cannot be reverted to draft status."}
-You can continue to make changes to published workflows by creating new versions of workflows.^[[Edit existing workflows](/guide/workflows/configure-workflows.qmd#edit-existing-workflows)]
+::: {.f5 .pl3 .mt4 .pr3 .embed}
+**Once a workflow is published, it cannot be reverted to draft status.**
+
+You can continue to make changes to published workflows by [creating new versions of workflows](/guide/workflows/configure-workflows.qmd#edit-existing-workflows){target="_blank"}.
 
 :::
-
-Once you are satisfied with the setup of your workflow, publish the workflow for use:
-
-a. In the left sidebar, click **{{< fa gear >}} Settings**.
-
-b. Under {{< fa shield >}} Governance, select **Workflows**.
-
-c. Hover over the workflow you want to publish.
-
-d. Under the **[actions]{.smallcaps}** column, click **{{< fa ellipsis-vertical >}}** and select **{{< fa circle-check >}} Publish Workflow**.
-
-e. Click **Yes, Publish** to confirm the publication of the workflow.
 
 ::::

--- a/site/guide/workflows/configure-workflows.qmd
+++ b/site/guide/workflows/configure-workflows.qmd
@@ -26,10 +26,10 @@ aliases:
 
 To set up a new custom workflow, you'll need to complete these four steps in sequence:
 
-1. [Add a new workflow](#add-new-workflows)
-2. [Configure the workflow steps](#configure-workflow-steps)
-3. [Link the workflow together](#link-workflow-together)
-4. [Publish the workflow](#publish-workflow)
+1. [Add a new workflow](#add-new-workflows) — Create a new workflow in `Draft` status.
+2. [Configure the workflow steps](#configure-workflow-steps) — Configure the workflow steps to define the workflow's logic.
+3. [Link the workflow together](#link-workflow-together) — Link the workflow steps together to define the workflow's flow.
+4. [Publish the workflow](#publish-workflow) — Publish the workflow to make it available for use.
 
 ### 1. Add new workflows
 

--- a/site/guide/workflows/configure-workflows.qmd
+++ b/site/guide/workflows/configure-workflows.qmd
@@ -29,22 +29,27 @@ To set up a new custom workflow, you'll need to complete these three steps in se
 1. [Add a new workflow](#add-new-workflows)
 2. [Configure the workflow steps](#configure-workflow-steps)
 3. [Link the workflow together](#link-workflow-together)
+4. [Publish the workflow](#publish-workflow)
 
-### Add new workflows
+### 1. Add new workflows
 
 {{< include /guide/workflows/_add-new-workflows.qmd >}}
 
-### Configure workflow steps
+### 2. Configure workflow steps
 
 {{< include /guide/workflows/_configure-workflow-steps.qmd >}}
 
-### Link workflow together
+### 3. Link workflow together
 
 {{< include /guide/workflows/_link-workflow-together.qmd >}}
 
 ::: {.callout title="Workflow steps relationship unclear on your canvas?"}
 Click **Tidy Layout** at any time for a linear view of your workflow.
 :::
+
+### 4. Publish workflow
+
+{{< include /guide/workflows/_publish-workflows.qmd >}}
 
 ## Clone existing workflows
 

--- a/site/guide/workflows/configure-workflows.qmd
+++ b/site/guide/workflows/configure-workflows.qmd
@@ -43,8 +43,14 @@ To set up a new custom workflow, you'll need to complete these three steps in se
 
 {{< include /guide/workflows/_link-workflow-together.qmd >}}
 
-::: {.callout title="Workflow steps relationship unclear on your canvas?"}
+<br>
+
+::: {.callout-button .pl4 .nt4}
+::: {.callout collapse="true" appearance="minimal"}
+### Workflow steps relationship unclear on your canvas?
 Click **Tidy Layout** at any time for a linear view of your workflow.
+
+:::
 :::
 
 ### 4. Publish workflow
@@ -53,7 +59,7 @@ Click **Tidy Layout** at any time for a linear view of your workflow.
 
 ## Clone existing workflows
 
-To create a copy of an existing workflow:
+To create a copy of an existing workflow as a new draft workflow:^
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
@@ -64,7 +70,6 @@ To create a copy of an existing workflow:
 4. Make your changes to the workflow's **[title]{.smallcaps}** and **[workflow type]{.smallcaps}**.
 
     Additional changes can be made to the cloned workflow after cloning by editing.[^4]
-
 
 ## Edit existing workflows
 

--- a/site/guide/workflows/configure-workflows.qmd
+++ b/site/guide/workflows/configure-workflows.qmd
@@ -24,7 +24,7 @@ aliases:
 
 ## Create custom workflows
 
-To set up a new custom workflow, you'll need to complete these three steps in sequence:
+To set up a new custom workflow, you'll need to complete these four steps in sequence:
 
 1. [Add a new workflow](#add-new-workflows)
 2. [Configure the workflow steps](#configure-workflow-steps)
@@ -59,17 +59,19 @@ Click **Tidy Layout** at any time for a linear view of your workflow.
 
 ## Clone existing workflows
 
-To create a copy of an existing workflow as a new draft workflow:^
+To create a copy of an existing workflow as a new draft workflow:[^3]
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-2. Hover over the workflow you'd like to clone.[^3]
+2. Hover over the workflow you'd like to clone.[^4]
 
 3.  When the **{{< fa ellipsis-vertical >}}** appears, click on it and select **{{< fa copy >}} Clone Workflow**.
 
 4. Make your changes to the workflow's **[title]{.smallcaps}** and **[workflow type]{.smallcaps}**.
 
-    Additional changes can be made to the cloned workflow after cloning by editing.[^4]
+    Additional changes can be made to the cloned workflow after cloning by editing.
+
+Once you are satisfied with the setup of your workflow, publish the workflow for use.
 
 ## Edit existing workflows
 
@@ -174,9 +176,9 @@ Deleting workflow steps on workflows active on models may result in malfunctioni
 
 [^2]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
 
-[^3]: [Setting up workflows](setting-up-workflows.qmd#view-sort-and-filter-workflows)
+[^3]: If a cloned workflow's [workflow start]{.smallcaps} trigger conflicts with an existing workflow, the cloned workflow will be set to manual initiation instead.
 
-[^4]: If a cloned workflow's [workflow start]{.smallcaps} trigger conflicts with an existing workflow, the cloned workflow will be set to manual initiation instead.
+[^4]: [Setting up workflows](setting-up-workflows.qmd#view-sort-and-filter-workflows)
 
 [^5]: [Setting up workflows](setting-up-workflows.qmd#view-sort-and-filter-workflows)
 

--- a/site/guide/workflows/setting-up-workflows.qmd
+++ b/site/guide/workflows/setting-up-workflows.qmd
@@ -43,9 +43,10 @@ Click on any column header to sort the list of workflows by that column:
 
 Click **{{< fa filter >}} Filter** to filter for workflows using different [workflow fields]{.smallcaps}:
 
+  - **Status** — Whether the workflow is a `Draft` workflow or an `Active` workflow.
   - **Target Type** — The subcategory of workflow target. For example: Validation Issue (artifact workflow)
   - **Trigger** — The type of trigger that initiates the workflow.
-  - **Workflow Target** — The type of workflow: Artifact, Inventory Model
+  - **Workflow Target** — The type of workflow: `Artifact`, `Inventory Model`
 
 <br>
 

--- a/site/guide/workflows/setting-up-workflows.qmd
+++ b/site/guide/workflows/setting-up-workflows.qmd
@@ -14,8 +14,10 @@ listing:
     - manage-model-stages.qmd
     - configure-workflows.qmd
     - workflow-configuration-examples.qmd
-aliases: 
+aliases:
   - /guide/model-workflows/setting-up-model-workflows.html
+includes:
+  workflows: true
 ---
 
 {{< include /guide/workflows/_set-up-workflows.qmd >}}

--- a/site/training/administrator-fundamentals/using-validmind-for-risk-management.qmd
+++ b/site/training/administrator-fundamentals/using-validmind-for-risk-management.qmd
@@ -259,6 +259,10 @@ To set up a new custom workflow, you'll need to complete these three steps in se
 
 {{< include /guide/workflows/_link-workflow-together.qmd >}}
 
+### 4. Publish workflow
+
+{{< include /guide/workflows/_publish-workflows.qmd >}}
+
 :::
 
 :::

--- a/site/training/administrator-fundamentals/using-validmind-for-risk-management.qmd
+++ b/site/training/administrator-fundamentals/using-validmind-for-risk-management.qmd
@@ -279,7 +279,7 @@ To set up a new custom workflow, you'll need to complete these four steps in seq
 2. On the Add New Model Workflow modal, enter in a **[title]{.smallcaps}** and a **[description]{.smallcaps}** the workflow.
 3. Under **[workflow start]{.smallcaps}**, select **Manually**.
 4. Under **[workflow expected duration]{.smallcaps}**, define the SLA for the workflow.
-5. Click **Add Workflow** to save your blank workflow.
+5. Click **Save Draft** to save your blank workflow.
 
 When you're done, click [{{< fa chevron-right >}}]() to continue.
 
@@ -292,7 +292,7 @@ When you're done, click [{{< fa chevron-right >}}]() to continue.
 **Configure & link workflow steps**
 :::
 
-1. Click on the workflow you'd added earlier, then:
+1. Click on the workflow you added earlier, then:
     - To add a step, drag and drop a new step onto the canvas. For example: {{< fa arrow-pointer >}} User Action
     - Double-click the new step to open up the configuration modal.
 2. After you're finished with step configuration, click **Update Step** to apply your changes.
@@ -302,6 +302,21 @@ When you're done, click [{{< fa chevron-right >}}]() to continue.
 4. Designate the end of your workflow by dragging an **{{< fa circle-stop >}} End** step onto the canvas.
 5. Link your previous step to the **{{< fa circle-stop >}} End** step by clicking on the bottom **{{< fa circle >}}** of that step, and dragging to the top **{{< fa circle >}}** of the **{{< fa circle-stop >}} End** step.
 6. Click **Save** to apply your changes.
+
+When you're done, click [{{< fa chevron-right >}}]() to continue.
+
+::::
+
+## {background-iframe="https://app.prod.validmind.ai/settings/workflows" background-interactive="true" data-preload="yes"}
+
+:::: {.slideover--l .auto-collapse-10}
+::: {.tc}
+**Publish workflow**
+:::
+
+1. Hover over the workflow you added earlier.
+2. Under the [actions]{.smallcaps} column, click **{{< fa ellipsis-vertical >}}** and select **{{< fa circle-check >}} Publish Workflow**.
+3. Click **Yes, Publish** to confirm the publication of the workflow.
 
 When you're done, click [{{< fa chevron-right >}}]() to continue.
 

--- a/site/training/administrator-fundamentals/using-validmind-for-risk-management.qmd
+++ b/site/training/administrator-fundamentals/using-validmind-for-risk-management.qmd
@@ -243,7 +243,7 @@ For more assistance configuring workflows, refer to our [Workflow configuration 
 
 {{< include /guide/workflows/_configure-workflows.qmd >}}
 
-To set up a new custom workflow, you'll need to complete these three steps in sequence:
+To set up a new custom workflow, you'll need to complete these four steps in sequence:
 
 ::: {.panel-tabset}
 
@@ -251,15 +251,15 @@ To set up a new custom workflow, you'll need to complete these three steps in se
 
 {{< include /guide/workflows/_add-new-workflows.qmd >}}
 
-### 2. Configure workflow steps
+### 2. Configure steps
 
 {{< include /guide/workflows/_configure-workflow-steps.qmd >}}
 
-### 3. Link workflow together
+### 3. Link steps together
 
 {{< include /guide/workflows/_link-workflow-together.qmd >}}
 
-### 4. Publish workflow
+### 4. Publish
 
 {{< include /guide/workflows/_publish-workflows.qmd >}}
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-15650

Creating workflows now starts you off with a draft that needs to be published. Docs updated to reflect this functionality.

## How to test

Click on the live previews and compare the changes:

| page | OLD | NEW |
|--|--|--|
| [Work with filters](https://docs-staging.validmind.ai/pr_previews/beck/sc-15650/documentation-workflow-draft-state/guide/shared/work-with-filters.html) |<img width="1043" height="324" alt="Screenshot 2026-04-24 at 2 24 26 PM" src="https://github.com/user-attachments/assets/dd972353-4228-4ccc-85ac-ca2610689f3e" /> | <img width="1047" height="443" alt="Screenshot 2026-04-24 at 2 27 43 PM" src="https://github.com/user-attachments/assets/d81ae712-6203-491e-b612-89646633907f" />|
| [**Setting up workflows**](https://docs-staging.validmind.ai/pr_previews/beck/sc-15650/documentation-workflow-draft-state/guide/workflows/setting-up-workflows.html#view-sort-and-filter-workflows) (Click **Filter workflows**) | <img width="1203" height="603" alt="Screenshot 2026-04-24 at 2 24 36 PM" src="https://github.com/user-attachments/assets/10c12f8b-d28b-4fee-b029-70efa5757868" /><img width="1126" height="600" alt="Screenshot 2026-04-24 at 2 24 47 PM" src="https://github.com/user-attachments/assets/801e257b-ffce-4575-952e-b5aa8b4694ca" /> | <img width="1183" height="622" alt="Screenshot 2026-04-24 at 2 27 55 PM" src="https://github.com/user-attachments/assets/2bbb01b3-1665-405d-b001-d7a0431acd1b" /><img width="1130" height="663" alt="Screenshot 2026-04-24 at 2 28 01 PM" src="https://github.com/user-attachments/assets/a199a3f7-221c-484c-8842-eca03d91f854" />|
| [**Configure workflows**](https://docs-staging.validmind.ai/pr_previews/beck/sc-15650/documentation-workflow-draft-state/guide/workflows/configure-workflows.html#publish-workflow) |<img width="924" height="245" alt="Screenshot 2026-04-24 at 2 25 00 PM" src="https://github.com/user-attachments/assets/b1350a9e-0883-4a2f-a41a-fcecff7e3f6b" /> |<img width="936" height="232" alt="Screenshot 2026-04-24 at 2 28 09 PM" src="https://github.com/user-attachments/assets/fb1dbe68-b46b-4992-9738-25f6b5a3fda8" /><img width="1120" height="441" alt="Screenshot 2026-04-24 at 2 28 15 PM" src="https://github.com/user-attachments/assets/2176132a-a46a-4b3b-821b-a52aeb767925" /> |
| [**Using ValidMind for Risk Management**](https://docs-staging.validmind.ai/pr_previews/beck/sc-15650/documentation-workflow-draft-state/training/administrator-fundamentals/using-validmind-for-risk-management.html#/section-4) (Click **4. Publish**, then **>** until you reach *Run workflows manually*) ) | <img width="1418" height="929" alt="Screenshot 2026-04-24 at 2 25 21 PM" src="https://github.com/user-attachments/assets/b6d07f38-9516-4ca2-9a61-8e6597e866bc" />|<img width="1455" height="858" alt="Screenshot 2026-04-24 at 2 28 30 PM" src="https://github.com/user-attachments/assets/0a56d6f3-4e72-420c-917a-3b23610719da" /><img width="1920" height="952" alt="Screenshot 2026-04-24 at 2 28 38 PM" src="https://github.com/user-attachments/assets/90be13bc-7581-4b77-b59a-034c45db2fb2" /> |

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

> [!NOTE]
> This PR doesn't cover the model > record updates that are being dealt with in other Stories; trying to reduce merge conflicts as I work in parallel.

## Release notes

Should be covered by https://github.com/validmind/frontend/pull/2406.

## Checklist
- [x] What and why
- [x] Screenshots or videos (Frontend)
- [x] How to test
- [ ] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

