### PR TITLE
Promote prebuilt documentation artifacts to production

### DIFF
--- a/.github/actions/build-docs-site/action.yml
+++ b/.github/actions/build-docs-site/action.yml
@@ -1,0 +1,114 @@
+name: Build docs site
+description: Populate generated sources and render a complete documentation site
+
+inputs:
+  profile:
+    description: Quarto profile to render
+    required: true
+  docs_ci_ro_pat:
+    description: Read-only token for private source repositories
+    required: true
+  quarto_version:
+    description: Quarto version to install
+    required: true
+  library_ref:
+    description: validmind-library revision to build
+    required: true
+  installation_ref:
+    description: installation revision to build
+    required: true
+  release_notes_ref:
+    description: release-notes revision to build
+    required: true
+  backend_ref:
+    description: backend revision to build
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Check out validmind-library repository
+      uses: actions/checkout@v4
+      with:
+        repository: validmind/validmind-library
+        ref: ${{ inputs.library_ref }}
+        path: site/_source/validmind-library
+        token: ${{ inputs.docs_ci_ro_pat }}
+
+    - name: Check out installation repository
+      uses: actions/checkout@v4
+      with:
+        repository: validmind/installation
+        ref: ${{ inputs.installation_ref }}
+        path: site/_source/installation
+        token: ${{ inputs.docs_ci_ro_pat }}
+        sparse-checkout: |
+          site/installation
+        sparse-checkout-cone-mode: true
+
+    - name: Check out release-notes repository
+      uses: actions/checkout@v4
+      with:
+        repository: validmind/release-notes
+        ref: ${{ inputs.release_notes_ref }}
+        path: site/_source/release-notes
+        token: ${{ inputs.docs_ci_ro_pat }}
+        sparse-checkout: |
+          releases
+        sparse-checkout-cone-mode: true
+
+    - name: Check out backend repository
+      uses: actions/checkout@v4
+      with:
+        repository: validmind/backend
+        ref: ${{ inputs.backend_ref }}
+        path: site/_source/backend
+        token: ${{ inputs.docs_ci_ro_pat }}
+        sparse-checkout: |
+          src/backend/templates/documentation/model_documentation
+        sparse-checkout-cone-mode: true
+
+    - name: Set up Quarto
+      uses: quarto-dev/quarto-actions/setup@v2
+      with:
+        version: ${{ inputs.quarto_version }}
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Generate Python library docs
+      shell: bash
+      run: |
+        cd site/_source/validmind-library
+        make install && make quarto-docs
+        cd ../../
+        rm -rf validmind
+        mkdir -p validmind
+        rsync -av --exclude '_build' --exclude 'templates' _source/validmind-library/docs/ validmind/
+
+    - name: Generate template schema docs
+      shell: bash
+      run: BACKEND_ROOT=site/_source/backend uv run --with json-schema-for-humans python scripts/generate_template_schema_docs.py
+
+    - name: Populate installation
+      shell: bash
+      run: cp -r site/_source/installation/site/installation site/installation
+
+    - name: Populate release notes
+      shell: bash
+      run: |
+        cp -r site/_source/release-notes/releases site
+        rm -f site/releases/backend-releases.qmd site/releases/cmvm-releases.qmd
+
+    - name: Render docs site
+      shell: bash
+      env:
+        QUARTO_PROFILE: ${{ inputs.profile }}
+      run: |
+        cd site
+        quarto render --profile "$QUARTO_PROFILE" &> render_errors.log || {
+          echo "Quarto render failed immediately"
+          cat render_errors.log
+          exit 1
+        }
+        make generate-sitemap

--- a/.github/workflows/deploy-docs-prod.yaml
+++ b/.github/workflows/deploy-docs-prod.yaml
@@ -10,6 +10,14 @@ on:
       - completed
   workflow_dispatch:
 
+concurrency:
+  group: deploy-docs-production
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+
 jobs:
   deploy:
     if: |
@@ -22,8 +30,46 @@ jobs:
       - name: Check out documentation repository
         uses: actions/checkout@v4
 
