### PR TITLE
Render release-note planning previews

### DIFF
--- a/.github/workflows/release-notes-preview.yaml
+++ b/.github/workflows/release-notes-preview.yaml
@@ -106,6 +106,7 @@ jobs:
           token: ${{ secrets.DOCS_CI_RO_PAT || secrets.docs_ci_ro_pat }}
           sparse-checkout: |
             releases
+            previews
           sparse-checkout-cone-mode: true
 
       - name: Select changed release directories
@@ -115,14 +116,17 @@ jobs:
           set -euo pipefail
           git -C site/_source/release-notes fetch --depth=1 origin main
           git -C site/_source/release-notes diff --name-only --diff-filter=ACMRT \
-            FETCH_HEAD HEAD -- releases \
-            | awk -F/ 'NF >= 4 { print $1 "/" $2 "/" $3 }' \
+            FETCH_HEAD HEAD -- releases previews \
+            | awk -F/ '
+                $1 == "releases" && NF >= 4 { print $1 "/" $2 "/" $3 }
+                $1 == "previews" && NF >= 3 { print $1 "/" $2 }
+              ' \
             | sort -u > .release-preview-targets
           if [[ ! -s .release-preview-targets ]]; then
-            echo "No changed release directories found"
+            echo "No changed release or preview directories found"
             exit 1
           fi
-          echo "Targeted release directories:"
+          echo "Targeted release and preview directories:"
           cat .release-preview-targets
 
       - name: Verify copyright headers
@@ -139,6 +143,9 @@ jobs:
       - name: Populate release notes
         run: |
           cp -r site/_source/release-notes/releases site
+          if [[ -d site/_source/release-notes/previews ]]; then
+            cp -r site/_source/release-notes/previews site
+          fi
           rm -f site/releases/backend-releases.qmd site/releases/cmvm-releases.qmd
 
       - name: Configure AWS credentials


### PR DESCRIPTION
## What changed

- include `previews/**` when checking out release-notes PR revisions
- select `previews/<version>` as a targeted render directory alongside versioned `releases/**`
- populate preview sources into the documentation tree before rendering

## Why

Release planning previews are intentionally stored outside `releases/**` so they cannot enter normal release publication. The release-notes PR preview workflow needs a receiver that can render this isolated source path into its PR-specific staging prefix.

This PR must merge before validmind/release-notes#123 is marked ready for review.

## Validation

- workflow YAML parses successfully
- preview target selector resolves `previews/26.08` and existing release targets correctly
- existing `test_merge_quarto_indexes.py` suite: 3 passed
- simulated receiver population and `quarto render --profile development previews/26.08`
- rendered `_site/previews/26.08/release-notes.html` with no warnings or errors
