### PR TITLE
Preview library release notes: v2.13.4

### DIFF
--- a/.github/workflows/validate-docs-site.yaml
+++ b/.github/workflows/validate-docs-site.yaml
@@ -55,6 +55,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: validmind/release-notes
+        ref: automated/library-v2.13.4
         path: site/_source/release-notes
         token: ${{ secrets.DOCS_CI_RO_PAT }}
         sparse-checkout: |


### PR DESCRIPTION
# Pull Request Description

> [sc-17136](https://app.shortcut.com/validmind/story/17136)

## What and why?

Preview for [Patch release notes: 2.13.4 (#95)](https://github.com/validmind/release-notes/pull/95).

> [!WARNING]
> This PR automatically checks out the release notes branch `automated/library-v2.13.4` in `.github/workflows/validate-docs-site.yaml` so the preview displays the in-progress release notes (temporary `ref:` — remove before merge).

| | |
| --- | --- |
| Release type | Library patch release |
| Version | `2.13.4` |
| `validate-docs-site.yaml` (**REVERT BEFORE MERGE**) | Temporary `ref: automated/library-v2.13.4` on *Check out release-notes repository* step |

### How to regenerate release notes preview

After updates are pushed to the linked release-notes PR: [https://github.com/validmind/release-notes/pull/95](https://github.com/validmind/release-notes/pull/95)

1. Open *this* PR in `validmind/documentation`
2. Re-run *Validate docs site* workflow (**Actions** tab → **Validate docs site ...** in the left sidebar → Select the latest workflow run linked to this PR → **Re-run all jobs**)

No commits on this branch are required — that workflow already checks out release-notes branch `automated/library-v2.13.4` via the temporary `ref:` on the *Check out release-notes repository* step.

## How to test

Click on the live `documentation` previews.

### Public release notes

> [!IMPORTANT]
> Release notes author to remove links to pages without updates before marking `release-notes` PR ready for review.

- [Latest releases](https://docs-staging.validmind.ai/pr_previews/automated/preview-library-v2.13.4/index.html#releases)
- [All releases](https://docs-staging.validmind.ai/pr_previews/automated/preview-library-v2.13.4/releases/all-releases.html):
  - [Feature highlights](https://docs-staging.validmind.ai/pr_previews/automated/preview-library-v2.13.4/releases/feature-highlights.html)
  - [ValidMind Library Releases](https://docs-staging.validmind.ai/pr_previews/automated/preview-library-v2.13.4/releases/validmind-library-releases.html)
  - [Breaking changes and deprecations](https://docs-staging.validmind.ai/pr_previews/automated/preview-library-v2.13.4/releases/breaking-changes-and-deprecations.html)


## What needs special review?

_Auto-generated. Complete **What needs special review?** on the linked `release-notes` PR — not here._

1. Verify that you can see release notes in the previews above as expected and that they render without any issues.
2. Work through the merge checklist below

### Merge (documentation preview)

- [ ] Verify that you can see release notes in the previews as expected and that they render without any issues
- [ ] Only when you are satisfied with the release notes, merge the linked `release-notes` PR to `main` first
- [ ] On *this* branch, resolve the automated `CHANGES_REQUESTED` review by removing the `ref:` line from `.github/workflows/validate-docs-site.yaml` (keep `repository:` and `path:`)
- [ ] Confirm **Validate docs site** passes again on *this* PR
- [ ] Merge *this* PR to `documentation` / `main` after the `release-notes` PR merges sucessfully

## Dependencies, breaking changes, and deployment notes

**Release-notes PR (complete review there):** [Library release notes: v2.13.4 (#95)](https://github.com/validmind/release-notes/pull/95) — customer-facing `.qmd` content and full track checklist.

## Release notes

n/a (`internal` label — customer-facing content is in `validmind/release-notes`)

## Checklist

- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [ ] Tested locally
- [x] Documentation updated (if required)
> _Preserved checked items from prior PR body after stable refresh._