### PR TITLE
docs: Reference other sections in document content blocks

### DIFF
--- a/site/guide/documentation/content_blocks/_generate-with-ai.qmd
+++ b/site/guide/documentation/content_blocks/_generate-with-ai.qmd
@@ -3,7 +3,7 @@ Refer to the LICENSE file in the root of this repository for details.
 SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 
 :::: {.content-visible unless-format="revealjs"}
-1. Click **[{{< fa diamond >}} (Generate Text with AI)]{.pink}** in the toolbar while editing a content block.
+1. Click **{{< fa ellipsis-vertical >}}** in the content editing toolbar and select **[{{< fa diamond >}} (Generate Text with AI)]{.pink}**.
 
 1. Enter in a custom prompt and click **Send**, or click **Generate Content** to compose a draft for review.
 
@@ -31,7 +31,7 @@ SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 
 <!-- INLINE LINKS FOR REVEALJS TRAINING -->
 :::: {.content-hidden unless-format="revealjs"}
-1. Click **[{{< fa diamond >}} (Generate Text with AI)]{.pink}** in the toolbar while editing a content block.
+1. Click **{{< fa ellipsis-vertical >}}** in the content editing toolbar and select **[{{< fa diamond >}} (Generate Text with AI)]{.pink}**.
 
 1. Enter in a custom prompt and click **Send**, or click **Generate Content** to compose a draft for review.
 

--- a/site/guide/documentation/work-with-content-blocks.qmd
+++ b/site/guide/documentation/work-with-content-blocks.qmd
@@ -150,6 +150,16 @@ When you generate content, the content builder uses the following context:
 :::
 :::
 
+### Reference document sections
+
+While editing a simple text block within documents, you can directly reference other sections of the document and create hyperlinks to other sections:
+
+1. In any simple text block, type `#` to retrieve the table of contents for the document you're editing.
+
+2. Select the title of the section you want to reference from the drop-down menu.
+
+3. After you click out of the content block editor, click on the hyperlink to verify that it navigates you to the correct section as expected.
+
 ## Remove content blocks
 
 ::: {.callout-important}

--- a/site/guide/documentation/work-with-content-blocks.qmd
+++ b/site/guide/documentation/work-with-content-blocks.qmd
@@ -154,11 +154,27 @@ When you generate content, the content builder uses the following context:
 
 While editing a simple text block within documents, you can directly reference other sections of the document and create hyperlinks to those sections:
 
+::: {.panel-tabset}
+
+#### From the content block editor
+
 1. In any simple text block, type `#` to retrieve the table of contents for the document you're editing.
 
 2. Select the title of the section you want to reference from the drop-down menu.
 
 3. After you click out of the content block editor, click on the hyperlink to verify that it navigates you to the correct section as expected.
+
+#### Using the content toolbar
+
+1. Click **{{< fa ellipsis-vertical >}}** in the content editing toolbar.
+
+2. Select **{{< fa link >}} Insert Reference**.
+
+3. Select the title of the section you want to reference from the drop-down menu.
+
+4. After you click out of the content block editor, click on the hyperlink to verify that it navigates you to the correct section as expected.
+
+:::
 
 Hyperlinks will also take you to the referenced section in PDF document exports.[^16]
 

--- a/site/guide/documentation/work-with-content-blocks.qmd
+++ b/site/guide/documentation/work-with-content-blocks.qmd
@@ -152,7 +152,7 @@ When you generate content, the content builder uses the following context:
 
 ### Reference document sections
 
-While editing a simple text block within documents, you can directly reference other sections of the document and create hyperlinks to other sections:
+While editing a simple text block within documents, you can directly reference other sections of the document and create hyperlinks to those sections:
 
 1. In any simple text block, type `#` to retrieve the table of contents for the document you're editing.
 

--- a/site/guide/documentation/work-with-content-blocks.qmd
+++ b/site/guide/documentation/work-with-content-blocks.qmd
@@ -160,6 +160,8 @@ While editing a simple text block within documents, you can directly reference o
 
 3. After you click out of the content block editor, click on the hyperlink to verify that it navigates you to the correct section as expected.
 
+Hyperlinks will also take you to the referenced section in PDF document exports.[^16]
+
 ## Remove content blocks
 
 ::: {.callout-important}
@@ -168,11 +170,11 @@ Test-driven or metric over time blocks can be re-added later on but **text block
 
 1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
 
-2. Select a record or find your record by applying a filter or searching for it.[^16]
+2. Select a record or find your record by applying a filter or searching for it.[^17]
 
-3. In the left sidebar that appears for your record, click **{{< fa file >}} Documents** and select the **Latest** tab.[^17]
+3. In the left sidebar that appears for your record, click **{{< fa file >}} Documents** and select the **Latest** tab.[^18]
 
-4. Click on the document file you want to remove a block from.[^18]
+4. Click on the document file you want to remove a block from.[^19]
 
 5. Click on a section header to expand that section and remove content.
 
@@ -215,8 +217,10 @@ Test-driven or metric over time blocks can be re-added later on but **text block
 
 [^15]: [View model activity](/guide/inventory/view-record-activity.qmd)
 
-[^16]: [Working with the model inventory](/guide/inventory/working-with-the-inventory.qmd#search-filter-and-sort-models)
+[^16]: [Export documents](/guide/reporting/export-documents.qmd)
 
-[^17]: [Work with document versions](/guide/documentation/work-with-document-versions.qmd)
+[^17]: [Working with the model inventory](/guide/inventory/working-with-the-inventory.qmd#search-filter-and-sort-models)
 
-[^18]: [Working with documents](/guide/templates/working-with-documents.qmd)
+[^18]: [Work with document versions](/guide/documentation/work-with-document-versions.qmd)
+
+[^19]: [Working with documents](/guide/templates/working-with-documents.qmd)


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-15297

We now have functionality for:

<img width="1290" height="370" alt="Screenshot 2026-05-15 at 8 21 27 PM" src="https://github.com/user-attachments/assets/cb424e42-d8dd-419b-9c45-33a2e7290b03" />

## How to test

Click on the live preview for the net-new section: [**Work with content blocks**](https://docs-staging.validmind.ai/pr_previews/beck/sc-15297/documentation-references-in-documentation/guide/documentation/work-with-content-blocks.html#reference-document-sections)

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

n/a

## Release notes

Covered by https://github.com/validmind/frontend/pull/2419 & https://github.com/validmind/frontend/pull/2418 & https://github.com/validmind/backend/pull/2964.

## Checklist
- [x] What and why
- [x] Screenshots or videos (Frontend)
- [x] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

