### PR TITLE
docs: Add unlisted chatbot capabilities page (Phase 1-2)

### DIFF
--- a/site/guide/chatbot-capabilities.qmd
+++ b/site/guide/chatbot-capabilities.qmd
@@ -37,6 +37,7 @@ Keep these limitations in mind when using the assistant:
 - **Hallucination risk** — AI-generated responses may occasionally contain inaccuracies. Verify critical information before acting on it.
 - **Documentation lag** — The assistant's knowledge is based on published documentation, which may not reflect the latest release features. Check [release notes](/releases/all-releases.qmd) for recent changes.
 - **Not a compliance substitute** — The assistant provides guidance but cannot replace professional compliance judgment or regulatory expertise.
+- **Limited live query scope** — When querying your organization's data, the assistant can currently access model inventory and artifacts only. Questions about workflows, analytics, or other platform areas are not yet supported.
 
 ## In-app assistant vs. MCP
 

--- a/site/guide/chatbot-capabilities.qmd
+++ b/site/guide/chatbot-capabilities.qmd
@@ -7,51 +7,32 @@ date: last-modified
 listing: false
 ---
 
-The {{< var vm.product >}} in-app assistant helps you navigate the platform and find answers to product questions. This page describes what the assistant can and cannot do, organized by product phase.
+The {{< var vm.product >}} in-app assistant helps you navigate the platform and find answers to product questions. This page describes what the assistant can and cannot do.
 
-::: {.callout-important title="Capabilities may vary"}
-Features described for Phase 2 and Phase 3 are subject to availability and may vary by organization. Consult your administrator or support contact for details on what's enabled for your environment.
-:::
+## Current capabilities
 
-## Phase 1 — Documentation-focused chat
-
-The current release provides a static, documentation-focused chat experience.
+The in-app assistant provides context-aware assistance, understanding where you are in the platform and tailoring responses accordingly.
 
 ### What the assistant can do
 
 - Answer questions grounded in **published {{< var vm.product >}} documentation**
-- Provide general how-to guidance for using the platform
-- Respond to follow-up questions within a conversation
+- Understand **where you are** in the platform and tailor responses to your current context
+- Provide **permission-aware** guidance based on your role
 - Help you understand platform features and workflows
+- Respond to follow-up questions within a conversation
+- Offer guidance for the specific page or feature you're viewing
 
 ### What the assistant cannot do
 
-- Access your organization's private data (models, documents, artifacts)
 - Execute actions in the platform on your behalf
+- Make changes to your organization's data
+- Access data you don't have permission to view
 - Guarantee accurate answers for topics outside indexed documentation
 - Replace compliance judgment or regulatory expertise
-- Know which page you're currently viewing or your permission level
 
-## Phase 2 — Context-aware assistance (when available)
+## Future capabilities
 
-When enabled, Phase 2 introduces dynamic, context-aware capabilities.
-
-### Additional capabilities
-
-- Understand **where you are** in the platform and tailor responses accordingly
-- Provide **permission-aware** guidance based on your role
-- Offer enhanced documentation assistance using your current context
-- Deliver guided tours and in-product training
-
-### Still not available
-
-- Access to data you cannot see in the UI
-- Making unapproved changes to your organization's data
-- Performing actions without explicit user confirmation
-
-## Phase 3 — Agentic workflows (future)
-
-Phase 3 will introduce agentic capabilities with human oversight.
+Future releases will introduce agentic capabilities with human oversight.
 
 ### Planned capabilities
 
@@ -59,7 +40,7 @@ Phase 3 will introduce agentic capabilities with human oversight.
 - Execute platform actions after explicit user approval
 - Complete training modules with certification tracking
 
-### Still not available
+### Will not be available
 
 - Silent writes or changes without user confirmation
 - Bypassing organizational policies or permission controls
@@ -67,7 +48,7 @@ Phase 3 will introduce agentic capabilities with human oversight.
 
 ## Important limitations
 