-      # Reclaim space + create a reserve for deterministic headroom
+      - name: Find production artifact for this source tree
+        id: production-artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          name="docs-production-$(git rev-parse 'HEAD^{tree}')"
+          run_id=$(gh api "repos/${{ github.repository }}/actions/artifacts?name=$name&per_page=100" \
+            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | reverse | .[0].workflow_run.id // empty')
+
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          if [[ -n "$run_id" ]]; then
+            echo "Found $name in workflow run $run_id"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            echo "run_id=$run_id" >> "$GITHUB_OUTPUT"
+          else
+            echo "No matching artifact found; falling back to a full production build."
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download prebuilt production docs
+        if: steps.production-artifact.outputs.found == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ steps.production-artifact.outputs.name }}
+          path: ${{ runner.temp }}/production-artifact
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ steps.production-artifact.outputs.run_id }}
+
+      - name: Extract prebuilt production docs
+        if: steps.production-artifact.outputs.found == 'true'
+        run: |
+          mkdir -p site/_site
+          tar --zstd -xf "$RUNNER_TEMP/production-artifact/docs-production.tar.zst" -C site/_site
+
+      # Reclaim space only when the prebuilt artifact is unavailable and the
+      # workflow must perform the original full-site build.
       - name: Free space + create reserve
+        if: steps.production-artifact.outputs.found != 'true'
         uses: ./.github/actions/free-disk-space
         with:
           remove_dotnet: "true"
@@ -33,84 +79,17 @@ jobs:
           apt_cleanup: "true"
           create_reserve_gb: "3"
 
-      - name: Check out validmind-library repository
-        uses: actions/checkout@v4
+      - name: Build production docs site
+        if: steps.production-artifact.outputs.found != 'true'
+        uses: ./.github/actions/build-docs-site
         with:
-          repository: validmind/validmind-library
-          path: site/_source/validmind-library
-          token: ${{ secrets.DOCS_CI_RO_PAT }}
-
-      - name: Check out installation repository
-        uses: actions/checkout@v4
-        with:
-          repository: validmind/installation
-          path: site/_source/installation
-          token: ${{ secrets.DOCS_CI_RO_PAT }}
-          sparse-checkout: |
-            site/installation
-          sparse-checkout-cone-mode: true
-
-      - name: Check out release-notes repository
-        uses: actions/checkout@v4
-        with:
-          repository: validmind/release-notes
-          path: site/_source/release-notes
-          token: ${{ secrets.DOCS_CI_RO_PAT }}
-          sparse-checkout: |
-            releases
-          sparse-checkout-cone-mode: true
-
-      - name: Check out backend repository
-        uses: actions/checkout@v4
-        with:
-          repository: validmind/backend
-          path: site/_source/backend
-          token: ${{ secrets.DOCS_CI_RO_PAT }}
-          sparse-checkout: |
-            src/backend/templates/documentation/model_documentation
-          sparse-checkout-cone-mode: true
-
-      - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: ${{ vars.QUARTO_VERSION }}
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Generate Python library docs
-        run: |
-          cd site/_source/validmind-library
-          make install && make quarto-docs
-          cd ../../
-          rm -rf validmind
-          mkdir -p validmind
-          rsync -av --exclude '_build' --exclude 'templates' _source/validmind-library/docs/ validmind/
-
-      - name: Generate template schema docs
-        run: |
-          BACKEND_ROOT=site/_source/backend uv run --with json-schema-for-humans python scripts/generate_template_schema_docs.py
-
-      - name: Populate installation
-        run: cp -r site/_source/installation/site/installation site/installation
-
-      - name: Populate release notes
-        run: |
-          cp -r site/_source/release-notes/releases site
-          rm -f site/releases/backend-releases.qmd site/releases/cmvm-releases.qmd
-
-      - name: Render prod docs site
-        run: |
-            cd site
-            quarto render --profile production &> render_errors.log || {
-            echo "Quarto render failed immediately";
-            cat render_errors.log;
-            exit 1;
-            }
-            make generate-sitemap
+          profile: production
+          docs_ci_ro_pat: ${{ secrets.DOCS_CI_RO_PAT }}
+          quarto_version: ${{ vars.QUARTO_VERSION }}
+          library_ref: main
+          installation_ref: main
+          release_notes_ref: main
+          backend_ref: main
 
       # Prod bucket is in us-east-1
       - name: Configure AWS credentials

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -10,17 +10,64 @@ on:
       - completed
   workflow_dispatch:
 
+concurrency:
+  group: deploy-docs-staging
+  cancel-in-progress: true
+
 jobs:
