### PR TITLE
Add post-merge-guard review workflow for release notes automation

### DIFF
--- a/.github/workflows/post-merge-guard-review.yml
+++ b/.github/workflows/post-merge-guard-review.yml
@@ -1,0 +1,122 @@
+name: Post merge-guard review
+
+on:
+  repository_dispatch:
+    types: [post-merge-guard-review]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post CHANGES_REQUESTED review
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const payload = context.payload.client_payload;
+            const pr_number = payload.pr_number;
+            const owner = 'validmind';
+            const repo = 'documentation';
+
+            const existing = await github.rest.pulls.listReviews({
+              owner,
+              repo,
+              pull_number: pr_number,
+            });
+            const already = existing.data.some(
+              (r) => r.user.login === 'github-actions[bot]' && r.state === 'CHANGES_REQUESTED',
+            );
+            if (already) {
+              core.info(
+                `CHANGES_REQUESTED review already present on PR #${pr_number} — skipping`,
+              );
+              return;
+            }
+
+            let commitSha = payload.commit_sha;
+            let headRef = payload.preview_branch;
+            try {
+              const prResp = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: pr_number,
+              });
+              commitSha = prResp.data.head.sha;
+              headRef = prResp.data.head.ref;
+            } catch (e) {
+              core.warning(
+                `Could not re-fetch PR HEAD; using payload values: ${e.message}`,
+              );
+            }
+
+            let lineNumber = payload.line_number;
+            if (payload.workflow_rel && headRef && payload.ref) {
+              try {
+                const fileResp = await github.rest.repos.getContent({
+                  owner,
+                  repo,
+                  path: payload.workflow_rel,
+                  ref: headRef,
+                });
+                const text = Buffer.from(fileResp.data.content, 'base64').toString();
+                const needle = `ref: ${payload.ref}`;
+                const idx = text.split('\n').findIndex((l) => l.trim() === needle);
+                if (idx !== -1) {
+                  lineNumber = idx + 1;
+                }
+              } catch (e) {
+                core.warning(
+                  `Could not re-read workflow file to verify line number: ${e.message}`,
+                );
+              }
+            }
+
+            const comments =
+              payload.workflow_rel && lineNumber && payload.inline_body
+                ? [
+                    {
+                      path: payload.workflow_rel,
+                      line: lineNumber,
+                      side: 'RIGHT',
+                      body: payload.inline_body,
+                    },
+                  ]
+                : [];
+
+            try {
+              await github.rest.pulls.createReview({
+                owner,
+                repo,
+                pull_number: pr_number,
+                commit_id: commitSha,
+                event: 'CHANGES_REQUESTED',
+                body: payload.body,
+                comments,
+              });
+              core.info(
+                `CHANGES_REQUESTED review posted on PR #${pr_number} by github-actions[bot]`,
+              );
+            } catch (e) {
+              if (e.status === 422 && comments.length > 0) {
+                core.warning(
+                  `Inline comment caused 422; retrying body-only: ${e.message}`,
+                );
+                await github.rest.pulls.createReview({
+                  owner,
+                  repo,
+                  pull_number: pr_number,
+                  commit_id: commitSha,
+                  event: 'CHANGES_REQUESTED',
+                  body: payload.body,
+                });
+                core.info(
+                  `CHANGES_REQUESTED review posted (body only) on PR #${pr_number}`,
+                );
+              } else {
+                throw e;
+              }
+            }


### PR DESCRIPTION
# Pull Request Description

## What and why?

> sc-17064

MVP release notes automation was failing when documentation PRs left workflow `ref` values pointing at `main` instead of the PR branch:

-  Solution: GitHub Actions workflow that posts a `CHANGES_REQUESTED` review (with an optional inline comment on the workflow file) when the release-notes automation dispatches a `post-merge-guard-review` event.
- Added: [`.github/workflows/post-merge-guard-review.yml`](https://github.com/validmind/documentation/blob/beck/sc-17064/release-notes-automation-troubleshooting/.github/workflows/post-merge-guard-review.yml) — listens for `repository_dispatch` events of type `post-merge-guard-review`, skips duplicate bot reviews, re-fetches the PR HEAD for the latest commit SHA, resolves the inline comment line from the workflow file when possible, and falls back to a body-only review if GitHub returns 422 on inline comments.

## How to test

To verify the workflow:

1. Merge this branch to `main` so the workflow is available.
2. From the release-notes automation (or manually via `repository_dispatch`), send a `post-merge-guard-review` event with `client_payload` containing `pr_number`, `body`, and optionally `workflow_rel`, `ref`, `line_number`, and `inline_body`.
3. Confirm a `CHANGES_REQUESTED` review from `github-actions[bot]` appears on the target documentation PR.
4. Re-dispatch the same event and confirm the workflow skips posting a duplicate review.

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

Fix for https://github.com/validmind/release-notes/pull/93.

## Release notes

<!-- CURSOR: Make sure the PR is labeled `internal` when created not put internal here -->

n/a

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [ ] What needs special review
- [ ] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
