### PR TITLE
Trigger main-to-staging after release-notes merges

### DIFF
--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -1,6 +1,6 @@
 name: Deploy docs site to staging
 
-run-name: Deploy docs site to staging | ${{ github.event.client_payload.correlation_id || github.sha }}
+run-name: Deploy docs site to staging | ${{ github.event.workflow_run.id || github.sha }}
 
 on:
   push:
@@ -10,8 +10,6 @@ on:
     workflows: ["Merge main into staging"]
     types:
       - completed
-  repository_dispatch:
-    types: [release-notes-published]
   workflow_dispatch:
 
 concurrency:
@@ -24,7 +22,6 @@ jobs:
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      github.event_name == 'repository_dispatch' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
@@ -48,7 +45,6 @@ jobs:
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      github.event_name == 'repository_dispatch' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: resolve-sources
@@ -61,9 +57,6 @@ jobs:
       - name: Check out documentation repository
         uses: actions/checkout@v4
         with:
-          # A release-notes publication changes an external source, not this
-          # repository. Build it against the currently promoted staging tree.
-          ref: ${{ github.event_name == 'repository_dispatch' && 'staging' || '' }}
           # The production build predicts the staging-to-prod merge tree and
           # therefore needs the shared branch history, not a depth-one clone.
           fetch-depth: 0

--- a/.github/workflows/deploy-docs-staging.yaml
+++ b/.github/workflows/deploy-docs-staging.yaml
@@ -1,5 +1,7 @@
 name: Deploy docs site to staging
 
+run-name: Deploy docs site to staging | ${{ github.event.client_payload.correlation_id || github.sha }}
+
 on:
   push:
     branches:
@@ -8,6 +10,8 @@ on:
     workflows: ["Merge main into staging"]
     types:
       - completed
+  repository_dispatch:
+    types: [release-notes-published]
   workflow_dispatch:
 
 concurrency:
@@ -20,6 +24,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'repository_dispatch' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
@@ -43,6 +48,7 @@ jobs:
     if: |
       github.event_name == 'push' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
+      github.event_name == 'repository_dispatch' ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     needs: resolve-sources
@@ -55,6 +61,9 @@ jobs:
       - name: Check out documentation repository
         uses: actions/checkout@v4
         with:
+          # A release-notes publication changes an external source, not this
+          # repository. Build it against the currently promoted staging tree.
+          ref: ${{ github.event_name == 'repository_dispatch' && 'staging' || '' }}
           # The production build predicts the staging-to-prod merge tree and
           # therefore needs the shared branch history, not a depth-one clone.
           fetch-depth: 0

--- a/.github/workflows/merge-main-into-staging.yaml
+++ b/.github/workflows/merge-main-into-staging.yaml
@@ -1,9 +1,13 @@
 name: Merge main into staging
 
+run-name: Merge main into staging | ${{ github.event.client_payload.correlation_id || github.sha }}
+
 on:
   push:
     branches:
       - main
+  repository_dispatch:
+    types: [release-notes-published]
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,10 @@ Documentation moves through `main` → `staging` → `prod`:
 
 Release-note content is sourced from `validmind/release-notes`, so merging a
 release-notes pull request does not create or merge a documentation pull request.
-Instead, the release-notes repository dispatches the staging deployment directly;
-that deployment uses the current documentation `staging` tree and the latest
-release-notes `main` revision.
+Instead, the release-notes repository dispatches the existing **Merge main into
+staging** workflow. Its successful completion triggers the staging deployment,
+which builds the promoted documentation tree with the latest release-notes
+`main` revision.
 
 The merge-queue `validate` bridge does not render the site again. It records that the pull-request revision passed preview validation; the complete production safety boundary is the post-merge staging artifact.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,12 @@ Documentation moves through `main` → `staging` → `prod`:
 3. The prospective production build runs the complete production-profile validation and uploads an immutable artifact keyed to the exact Git tree that a `staging` → `prod` merge will create.
 4. The production workflow deploys only that exact-tree artifact from a successful staging workflow run. If the artifact is missing, expired, or came from another workflow, production deployment must fail before loading AWS credentials or modifying production.
 
+Release-note content is sourced from `validmind/release-notes`, so merging a
+release-notes pull request does not create or merge a documentation pull request.
+Instead, the release-notes repository dispatches the staging deployment directly;
+that deployment uses the current documentation `staging` tree and the latest
+release-notes `main` revision.
+
 The merge-queue `validate` bridge does not render the site again. It records that the pull-request revision passed preview validation; the complete production safety boundary is the post-merge staging artifact.
 
 ## CI invariants


### PR DESCRIPTION
## What and why?

Release-note previews no longer use paired documentation PRs with temporary `ref:` overrides. That removed the documentation `main` push that previously started the normal `main → staging → staging deploy` chain after a release-notes merge.

Accept a `release-notes-published` repository dispatch in **Merge main into staging**. Its successful completion triggers the existing staging deployment through `workflow_run`, preserving the normal documentation promotion path without creating a temporary ref PR.

The staging deployment run name includes the triggering merge-workflow run ID so the release-notes sender can wait for the exact downstream deployment.

## How to test

- Merge this PR before the linked release-notes sender PR.
- Merge a release-notes PR that changes `releases/**`.
- Confirm **Merge main into staging** runs with event `repository_dispatch`.
- Confirm its successful completion triggers **Deploy docs site to staging**.
- Confirm staging contains the merged release notes and the production artifact is generated.

## What needs special review?

- The established main-to-staging workflow remains the staging publication gate.
- Existing push, workflow-run, and manual triggers remain available.
- Production continues to require an artifact from a successful staging workflow.

## Dependencies, breaking changes, and deployment notes

Merge this PR before validmind/release-notes#110. No user-facing changes.

## Release notes

n/a (`internal`)
