### PR TITLE
[SC-15827] Document configurable attachment upload limits

### DIFF
--- a/site/guide/inventory/_field-types.qmd
+++ b/site/guide/inventory/_field-types.qmd
@@ -57,12 +57,12 @@ For an aggregation field that returns the most recent date a Policy Exception wa
 
 :::: {.content-visible when-format="html" when-meta="includes.inventory"}
 Attachments
-: Upload supporting files for your record.^[[Manage attachments on records](/guide/inventory/edit-inventory-fields.qmd#manage-attachments)] Files must be less than 50 MB each in size.
+: Upload supporting files for your record.^[[Manage attachments on records](/guide/inventory/edit-inventory-fields.qmd#manage-attachments)] The default maximum upload size is 100 MB per file. The limit shown in {{< var vm.product >}} may differ depending on your deployment configuration.
 ::::
 
 :::: {.content-visible when-format="html" when-meta="includes.artifacts"}
 Attachments
-: Upload supporting files for your artifact.^[[Manage attachments on artifacts](/guide/validation/update-artifacts.qmd#manage-attachments)] Files must be less than 50 MB each in size.
+: Upload supporting files for your artifact.^[[Manage attachments on artifacts](/guide/validation/update-artifacts.qmd#manage-attachments)] The default maximum upload size is 100 MB per file. The limit shown in {{< var vm.product >}} may differ depending on your deployment configuration.
 ::::
 
 Calculation
@@ -302,7 +302,7 @@ User
 
 :::: {.content-hidden unless-format="revealjs"}
 Attachments
-: Upload supporting files for your [record](/guide/inventory/edit-inventory-fields.qmd#manage-attachments){target="_blank"} or [artifact](/guide/validation/update-artifacts.qmd#manage-attachments){target="_blank"}. Files must be less than 50 MB each in size.
+: Upload supporting files for your [record](/guide/inventory/edit-inventory-fields.qmd#manage-attachments){target="_blank"} or [artifact](/guide/validation/update-artifacts.qmd#manage-attachments){target="_blank"}. The default maximum upload size is 100 MB per file. The limit shown in {{< var vm.product >}} may differ depending on your deployment configuration.
 
 Calculation
 : Define a `formula(params)` function that reads field values from the `params` dictionary (`params["fieldKey"]`) and returns a read-only value. Formulas are written in Starlark and have access to a set of built-in helpers for dates, numbers, and lists.

--- a/site/guide/inventory/edit-inventory-fields.qmd
+++ b/site/guide/inventory/edit-inventory-fields.qmd
@@ -90,7 +90,9 @@ Learn more: [Work with content blocks](/guide/documentation/work-with-content-bl
 ### Manage attachments on records
 <span id="manage-attachments"></span>
 
-::: {.callout title="Uploaded files must be less than 50 MB each in size."}
+::: {.callout title="The default maximum upload size is 100 MB per file."}
+The limit shown in {{< var vm.product >}} may differ depending on your deployment configuration.
+
 - To work with attachments on records, first add an attachment inventory field.[^10]
 - Select attachments in `.pdf` format as context documents when generating text blocks with AI within your documents.[^11]
 :::
@@ -159,7 +161,6 @@ In addition to editing individual fields on a per record basis, you can edit fie
 [^11]: [Work with content blocks](/guide/documentation/work-with-content-blocks.qmd#generate-content)
 
 [^12]: [Customize inventory layout](/guide/inventory/customize-inventory-layout.qmd#swap-between-views)
-
 
 
 

--- a/site/guide/validation/update-artifacts.qmd
+++ b/site/guide/validation/update-artifacts.qmd
@@ -72,7 +72,7 @@ After an artifact is created, you can upload attachments as supporting documenta
 #### Add attachments to artifacts
 
 ::: {.callout}
-Uploaded files must be less than 50 MB each in size.
+The default maximum upload size is 100 MB per file. The limit shown in {{< var vm.product >}} may differ depending on your deployment configuration.
 :::
 
 1. Click on the header of your attachment field.


### PR DESCRIPTION
# Pull Request Description

## What and why?

Updates attachment guidance for records and artifacts to replace the outdated fixed 50 MB limit with the new 100 MB default. The copy also directs readers to the limit shown in ValidMind because deployments can configure a different maximum.

This addresses [SC-15827](https://app.shortcut.com/validmind/story/15827/zd-603-attachment-custom-fields-should-rely-on-backend-upload-limits-instead-of-frontend-size-caps) and keeps the field-type reference consistent with the upload guides.

## How to test

Rendered the affected pages locally with Quarto using the development profile:

- `guide/inventory/edit-inventory-fields.qmd`
- `guide/validation/update-artifacts.qmd`
- `guide/inventory/manage-inventory-fields.qmd`
- `guide/validation/manage-artifact-fields.qmd`

All four pages rendered successfully. The existing unresolved `validmind/validmind.qmd` link warnings remain unrelated to this change.

## Documentation preview

[Open the documentation preview](https://docs-staging.validmind.ai/pr_previews/codex/sc-15827-attachment-upload-limits/index.html). The preview becomes available after the `validate` check completes successfully.

## What needs special review?

Please confirm that describing 100 MB as the default, while deferring to the limit shown in-product for configured deployments, matches the final behavior in the frontend fix.

## Dependencies, breaking changes, and deployment notes

Depends on [validmind/frontend#2457](https://github.com/validmind/frontend/pull/2457). The documentation should merge and deploy with or after the frontend behavior.

No breaking changes or special documentation deployment steps.

## Release notes

Updated attachment upload guidance to document the new 100 MB default and clarify that the maximum can vary by deployment. [Learn more about managing record attachments.](/guide/inventory/edit-inventory-fields.html#manage-attachments)

## Checklist

- [x] What and why
- [x] Screenshots or videos (Frontend) — Not applicable
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [x] Unit tests added (Backend) — Not applicable
- [x] Tested locally
- [x] Documentation updated (if required)
- [x] Environment variable additions/changes documented (if required) — Not applicable; this PR documents the user-visible configurable limit
