### PR TITLE
docs: Add Bedrock evaluation metrics integration documentation

### DIFF
--- a/site/guide/integrations/configure-connections.qmd
+++ b/site/guide/integrations/configure-connections.qmd
@@ -177,7 +177,7 @@ The connection detail page displays:
 
 - **Connection status** — Shows whether the connection is operational, disabled, or experiencing issues.
 - **Linked models** — Lists all {{< var vm.product >}} inventory records linked to resources in this integration.
-- **Metric sources** — For integrations that provide metrics (such as Amazon Bedrock), shows configured metric sources and their sync status.
+- **Monitoring** — For integrations that provide metrics (such as Amazon Bedrock), shows configured metric sources and their sync status.
 
 ## Monitor connection health
 
@@ -244,11 +244,11 @@ If the test is successful, the message **{{< fa check-circle >}} Connection succ
 
 5. In the confirmation dialog, select **OK** to confirm deletion.
 
-## Manage metric sources
+## View monitoring data
 
 Some integrations, such as Amazon Bedrock, can provide metrics that sync into {{< var vm.product >}} for use in monitoring documents. Metric sources define which external evaluations or metrics are available for a linked model.
 
-### View metric sources
+### Access the Monitoring tab
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
@@ -256,7 +256,7 @@ Some integrations, such as Amazon Bedrock, can provide metrics that sync into {{
 
 3. Click on a connection that supports metric sources, for example a **Bedrock** connection.
 
-4. On the connection detail page, locate the **Metric Sources** section.
+4. On the connection detail page, select the **Monitoring** tab.
 
    This section lists all configured metric sources, their sync status, and when they last synced.
 

--- a/site/guide/integrations/configure-connections.qmd
+++ b/site/guide/integrations/configure-connections.qmd
@@ -254,7 +254,7 @@ Some integrations, such as Amazon Bedrock, can provide metrics that sync into {{
 
 2. Under {{< fa puzzle-piece >}} Integrations, select **Connections**.
 
-3. Click on a connection that supports metric sources — for example, a **Bedrock** connection.
+3. Click on a connection that supports metric sources, for example a **Bedrock** connection.
 
 4. On the connection detail page, locate the **Metric Sources** section.
 
@@ -262,7 +262,7 @@ Some integrations, such as Amazon Bedrock, can provide metrics that sync into {{
 
 ### How metric sources work
 
-When a model in the {{< var vm.product >}} inventory is linked to an external resource — such as a Bedrock agent — available evaluations from that resource become metric sources. These metrics:
+When a model in the {{< var vm.product >}} inventory is linked to an external resource, such as a Bedrock agent, available evaluations from that resource become metric sources. These metrics:
 
 - Sync automatically on a scheduled interval.
 - Appear in the **From Integration** tab when adding metrics over time to monitoring documents.[^5]

--- a/site/guide/integrations/configure-connections.qmd
+++ b/site/guide/integrations/configure-connections.qmd
@@ -163,13 +163,21 @@ Required configuration details:
 
 You can now [test the connection](#test-connections) to ensure it is working as expected.
 
-## View details
+## View connection details
+
+The connection detail page provides a dashboard-style view for managing a connection, its linked models, and metric sources.
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
 2. Under {{< fa puzzle-piece >}} Integrations, select **Connections**.
 
 3. Click the connection you want to view.
+
+The connection detail page displays:
+
+- **Connection status** — Shows whether the connection is operational, disabled, or experiencing issues.
+- **Linked models** — Lists all models in the inventory linked to resources in this integration.
+- **Metric sources** — For integrations that provide metrics (such as Amazon Bedrock), shows configured metric sources and their sync status.
 
 ## Edit connections
 
@@ -215,6 +223,34 @@ If the test is successful, the message **{{< fa check-circle >}} Connection succ
 
 5. In the confirmation dialog, select **OK** to confirm deletion.
 
+## Manage metric sources
+
+Some integrations, such as Amazon Bedrock, can provide metrics that sync into {{< var vm.product >}} for use in monitoring documents. Metric sources define which external evaluations or metrics are available for a linked model.
+
+### View metric sources
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+2. Under {{< fa puzzle-piece >}} Integrations, select **Connections**.
+
+3. Click on a connection that supports metric sources — for example, a **Bedrock** connection.
+
+4. On the connection detail page, locate the **Metric Sources** section.
+
+   This section lists all configured metric sources, their sync status, and when they last synced.
+
+### How metric sources work
+
+When a model in the {{< var vm.product >}} inventory is linked to an external resource — such as a Bedrock agent — available evaluations from that resource become metric sources. These metrics:
+
+- Sync automatically on a scheduled interval.
+- Appear in the **From Integration** tab when adding metrics over time to monitoring documents.[^5]
+- Support threshold configuration for alerting when values exceed acceptable limits.
+
+::: {.callout title="Bedrock Agent Evaluations"}
+For Amazon Bedrock connections, metric sources include agent evaluation results such as accuracy, helpfulness, and other assessment metrics. Link a model to a Bedrock agent to enable these metrics.[^6]
+:::
+
 <!-- FOOTNOTES -->
 
 [^1]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
@@ -225,3 +261,6 @@ If the test is successful, the message **{{< fa check-circle >}} Connection succ
 
 [^4]: [Implement custom integrations](implement-custom-integrations.qmd)
 
+[^5]: [Work with metrics over time](/guide/monitoring/work-with-metrics-over-time.qmd#add-integration-metrics)
+
+[^6]: [Link external models](link-external-models.qmd)

--- a/site/guide/integrations/configure-connections.qmd
+++ b/site/guide/integrations/configure-connections.qmd
@@ -176,8 +176,29 @@ The connection detail page provides a dashboard-style view for managing a connec
 The connection detail page displays:
 
 - **Connection status** — Shows whether the connection is operational, disabled, or experiencing issues.
-- **Linked models** — Lists all models in the inventory linked to resources in this integration.
+- **Linked models** — Lists all {{< var vm.product >}} inventory records linked to resources in this integration.
 - **Metric sources** — For integrations that provide metrics (such as Amazon Bedrock), shows configured metric sources and their sync status.
+
+## Monitor connection health
+
+The Connections page provides visibility into the health of your integrations at a glance.
+
+### Health indicators
+
+Each connection displays a status indicator:
+
+- [Operational]{.bubble .green-bg} — The connection is active and working correctly.
+- [Needs Attention]{.bubble .orange-bg} — The connection has issues that need to be resolved.
+- [Disabled]{.bubble} — The connection has been manually disabled.
+
+### View connections requiring attention
+
+Connections with errors or warnings display a status indicator, such as [{{< fa triangle-exclamation >}} 1 link with sync errors]{.bubble .yellow-bg}. Review these connections to:
+
+1. Identify the cause of the issue from the error details.
+2. Check that required secrets are still valid.
+3. Verify the external service is accessible.
+4. Test the connection after making changes.
 
 ## Edit connections
 

--- a/site/guide/monitoring/work-with-metrics-over-time.qmd
+++ b/site/guide/monitoring/work-with-metrics-over-time.qmd
@@ -98,17 +98,21 @@ Before you can add metrics from an integration, ensure that the connection is co
 
 After the metrics sync, data from the integration appears in your document alongside any metrics logged via the {{< var validmind.developer >}}.
 
-## Use the global time selector
+## Use the global time range
 
-When working with monitoring documents that contain multiple time-based metrics, use the global time selector to coordinate the time range across all relevant content.
+When working with monitoring documents that contain multiple time-based metrics, use the global time range to coordinate the time range across all relevant content.
 
 1. Navigate to a monitoring document with metrics over time.
 
-2. Locate the time selector at the top of the document.
+2. Locate the {{< fa clock >}} time range button at the top of the document.
 
-3. Select the desired time range from the available options.
+3. Select the desired time range from the available options:
 
-The selected time range applies to all metrics in the document that support time-based filtering, providing a consistent view of your model's performance over the chosen period.
+   - **All Time** — Show all available data
+   - Relative presets (Last 7 days, Last 30 days, etc.)
+   - **Custom range** — Specify exact start and end dates
+
+The selected time range applies to all metrics in the document that support time-based filtering, providing a consistent view of your model's performance over the chosen period. This setting is only visible to you and does not affect other users.
 
 ## View metric over time metadata
 

--- a/site/guide/monitoring/work-with-metrics-over-time.qmd
+++ b/site/guide/monitoring/work-with-metrics-over-time.qmd
@@ -69,7 +69,7 @@ Learn how to log metrics over time, set thresholds, and analyze model performanc
 
 ## Add integration metrics
 
-You can add metrics from external integrations such as Amazon Bedrock directly to your monitoring documents. This enables you to track evaluation results from Bedrock agents alongside your other model metrics.
+You can add metrics from external integrations such as Amazon Bedrock directly to your monitoring documents. This feature enables you to track evaluation results from Bedrock agents alongside your other model metrics.
 
 ::: {.callout title="Integration metrics require a configured connection."}
 Before you can add metrics from an integration, ensure that the connection is configured and the model is linked to the external system.[^11]
@@ -79,24 +79,22 @@ Before you can add metrics from an integration, ensure that the connection is co
 
 2. Select a model or find your model by applying a filter or searching for it.[^12]
 
-3. In the left sidebar that appears for your model, click **{{< fa file >}} Documents** and select the **Latest** tab.
+3. In the left sidebar, click **Monitoring** to open the monitoring report.
 
-4. Select a Monitoring type file.
+4. Hover your mouse over the space where you want your new block to go until a horizontal line with a {{< fa square-plus >}} sign appears.
 
-5. Hover your mouse over the space where you want your new block to go until a horizontal line with a {{< fa square-plus >}} sign appears.
+5. Click {{< fa square-plus >}} and then select **Metric Over Time**.
 
-6. Click {{< fa square-plus >}} and then select **Metric Over Time**.
+6. In the modal that opens, select the **From Integration** tab.
 
-7. In the modal that opens, select the **From Integration** tab.
+7. Under [integration source]{.smallcaps}, available integration metrics appear grouped by source — for example, **Bedrock Agent Evals**.
 
-8. Under [integration source]{.smallcaps}, available integration metrics appear grouped by source — for example, **Bedrock Agent Evals**.
-
-9. Select one or more evaluation metrics to add. For each metric, you can optionally configure:
+8. Select one or more evaluation metrics to add. For each metric, you can optionally configure:
 
    - **[threshold]{.smallcaps}** — Set an upper threshold value to flag when metrics exceed acceptable limits.
    - **[time window]{.smallcaps}** — Define the time range for querying metric data.
 
-10. Click **Insert # Metric(s) Over Time to Document** when you are ready.
+9. Click **Insert # Metric(s) Over Time to Document** when you are ready.
 
 After the metrics sync, data from the integration appears in your document alongside any metrics logged via the {{< var validmind.developer >}}.
 

--- a/site/guide/monitoring/work-with-metrics-over-time.qmd
+++ b/site/guide/monitoring/work-with-metrics-over-time.qmd
@@ -91,8 +91,9 @@ Before you can add metrics from an integration, ensure that the connection is co
 
 8. Select one or more evaluation metrics to add. For each metric, you can optionally configure:
 
-   - **[threshold]{.smallcaps}** — Set an upper threshold value to flag when metrics exceed acceptable limits.
-   - **[time window]{.smallcaps}** — Define the time range for querying metric data.
+   - **[threshold (lower)]{.smallcaps}** — Set a lower threshold value to flag when metrics fall below acceptable limits.
+   - **[threshold (upper)]{.smallcaps}** — Set an upper threshold value to flag when metrics exceed acceptable limits.
+   - **[time range]{.smallcaps}** — Define the time range for querying metric data. Choose to inherit from the document, use a relative preset, or specify a custom date range.
 
 9. Click **Insert # Metric(s) Over Time to Document** when you are ready.
 

--- a/site/guide/monitoring/work-with-metrics-over-time.qmd
+++ b/site/guide/monitoring/work-with-metrics-over-time.qmd
@@ -87,7 +87,7 @@ Before you can add metrics from an integration, ensure that the connection is co
 
 6. In the modal that opens, select the **From Integration** tab.
 
-7. Under [integration source]{.smallcaps}, available integration metrics appear grouped by source — for example, **Bedrock Agent Evals**.
+7. Select your integration under [integration source]{.smallcaps}, then choose from the **Evaluators** list — such as Goal Success Rate, Correctness, or Helpfulness.
 
 8. Select one or more evaluation metrics to add. For each metric, you can optionally configure:
 

--- a/site/guide/monitoring/work-with-metrics-over-time.qmd
+++ b/site/guide/monitoring/work-with-metrics-over-time.qmd
@@ -67,6 +67,51 @@ Learn how to log metrics over time, set thresholds, and analyze model performanc
 
     ![Example F1 Score — Metric Over Time visualization](example-f1-score.png){fig-alt="A screenshot showing an example F1 Score — Metric Over Time visualization" .screenshot group="time-metric"}
 
+## Add integration metrics
+
+You can add metrics from external integrations such as Amazon Bedrock directly to your monitoring documents. This enables you to track evaluation results from Bedrock agents alongside your other model metrics.
+
+::: {.callout title="Integration metrics require a configured connection."}
+Before you can add metrics from an integration, ensure that the connection is configured and the model is linked to the external system.[^11]
+:::
+
+1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
+
+2. Select a model or find your model by applying a filter or searching for it.[^12]
+
+3. In the left sidebar that appears for your model, click **{{< fa file >}} Documents** and select the **Latest** tab.
+
+4. Select a Monitoring type file.
+
+5. Hover your mouse over the space where you want your new block to go until a horizontal line with a {{< fa square-plus >}} sign appears.
+
+6. Click {{< fa square-plus >}} and then select **Metric Over Time**.
+
+7. In the modal that opens, select the **From Integration** tab.
+
+8. Under [integration source]{.smallcaps}, available integration metrics appear grouped by source — for example, **Bedrock Agent Evals**.
+
+9. Select one or more evaluation metrics to add. For each metric, you can optionally configure:
+
+   - **[threshold]{.smallcaps}** — Set an upper threshold value to flag when metrics exceed acceptable limits.
+   - **[time window]{.smallcaps}** — Define the time range for querying metric data.
+
+10. Click **Insert # Metric(s) Over Time to Document** when you are ready.
+
+After the metrics sync, data from the integration appears in your document alongside any metrics logged via the {{< var validmind.developer >}}.
+
+## Use the global time selector
+
+When working with monitoring documents that contain multiple time-based metrics, use the global time selector to coordinate the time range across all relevant content.
+
+1. Navigate to a monitoring document with metrics over time.
+
+2. Locate the time selector at the top of the document.
+
+3. Select the desired time range from the available options.
+
+The selected time range applies to all metrics in the document that support time-based filtering, providing a consistent view of your model's performance over the chosen period.
+
 ## View metric over time metadata
 
 After you have added metrics over time to your document, you can view the following information attached to the result:
@@ -113,3 +158,7 @@ After you have added metrics over time to your document, you can view the follow
 [^9]: [Work with document versions](/guide/model-documentation/work-with-document-versions.qmd)
 
 [^10]: [Working with model documents](/guide/templates/working-with-model-documents.qmd)
+
+[^11]: [Configure connections](/guide/integrations/configure-connections.qmd) and [Link external models](/guide/integrations/link-external-models.qmd)
+
+[^12]: [Working with the inventory](/guide/inventory/working-with-the-inventory.qmd#search-filter-and-sort-records)


### PR DESCRIPTION
## What and why?
Documents Bedrock Evaluations Integration and Guardrails (sc-15716). Adds:
- The **From Integration** tab flow for adding Bedrock Agent Evals to monitoring documents
- Configuration options for integration metrics: threshold (lower), threshold (upper), and time range
- **Global time range** selector for monitoring documents with available options (All Time, relative presets, Custom range)
- Metric sources documentation for the connection detail page
- Simplified navigation to use direct sidebar links

## How to test
Try the live preview:
- [Work with metrics over time](https://docs-staging.validmind.ai/pr_previews/nrichers/sc-15716/documentation---bedrock-evaluati/guide/monitoring/work-with-metrics-over-time.html)
- [Configure connections](https://docs-staging.validmind.ai/pr_previews/nrichers/sc-15716/documentation---bedrock-evaluati/guide/integrations/configure-connections.html)

## What needs special review?

I also was not able to find the **From Integration** tab when adding metrics over time when testing. Please check these steps are accurate.

## Dependencies, breaking changes, and deployment notes
- Related: Epic 11704 (Bedrock Integration)

## Release notes
Added documentation for Amazon Bedrock Evaluations integration, including adding evaluation metrics to monitoring and managing metric sources from the connection detail page.

## Checklist
- [x] What and why
- [x] How to test
- [x] Labels applied
- [x] PR linked to Shortcut