### PR TITLE
docs: Document Model Activity in Analytics Data Export

### DIFF
--- a/site/guide/integrations/configure-analytics-exports.qmd
+++ b/site/guide/integrations/configure-analytics-exports.qmd
@@ -29,15 +29,20 @@ Configure scheduled exports of analytics datasets to cloud storage so that BI to
 
 4. From the **[datasets]{.smallcaps}** dropdown, choose which analytics datasets to export:
 
-   - Artifact - Change Management Record (custom artifact example)[^3]
    - Artifact - Model Limitation
    - Artifact - Policy Exception
    - Artifact - Validation Issue
    - Inventory Models
    - Model Activity[^4]
+   - Custom artifact types[^3]
+   - Custom inventory record types
 
    ::: {.callout title="Model Activity exports"}
    Model Activity exports audit events — comments, workflow status changes, and field updates on inventory records. Use this dataset for compliance reporting or audit trails. Model Activity respects the same export scope (organization, workspace, or selected models) and supports date range filtering.
+   :::
+
+   ::: {.callout title="Custom types"}
+   Any custom artifact types or custom inventory record types defined for your organization also appear in the datasets dropdown and can be exported.
    :::
 
 ::: {.column-margin}

--- a/site/guide/integrations/configure-analytics-exports.qmd
+++ b/site/guide/integrations/configure-analytics-exports.qmd
@@ -7,7 +7,7 @@ date: last-modified
 ---
 <!-- Shortcut: 14706 -->
 
-Configure scheduled exports of analytics datasets to cloud storage so that BI tools such as Tableau, Snowflake, and Looker can consume models, findings, and workflow metrics.
+Configure scheduled exports of analytics datasets to cloud storage so that BI tools such as Tableau, Snowflake, and Looker can consume models, findings, workflow metrics, and activity events.
 
 ::: {.attn}
 
@@ -34,6 +34,11 @@ Configure scheduled exports of analytics datasets to cloud storage so that BI to
    - Artifact - Policy Exception
    - Artifact - Validation Issue
    - Inventory Models
+   - Model Activity[^4]
+
+   ::: {.callout title="Model Activity exports"}
+   Model Activity exports audit events — comments, workflow status changes, and field updates on inventory records. Use this dataset for compliance reporting or audit trails. Model Activity respects the same export scope (organization, workspace, or selected models) and supports date range filtering.
+   :::
 
 ::: {.column-margin}
 ![Selecting datasets](configure-analytics-export-step-1.png){fig-alt="Create Analytics Export modal showing Select Datasets step and datasets dropdown." .screenshot}
@@ -158,3 +163,5 @@ Data you exported previously will remain in the cloud storage destination unchan
 [^2]: [Manage secrets](/guide/integrations/manage-secrets.qmd)
 
 [^3]: [Manage artifact types](/guide/model-validation/manage-artifact-types.qmd)
+
+[^4]: [View record activity](/guide/inventory/view-record-activity.qmd)

--- a/site/guide/integrations/configure-analytics-exports.qmd
+++ b/site/guide/integrations/configure-analytics-exports.qmd
@@ -27,7 +27,7 @@ Configure scheduled exports of analytics datasets to cloud storage so that BI to
 
 3. On the Analytics Exports page, click **{{< fa plus >}} Create Analytics Export**.
 
-4. From the **[datasets]{.smallcaps}** dropdown, choose which analytics datasets to export:
+4. From the **[datasets]{.smallcaps}** dropdown, choose which analytics datasets to export. For example:
 
    - Artifact - Model Limitation
    - Artifact - Policy Exception

--- a/site/guide/integrations/configure-analytics-exports.qmd
+++ b/site/guide/integrations/configure-analytics-exports.qmd
@@ -38,7 +38,7 @@ Configure scheduled exports of analytics datasets to cloud storage so that BI to
    - Custom inventory record types
 
    ::: {.callout title="Model Activity exports"}
-   Model Activity exports audit events — comments, workflow status changes, and field updates on inventory records. Use this dataset for compliance reporting or audit trails. Model Activity respects the same export scope (organization, workspace, or selected models) and supports date range filtering.
+   Model Activity exports audit events — comments, workflow status changes, and field updates on inventory records. Use this dataset for compliance reporting or audit trails. Model Activity respects the same export scope (organization, workspace, or selected models) and supports 30, 60, or 90-day window filtering.
    :::
 
    ::: {.callout title="Custom types"}


### PR DESCRIPTION
## What and why?
Documents Model Activity in Analytics Data Export (sc-15291). Adds Model Activity to the available datasets list and clarifies that custom artifact types and custom inventory record types can also be exported.

**Changes:**
- Added Model Activity to datasets list with callout explaining audit event exports
- Added custom artifact types and custom inventory record types to datasets list
- Added callout explaining custom types appear in the dropdown

## How to test
Try the live preview:
- [Configure analytics exports](https://docs-staging.validmind.ai/pr_previews/nrichers/sc-15291/documentation---model-activity-i/guide/integrations/configure-analytics-exports.html)

## What needs special review?
- Verify Model Activity dataset name matches the actual UI
- Confirm the audit event types listed (comments, workflow changes, field updates) are accurate
- Verify custom types appear in the dropdown as described

## Dependencies, breaking changes, and deployment notes
- Related: Epic 14910 (26.04 Misc Features)
- This is docs debt cleanup

## Release notes
Added documentation for exporting Model Activity data, custom artifact types, and custom inventory record types through analytics integrations.

## Checklist
- [x] What and why
- [x] How to test
- [x] Labels applied
- [x] PR linked to Shortcut