-  deploy:
+  resolve-sources:
+    name: Resolve source revisions
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    outputs:
+      library: ${{ steps.refs.outputs.library }}
+      installation: ${{ steps.refs.outputs.installation }}
+      release_notes: ${{ steps.refs.outputs.release_notes }}
+      backend: ${{ steps.refs.outputs.backend }}
+    steps:
+      - name: Resolve source revisions
+        id: refs
+        env:
+          GH_TOKEN: ${{ secrets.DOCS_CI_RO_PAT }}
+        run: |
+          echo "library=$(gh api repos/validmind/validmind-library/commits/main --jq .sha)" >> "$GITHUB_OUTPUT"
+          echo "installation=$(gh api repos/validmind/installation/commits/main --jq .sha)" >> "$GITHUB_OUTPUT"
+          echo "release_notes=$(gh api repos/validmind/release-notes/commits/main --jq .sha)" >> "$GITHUB_OUTPUT"
+          echo "backend=$(gh api repos/validmind/backend/commits/main --jq .sha)" >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.profile }} docs site
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    needs: resolve-sources
+    strategy:
+      fail-fast: false
+      matrix:
+        profile: [staging, production]
 
     steps:
       - name: Check out documentation repository
         uses: actions/checkout@v4
+
+      # Production can contain hotfixes that have not flowed back to staging.
+      # Build the artifact from the tree that a staging-to-prod merge will
+      # produce, so its key matches the eventual prod merge commit.
+      - name: Prepare prospective production tree
+        if: matrix.profile == 'production'
+        run: |
+          set -euo pipefail
+          source_sha=$(git rev-parse HEAD)
+          git fetch origin prod
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git switch --detach origin/prod
+          git merge --no-commit --no-ff "$source_sha"
 
       # Reclaim space + create a reserve for deterministic headroom
       - name: Free space + create reserve
@@ -33,94 +80,49 @@ jobs:
           apt_cleanup: "true"
           create_reserve_gb: "3"
 
-      - name: Check out validmind-library repository
-        uses: actions/checkout@v4
+      - name: Build docs site
+        uses: ./.github/actions/build-docs-site
         with:
-          repository: validmind/validmind-library
-          path: site/_source/validmind-library
-          token: ${{ secrets.DOCS_CI_RO_PAT }}
-
-      - name: Check out installation repository
-        uses: actions/checkout@v4
-        with:
-          repository: validmind/installation
-          path: site/_source/installation
-          token: ${{ secrets.DOCS_CI_RO_PAT }}
-          sparse-checkout: |
-            site/installation
-          sparse-checkout-cone-mode: true
-
-      - name: Check out release-notes repository
-        uses: actions/checkout@v4
-        with:
-          repository: validmind/release-notes
-          path: site/_source/release-notes
-          token: ${{ secrets.DOCS_CI_RO_PAT }}
-          sparse-checkout: |
-            releases
-          sparse-checkout-cone-mode: true
-
-      - name: Check out backend repository
-        uses: actions/checkout@v4
-        with:
-          repository: validmind/backend
-          path: site/_source/backend
-          token: ${{ secrets.DOCS_CI_RO_PAT }}
-          sparse-checkout: |
-            src/backend/templates/documentation/model_documentation
-          sparse-checkout-cone-mode: true
-
-      - name: Set up Quarto
-        uses: quarto-dev/quarto-actions/setup@v2
-        with:
-          version: ${{ vars.QUARTO_VERSION }}
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Generate Python library docs
-        run: |
-          cd site/_source/validmind-library
-          make install && make quarto-docs
-          cd ../../
-          rm -rf validmind
-          mkdir -p validmind
-          rsync -av --exclude '_build' --exclude 'templates' _source/validmind-library/docs/ validmind/
-
-      - name: Generate template schema docs
-        run: |
-          BACKEND_ROOT=site/_source/backend uv run --with json-schema-for-humans python scripts/generate_template_schema_docs.py
-
-      - name: Populate installation
-        run: cp -r site/_source/installation/site/installation site/installation
-
-      - name: Populate release notes
-        run: |
-          cp -r site/_source/release-notes/releases site
-          rm -f site/releases/backend-releases.qmd site/releases/cmvm-releases.qmd
-
-      - name: Render staging docs site
-        run: |
-            cd site
-            quarto render --profile staging &> render_errors.log || {
-            echo "Quarto render failed immediately";
-            cat render_errors.log;
-            exit 1;
-            }
-            make generate-sitemap
+          profile: ${{ matrix.profile }}
+          docs_ci_ro_pat: ${{ secrets.DOCS_CI_RO_PAT }}
+          quarto_version: ${{ vars.QUARTO_VERSION }}
+          library_ref: ${{ needs.resolve-sources.outputs.library }}
+          installation_ref: ${{ needs.resolve-sources.outputs.installation }}
+          release_notes_ref: ${{ needs.resolve-sources.outputs.release_notes }}
+          backend_ref: ${{ needs.resolve-sources.outputs.backend }}
 
       - name: Add robots.txt for staging
