### PR TITLE
Prefer main when auto-merging into staging

### DIFF
--- a/.github/workflows/merge-main-into-staging.yaml
+++ b/.github/workflows/merge-main-into-staging.yaml
@@ -26,9 +26,16 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Merge in main branch
+      - name: Merge in main branch (prefer main on conflicts)
         run: |
-          git merge --no-ff origin/main
+          if ! git merge -X theirs --no-edit origin/main; then
+            echo "::warning::Merge reported conflicts; taking main's version for unresolved paths."
+            git diff --name-only --diff-filter=U | while IFS= read -r file; do
+              git checkout --theirs -- "$file"
+              git add -- "$file"
+            done
+            git commit --no-edit
+          fi
 
       # NEW: detect the PR that triggered this push to main (if any)
       - name: Determine source PR (if any)


### PR DESCRIPTION
## Summary

Updates the **Merge main into staging** workflow so conflicts resolve in favor of `main` instead of failing and leaving `staging` stuck.

- Uses `git merge -X theirs` (on `staging`, `theirs` = `main`)
- Falls back to `git checkout --theirs` for any paths Git still marks unmerged

## Test plan

- [ ] Merge this PR to `main`
- [ ] Merge [PR #1370](https://github.com/validmind/documentation/pull/1370) to unblock current `staging`
- [ ] Push a follow-up commit to `main` and confirm **Merge main into staging** succeeds without manual intervention


Made with [Cursor](https://cursor.com)