-Regardless of product phase, keep these limitations in mind:
+Keep these limitations in mind when using the assistant:
 
 - **Hallucination risk** — AI-generated responses may occasionally contain inaccuracies. Verify critical information before acting on it.
 - **Documentation lag** — The assistant's knowledge is based on published documentation, which may not reflect the latest release features. Check [release notes](/releases/all-releases.qmd) for recent changes.
@@ -81,7 +62,7 @@ Regardless of product phase, keep these limitations in mind:
 |---------|------------------|-----------------|
 | Access method | Floating chat window in platform | AI assistants (Cursor, Claude Code) |
 | Primary use | Product help and guidance | Model inventory management |
-| Data access | Documentation only (Phase 1) | Your models, artifacts, templates |
+| Data access | Documentation + your current context | Your models, artifacts, templates |
 | Actions | Read-only guidance | Create, read, update operations |
 
 The in-app assistant (described on this page) is focused on helping you use the platform. For programmatic access to your model inventory, see [Connect AI assistants via MCP](/guide/mcp/connect-ai-assistants-via-mcp.qmd).

--- a/site/guide/chatbot-capabilities.qmd
+++ b/site/guide/chatbot-capabilities.qmd
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
 title: "Chatbot capabilities"
 date: last-modified
-listing: false
+search: false
 ---
 
 The {{< var vm.product >}} in-app assistant helps you navigate the platform and find answers to product questions. This page describes what the assistant can and cannot do.

--- a/site/guide/chatbot-capabilities.qmd
+++ b/site/guide/chatbot-capabilities.qmd
@@ -1,0 +1,95 @@
+---
+# Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+# Refer to the LICENSE file in the root of this repository for details.
+# SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
+title: "Chatbot capabilities"
+date: last-modified
+listing: false
+---
+
+The {{< var vm.product >}} in-app assistant helps you navigate the platform and find answers to product questions. This page describes what the assistant can and cannot do, organized by product phase.
+
+::: {.callout-important title="Capabilities may vary"}
+Features described for Phase 2 and Phase 3 are subject to availability and may vary by organization. Consult your administrator or support contact for details on what's enabled for your environment.
+:::
+
+## Phase 1 — Documentation-focused chat
+
+The current release provides a static, documentation-focused chat experience.
+
+### What the assistant can do
+
+- Answer questions grounded in **published {{< var vm.product >}} documentation**
+- Provide general how-to guidance for using the platform
+- Respond to follow-up questions within a conversation
+- Help you understand platform features and workflows
+
+### What the assistant cannot do
+
+- Access your organization's private data (models, documents, artifacts)
+- Execute actions in the platform on your behalf
+- Guarantee accurate answers for topics outside indexed documentation
+- Replace compliance judgment or regulatory expertise
+- Know which page you're currently viewing or your permission level
+
+## Phase 2 — Context-aware assistance (when available)
+
+When enabled, Phase 2 introduces dynamic, context-aware capabilities.
+
+### Additional capabilities
+
+- Understand **where you are** in the platform and tailor responses accordingly
+- Provide **permission-aware** guidance based on your role
+- Offer enhanced documentation assistance using your current context
+- Deliver guided tours and in-product training
+
+### Still not available
+
+- Access to data you cannot see in the UI
+- Making unapproved changes to your organization's data
+- Performing actions without explicit user confirmation
+
+## Phase 3 — Agentic workflows (future)
+
+Phase 3 will introduce agentic capabilities with human oversight.
+
+### Planned capabilities
+
+- Perform **multi-step workflows** with human confirmation at each stage
+- Execute platform actions after explicit user approval
+- Complete training modules with certification tracking
+
+### Still not available
+
+- Silent writes or changes without user confirmation
+- Bypassing organizational policies or permission controls
+- Autonomous decision-making for compliance matters
+
+## Important limitations
+
+Regardless of product phase, keep these limitations in mind:
+
+- **Hallucination risk** — AI-generated responses may occasionally contain inaccuracies. Verify critical information before acting on it.
+- **Documentation lag** — The assistant's knowledge is based on published documentation, which may not reflect the latest release features. Check [release notes](/releases/all-releases.qmd) for recent changes.
+- **Not a compliance substitute** — The assistant provides guidance but cannot replace professional compliance judgment or regulatory expertise.
+
+## In-app assistant vs. MCP
+
+{{< var vm.product >}} offers two AI-powered interfaces:
+
+| Feature | In-app assistant | MCP integration |
+|---------|------------------|-----------------|
+| Access method | Floating chat window in platform | AI assistants (Cursor, Claude Code) |
+| Primary use | Product help and guidance | Model inventory management |
+| Data access | Documentation only (Phase 1) | Your models, artifacts, templates |
+| Actions | Read-only guidance | Create, read, update operations |
+
+The in-app assistant (described on this page) is focused on helping you use the platform. For programmatic access to your model inventory, see [Connect AI assistants via MCP](/guide/mcp/connect-ai-assistants-via-mcp.qmd).
+
+## Get help
+
+If the assistant cannot answer your question or you need additional support:
+
+- Browse the [documentation](/guide/guides.qmd) for detailed guides
+- Check the [FAQ](/faq/faq.qmd) for common questions
+- Contact [{{< var support.email >}}](mailto:{{< var support.email >}}) for direct assistance

