### PR TITLE
fix(ci): post-merge guard use REQUEST_CHANGES for createReview API

### DIFF
--- a/.github/workflows/post-merge-guard-review.yml
+++ b/.github/workflows/post-merge-guard-review.yml
@@ -93,7 +93,7 @@ jobs:
                 repo,
                 pull_number: pr_number,
                 commit_id: commitSha,
-                event: 'CHANGES_REQUESTED',
+                event: 'REQUEST_CHANGES',
                 body: payload.body,
                 comments,
               });
@@ -110,7 +110,7 @@ jobs:
                   repo,
                   pull_number: pr_number,
                   commit_id: commitSha,
-                  event: 'CHANGES_REQUESTED',
+                  event: 'REQUEST_CHANGES',
                   body: payload.body,
                 });
                 core.info(


### PR DESCRIPTION
## What and why?

> sc-17064

Follow up to: https://github.com/validmind/documentation/pull/1388

- The post-merge guard workflow was failing to post `CHANGES_REQUESTED` reviews because the GitHub API expects the review event value `REQUEST_CHANGES`. Updated the workflow to use the correct event name so merge-guard failures block PRs as intended.
- Fixed [`.github/workflows/post-merge-guard-review.yml`](https://github.com/validmind/documentation/blob/beck/sc-17064/post-merge-guard-request-changes-fix/.github/workflows/post-merge-guard-review.yml) to pass `event: 'REQUEST_CHANGES'` instead of `event: 'CHANGES_REQUESTED'` when calling `pulls.createReview` (both the inline-comment and body-only retry paths).

## How to test

To verify the workflow fix:

1. Merge a PR whose preview deploy workflow uses a non-`main` ref (triggering the merge guard).
2. Confirm the post-merge guard dispatches and posts a review with state **Changes requested** on the PR.
3. Confirm the review is attributed to `github-actions[bot]` and includes the expected body (and inline comment when applicable).

## What needs special review?

n/a

## Dependencies, breaking changes, and deployment notes

Hotfix inception for https://github.com/validmind/release-notes/pull/93.

## Release notes
<!--- CURSOR APPLY THE LABEL `internal` INSTEAD OF REPLACING THE BELOW --->

n/a

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

Made with [Cursor](https://cursor.com)