### PR TITLE
Fix VM API reference to use app.prod.validmind.ai

### DIFF
--- a/site/Makefile
+++ b/site/Makefile
@@ -277,7 +277,7 @@ get-api-json:
 	@rm -f reference/vm-api-swagger.json reference/admin-api-swagger.json reference/rapidoc-min.js
 	@mkdir -p reference
 	@echo "Fetching VM API Swagger spec ..."
-	@curl -s -o reference/vm-api-swagger.json "https://api.prod.validmind.ai/vm/api/v1/swagger.json" || echo "Failed to fetch VM API spec"
+	@curl -s -o reference/vm-api-swagger.json "https://app.prod.validmind.ai/vm/api/v1/swagger.json" || echo "Failed to fetch VM API spec"
 	@echo "Fetching Admin API Swagger spec ..."
 	@curl -s -o reference/admin-api-swagger.json "https://api.prod.validmind.ai/admin/api/v1/swagger.json" || echo "Failed to fetch Admin API spec"
 	@echo "Fetching RapiDoc JavaScript library ..."

--- a/site/reference/vm-api.qmd
+++ b/site/reference/vm-api.qmd
@@ -22,9 +22,9 @@ bread-crumbs: false
 <script type="module" src="https://unpkg.com/rapidoc/dist/rapidoc-min.js"></script>
 
 <rapi-doc 
-    spec-url="https://api.prod.validmind.ai/vm/api/v1/swagger.json"
-    server-url="https://api.prod.validmind.ai/vm/api/v1/"
-    default-api-server="https://api.prod.validmind.ai/vm/api/v1/"
+    spec-url="https://app.prod.validmind.ai/vm/api/v1/swagger.json"
+    server-url="https://app.prod.validmind.ai/vm/api/v1/"
+    default-api-server="https://app.prod.validmind.ai/vm/api/v1/"
     show-header="false"
     theme="light"
     load-fonts="true"


### PR DESCRIPTION
## Summary
- Update `/reference/vm-api.html` RapiDoc `spec-url`, `server-url`, and `default-api-server` from `api.prod.validmind.ai` to `app.prod.validmind.ai`
- Update the `get-api-json` Makefile target so local swagger downloads use the same host

## Test plan
- [ ] Open https://docs.validmind.ai/reference/vm-api.html (or preview build) and confirm the API reference loads without swagger fetch errors
- [ ] Run `make get-api-json` in `site/` and verify `reference/vm-api-swagger.json` downloads successfully


Made with [Cursor](https://cursor.com)