### PR TITLE
hotfix: Apply UV to Makefile & workflows

### DIFF
--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -75,10 +75,8 @@ jobs:
         with:
           version: ${{ vars.QUARTO_VERSION }}
 
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Generate Python library docs
         run: |

--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -89,8 +89,7 @@ jobs:
 
       - name: Generate template schema docs
         run: |
-          pip install json-schema-for-humans
-          BACKEND_ROOT=site/_source/backend python scripts/generate_template_schema_docs.py
+          BACKEND_ROOT=site/_source/backend uv run --with json-schema-for-humans python scripts/generate_template_schema_docs.py
 
       - name: Populate installation
         run: cp -r site/_source/installation/site/installation site/installation

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -75,10 +75,8 @@ jobs:
         with:
           version: ${{ vars.QUARTO_VERSION }}
 
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Generate Python library docs
         run: |

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -89,8 +89,7 @@ jobs:
 
       - name: Generate template schema docs
         run: |
-          pip install json-schema-for-humans
-          BACKEND_ROOT=site/_source/backend python scripts/generate_template_schema_docs.py
+          BACKEND_ROOT=site/_source/backend uv run --with json-schema-for-humans python scripts/generate_template_schema_docs.py
 
       - name: Populate installation
         run: cp -r site/_source/installation/site/installation site/installation

--- a/.github/workflows/publish-llm-markdown.yaml
+++ b/.github/workflows/publish-llm-markdown.yaml
@@ -39,10 +39,8 @@ jobs:
         with:
           version: ${{ vars.QUARTO_VERSION }}
 
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
 
       - name: Generate Python library docs
         run: |

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -89,8 +89,7 @@ jobs:
 
     - name: Generate template schema docs
       run: |
-        pip install json-schema-for-humans
-        BACKEND_ROOT=site/_source/backend python scripts/generate_template_schema_docs.py
+        BACKEND_ROOT=site/_source/backend uv run --with json-schema-for-humans python scripts/generate_template_schema_docs.py
 
     - name: Populate installation
       run: cp -r site/_source/installation/site/installation site/installation

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -65,6 +65,9 @@ jobs:
           src/backend/templates/documentation/model_documentation
         sparse-checkout-cone-mode: true
 
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Verify copyright headers
       run: |
         cd site
@@ -74,9 +77,6 @@ jobs:
       uses: quarto-dev/quarto-actions/setup@v2
       with:
         version: pre-release
-
-    - name: Set up uv
-      uses: astral-sh/setup-uv@v5
 
     - name: Generate Python library docs
       run: |

--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -75,10 +75,8 @@ jobs:
       with:
         version: pre-release
 
-    - name: Install Poetry
-      run: |
-        curl -sSL https://install.python-poetry.org | python3 -
-        echo "$HOME/.local/bin" >> $GITHUB_PATH
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
 
     - name: Generate Python library docs
       run: |

--- a/site/Makefile
+++ b/site/Makefile
@@ -59,7 +59,7 @@ help:
 
 add-copyright:
 	@echo "\nAdding copyright headers to .qmd and .yml/.yaml files ..."
-	@cd .. && python site/scripts/add_copyright.py
+	@cd .. && uv run python site/scripts/add_copyright.py
 
 # Clean up source directory
 clean:
@@ -337,9 +337,9 @@ notebooks:
 	@echo "Copying _metadata.yml into notebooks/ ..."
 	@cp developer/_metadata.yml $(DEST_DIR_NB)/_metadata.yml
 	@echo "Updating developer/_sidebar.yaml with use_cases directories ..."
-	@python scripts/developer-sidebar/update_use_cases.py
+	@uv run python scripts/developer-sidebar/update_use_cases.py
 	@echo "Updating developer/_sidebar.yaml with how-to directories ..."
-	@python scripts/developer-sidebar/update_how_tos.py
+	@uv run python scripts/developer-sidebar/update_how_tos.py
 	@echo "Zip up notebooks.zip ..."
 	@zip -r notebooks.zip $(DEST_DIR_NB) > /dev/null 2>&1
 