--- a/site/guide/chatbot-capabilities.qmd
+++ b/site/guide/chatbot-capabilities.qmd
@@ -49,7 +49,7 @@ Keep these limitations in mind when using the assistant:
 | Data access | Documentation + your current context | Your models, artifacts, templates |
 | Actions | Read-only guidance | Create, read, update operations |
 
-The in-app assistant (described on this page) is focused on helping you use the platform. For programmatic access to your model inventory, see [Connect AI assistants via MCP](/guide/mcp/connect-ai-assistants-via-mcp.qmd).
+The in-app assistant (described on this page) is focused on helping you use the platform. For programmatic access to your model inventory, refer to [Connect AI assistants via MCP](/guide/mcp/connect-ai-assistants-via-mcp.qmd).
 
 ## Get help
 

--- a/site/guide/chatbot-capabilities.qmd
+++ b/site/guide/chatbot-capabilities.qmd
@@ -30,22 +30,6 @@ The in-app assistant provides context-aware assistance, understanding where you 
 - Guarantee accurate answers for topics outside indexed documentation
 - Replace compliance judgment or regulatory expertise
 
-## Future capabilities
-
-Future releases will introduce agentic capabilities with human oversight.
-
-### Planned capabilities
-
-- Perform **multi-step workflows** with human confirmation at each stage
-- Execute platform actions after explicit user approval
-- Complete training modules with certification tracking
-
-### Will not be available
-
-- Silent writes or changes without user confirmation
-- Bypassing organizational policies or permission controls
-- Autonomous decision-making for compliance matters
-
 ## Important limitations
 
 Keep these limitations in mind when using the assistant:


### PR DESCRIPTION
## What and why?
Creates an unlisted chatbot capabilities page documenting what the in-app assistant can and cannot do (sc-15632). The page reflects the current Phase 2 implementation with context-aware assistance.

**Current capabilities:**
- Context-aware responses based on current page/feature
- Permission-aware guidance based on user role
- Documentation-grounded answers

**Not yet available:**
- Executing actions on behalf of users (Phase 3 - future)

## How to test
Try the live preview:
- [Chatbot capabilities](https://docs-staging.validmind.ai/pr_previews/nrichers/sc-15632/docs-add-unlisted-chatbot-valeri/guide/chatbot-capabilities.html) (direct URL only — unlisted)

## What needs special review?
- Verify context-aware capabilities match actual assistant behavior
- Confirm the page should remain unlisted (not in sidebar)

## Dependencies, breaking changes, and deployment notes
- Related: Epic 14335 (Agentic User Assistance - Valerie)
- This page will be included in RAG ingestion so the assistant can cite its own limitations
- PR #1300 adds an AGENTS.md file that references this page to help AI agents discover their capabilities documentation

## Release notes
Added unlisted documentation page describing the in-app assistant's current capabilities (context-aware assistance) and limitations.

## Checklist
- [x] What and why
- [x] How to test
- [x] Labels applied
- [x] PR linked to Shortcut