+        if: matrix.profile == 'staging'
         run: cp site/environments/robots-staging.txt site/_site/robots.txt
 
       # Staging bucket is in us-west-2
       - name: Configure AWS credentials
+        if: matrix.profile == 'staging'
         run: aws configure set aws_access_key_id ${{ secrets.AWS_ACCESS_KEY_ID_STAGING }} && aws configure set aws_secret_access_key ${{ secrets.AWS_SECRET_ACCESS_KEY_STAGING }} && aws configure set default.region us-west-2
 
       - name: Deploy docs staging site
+        if: matrix.profile == 'staging'
         run: aws s3 sync site/_site s3://validmind-docs-staging/site --delete --exclude "installation/helm-repo/*" --exclude "pr_previews/*" --exclude "notebooks/EXECUTED/*" --exclude "llm/*" --cache-control "no-cache, max-age=0, must-revalidate" && aws cloudfront create-invalidation --distribution-id ESWVTZYFL873V --paths "/*" --no-cli-pager
+
+      - name: Determine production artifact name
+        if: matrix.profile == 'production'
+        id: production-artifact
+        shell: bash
+        run: echo "name=docs-production-$(git write-tree)" >> "$GITHUB_OUTPUT"
+
+      - name: Package production docs site
+        if: matrix.profile == 'production'
+        run: tar --zstd -cf "$RUNNER_TEMP/docs-production.tar.zst" -C site/_site .
+
+      - name: Upload production docs artifact
+        if: matrix.profile == 'production'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.production-artifact.outputs.name }}
+          path: ${{ runner.temp }}/docs-production.tar.zst
+          compression-level: 0
+          if-no-files-found: error
+          retention-days: 14
 
       # Release headroom and shrink before final lightweight steps & post-job
       - name: Release reserve & shrink


### PR DESCRIPTION
# Pull Request Description

## What and why?

Production documentation deployments currently rebuild all ~1,000 pages after the staging-to-prod merge. The latest production run spent 14m28s rendering and only 42s deploying.

This change builds staging and production-profile sites in parallel during the staging workflow. The production build is packaged as a versioned GitHub Actions artifact keyed to the predicted post-merge Git tree. After staging is promoted, the production workflow downloads and deploys that exact artifact instead of rendering the site again.

It also:

- pins all external source repositories to the same resolved revisions for both parallel builds
- accounts for prod-only hotfixes when predicting the eventual merge tree
- retains the existing full production build as a fallback when no exact artifact exists
- cancels obsolete staging or production deployments when a newer run starts
- consolidates duplicated build steps into a composite action and removes the duplicate `uv` setup

## How to test

- Run `actionlint` against both deployment workflows.
- Parse the workflow and composite-action YAML.
- Package and extract a local `_site` directory with the same tar/zstd commands.
- Compare the prospective production tree with `git merge-tree --write-tree origin/prod origin/main`.
- After merge, confirm the staging workflow produces both a staging deployment and a `docs-production-<tree>` artifact.
- On the next staging-to-prod promotion, confirm production logs `Found docs-production-<tree>` and skips the full-build steps.

## What needs special review?

- Staging uses two runners in parallel, so its wall-clock duration should stay near the current ~18 minutes, but total runner usage approximately doubles.
- Artifact lookup and the predicted post-merge tree are the critical correctness boundary.
- The first production promotion without an exact artifact will safely use the original full-build path.

## Dependencies, breaking changes, and deployment notes

- Production artifacts are retained for 14 days.
- Production still requires its existing AWS credentials and CloudFront configuration.
- No environment-variable changes or user-facing breaking changes.

## Release notes

Not applicable; internal CI/CD optimization.

## Checklist

- [x] What and why
- [ ] Screenshots or videos (Frontend) — not applicable
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [ ] PR linked to Shortcut — not applicable
- [ ] Unit tests added (Backend) — not applicable
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented — not applicable