@@ -427,12 +427,11 @@ release-notes:
 template-schema-docs:
 	@echo "\nGenerating template schema documentation ..."
 	@if [ ! -d "$(SRC_ROOT)/backend" ]; then echo "Error: Backend not cloned. Run 'make clone' first."; exit 1; fi
-	@python -m pip install -q json-schema-for-humans
-	@BACKEND_ROOT=$(SRC_ROOT)/backend python ../scripts/generate_template_schema_docs.py
+	@BACKEND_ROOT=$(SRC_ROOT)/backend uv run --with json-schema-for-humans python ../scripts/generate_template_schema_docs.py
 
 test-descriptions:
 	@echo "\nUpdating test descriptions source ..."
-	@cd _source/validmind-library && make install && poetry run python scripts/extract_descriptions.py validmind/tests
+	@cd _source/validmind-library && make install && uv run python scripts/extract_descriptions.py validmind/tests
 	@cd ../../
 	@rm -rf $(DEST_DIR_TESTS)
 	@mkdir -p $(DEST_DIR_TESTS)
@@ -442,11 +441,11 @@ test-descriptions:
 
 verify-copyright:
 	@echo "\nVerifying copyright headers in .qmd and .yml/.yaml files ..."
-	@cd .. && python site/scripts/verify_copyright_qmd.py
+	@cd .. && uv run python site/scripts/verify_copyright_qmd.py
 
 # Collate yearly releases
 yearly-releases:
-	@python ../release-scripts/yearly_cleanup.py
+	@uv run python ../release-scripts/yearly_cleanup.py
 	cd ../
 	git status | grep -v 'release-scripts/'
 	quarto preview


### PR DESCRIPTION
# Pull Request Description

## What and why?

Hotfix swapping `documentation` Python toolchain from Poetry + pip to [uv](https://github.com/astral-sh/uv):

### `373275c30` — ci: Replace Poetry install step with uv setup

- In all four GitHub Actions workflows (`deploy-docs-prod.yaml`, `deploy-docs-staging.yaml`, `publish-llm-markdown.yaml`, `validate-docs-site.yaml`), the curl-based Poetry installer step is replaced with `astral-sh/setup-uv@v5`.
- CI no longer needs Poetry at all for these workflows.

### `0afe9455d` — Use uv for all Python script invocations

Once uv is the installer, every Python entry point should also go through uv so that CI and local dev both get reproducible, ephemeral envs without polluting system Python or relying on Poetry being present:

#### Workflows

`Generate template schema docs` step drops the separate `pip install json-schema-for-humans` line and runs the generator via `uv run --with json-schema-for-humans python …`.

#### Makefile (`site/Makefile`)

- Every `python`, `pip`, and `poetry run` call is rewritten to `uv run …` (or `uv run --with …` where deps are needed). Affects `add-copyright`, `notebooks`, `template-schema-docs`, `test-descriptions`, `verify-copyright`, and `yearly-releases`.
- Local contributors only need `uv` on their PATH; they no longer need a working Poetry install to run the affected `make` targets.

## How to test

### Prerequisite — UV installed locally

```bash
brew install uv
# or, cross-platform:
curl -LsSf https://astral.sh/uv/install.sh | sh
```

### Smoke-test the Makefile targets that changed

Run these from `site/`. Each maps directly to a line in commit `0afe9455d`:

```bash
cd site

# add_copyright.py via uv
make add-copyright

# verify_copyright_qmd.py via uv
make verify-copyright
```

The two above are the safest standalone targets — no source clone required. If they exit cleanly, the `uv run python …` rewrites are working.

### Full end-to-end check via `make get-source`

For a deeper test (and to get rid of the Python docs render errors when you call `quarto preview` or `quarto render` locally), run the consolidated `get-source` target on this branch (HEAD):

```bash
cd site
make get-source
```

When prompted by `Enter release tag (example: v2.8.10, or HEAD for latest):`, enter `HEAD`.

## What needs special review?

Can someone smarter than me actually confirm this fix is best practice for the security issue we've been dealing w/ pls & ty!!

## Dependencies, breaking changes, and deployment notes

Without this PR, other PR workflows/local branches will throw weird errors on render.

## Release notes

n/a

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [ ] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [ ] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

