### PR TITLE
Documentation — Disable organization users

### DIFF
--- a/site/guide/configuration/manage-users.qmd
+++ b/site/guide/configuration/manage-users.qmd
@@ -72,7 +72,7 @@ To remove a user from your organization, revoking their access and any API keys 
 
 4. Under the Actions column, click **{{< fa ellipsis-vertical >}}** and select **{{< fa user-minus >}} Disable**.
 
-5. Click **Disable** to confirm removal of the selected user from your organization.
+5. Select **Disable** to confirm removal of the selected user from your organization.
 
 
 <!-- FOOTNOTES -->

--- a/site/guide/configuration/manage-users.qmd
+++ b/site/guide/configuration/manage-users.qmd
@@ -55,9 +55,32 @@ Adjust the roles[^2] users from your organization have within the {{< var validm
 
 {{< include _manage-user-roles.qmd >}}
 
+## Disable users
+
+::: {.callout-important title="Disabling users is permanent and cannot be undone."}
+To allow users access to your organization again, including providing valid API keys and secrets, you must re-invite them.[^3]
+
+:::
+
+To remove a user from your organization, revoking their access and any API keys and secrets:[^4]
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+2. Under {{< fa users >}} Users & Access, select **User Directory**.
+
+3. Hover over the user you want to remove from your organization.
+
+4. Under the Actions column, click **{{< fa ellipsis-vertical >}}** and select **{{< fa user-minus >}} Disable**.
+
+5. Click **Disable** to confirm removal of the selected user from your organization.
+
 
 <!-- FOOTNOTES -->
 
 [^1]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
 
 [^2]: [Manage roles](/guide/configuration/manage-roles.qmd)
+
+[^3]: [Manage user invitations](#manage-user-invitations)
+
+[^4]: [Manage your profile](/guide/configuration/manage-your-profile.qmd#access-keys)

--- a/site/llm/chatbot-product-map.md
+++ b/site/llm/chatbot-product-map.md
@@ -243,7 +243,7 @@
 **Docs (related):**
 
 - `/guide/configuration/manage-users.html`
-  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles
+  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles; Disable users
 - `/guide/configuration/managing-users.html`
   - Sections: Key concepts; Key terms; Default roles; User management; What's next
 
@@ -315,7 +315,7 @@
 - `/guide/configuration/managing-users.html`
   - Sections: Key concepts; Key terms; Default roles; User management; What's next
 - `/guide/configuration/manage-users.html` (section: #manage-user-invitations)
-  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles
+  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles; Disable users
 
 ### Organization
 
@@ -338,7 +338,7 @@
 **Docs (related):**
 
 - `/guide/configuration/manage-users.html`
-  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles
+  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles; Disable users
 - `/guide/configuration/managing-users.html`
   - Sections: Key concepts; Key terms; Default roles; User management; What's next
 
@@ -421,7 +421,7 @@
 **Docs (related):**
 
 - `/guide/configuration/manage-users.html`
-  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles
+  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles; Disable users
 
 ### Main navigation
 
@@ -478,7 +478,7 @@
 - `/guide/configuration/managing-users.html`
   - Sections: Key concepts; Key terms; Default roles; User management; What's next
 - `/guide/configuration/manage-users.html`
-  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles
+  - Sections: Prerequisites; View and search for users; Manage user invitations; Invite new users; Monitor user invitations; Manage user roles; Disable users
 
 ### Governance
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-17036

Administrators can now disable users within their organization, revoking access and API keys. Documentation updated to cover this 26.07 release feature.

## How to test

Click on the live previews:

#### Guides

##### Configuration

| OLD | NEW | Changes |
|--|--|--|
| [Manage users](https://docs-staging.validmind.ai/guide/configuration/manage-users.html) | [**Manage users**](https://docs-staging.validmind.ai/pr_previews/beck/sc-17036/documentation-disable-organization-users/guide/configuration/manage-users.html#disable-users) | Added a net-new **Disable users** section. |

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

n/a

## Release notes

Covered by https://docs.validmind.ai/releases/frontend/26.07/pr-platform-highlights.html.

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
