### PR TITLE
Fix production artifact merge prediction

### DIFF
--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -54,6 +54,10 @@ jobs:
     steps:
       - name: Check out documentation repository
         uses: actions/checkout@v4
+        with:
+          # The production build predicts the staging-to-prod merge tree and
+          # therefore needs the shared branch history, not a depth-one clone.
+          fetch-depth: 0
 
       # Production can contain hotfixes that have not flowed back to staging.
       # Build the artifact from the tree that a staging-to-prod merge will


### PR DESCRIPTION
# Pull Request Description

## What and why?

The first production-artifact build introduced by #1409 failed while predicting the staging-to-prod merge tree because the documentation checkout contained only one commit from each branch. Git therefore treated the branches as unrelated histories.

Fetch the complete documentation history so the prospective production merge can find its real merge base.

## How to test

- `actionlint .github/workflows/deploy-docs-staging.yaml`
- Confirm the next staging workflow completes `Prepare prospective production tree`, renders both profiles, and uploads a `docs-production-<tree>` artifact.

## What needs special review?

None.

## Dependencies, breaking changes, and deployment notes

This is required for the production-artifact path from #1409. Staging itself deployed successfully; only artifact creation failed.

## Release notes

Not applicable; internal CI fix.

## Checklist

- [x] What and why
- [x] How to test
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] Tested locally
