### PR TITLE
[SC-16823] Documentation: Document Checker runs, publishing, and artifacts

### DIFF
--- a/site/guide/documentation/_check-documents.qmd
+++ b/site/guide/documentation/_check-documents.qmd
@@ -37,9 +37,9 @@ a. In the {{< var vm.checker >}} modal, select a **Regulation or Policy** and an
 
    A list of regulation-based questions appears for your review.
 
-a. Scroll to the bottom and click **Check {document type} Document** where `{document type}` is the type of document you are checking.
+a. Scroll to the bottom and click **Check Document**.
 
-The {{< var validmind.checker >}} analyzes your document, identifies gaps, and generates recommendations for specific questions for your review.
+The {{< var validmind.checker >}} analyzes your document, identifies gaps, and generates recommendations for specific questions for your review. When the analysis completes, your results are saved automatically as a private run that only you can see.^[[Manage {{< var vm.checker >}} runs](/guide/documentation/check-documents-for-compliance.qmd#manage-document-checker-runs)]
 
 ### 3. Review the observations
 
@@ -74,7 +74,9 @@ Use the feedback provided by the {{< var validmind.checker >}} to review the app
 
 ### 4. (Optional) Export results
 
-To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**.
+To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**. To export only some questions, select the questions you want and click **Export _n_ selected**, where `n` is the number of questions you selected.
+
+The exported file reflects the saved results of that run, including any artifacts created from it.^[[Create artifacts from a run](/guide/documentation/check-documents-for-compliance.qmd#create-artifacts-from-a-run)]
 
 ::::
 
@@ -107,7 +109,7 @@ a. In the {{< var vm.checker >}} modal, select a **Regulation or Policy** and an
 
 a. Scroll to the bottom and click **Check Document**.
 
-The {{< var validmind.checker >}} analyzes your documentation, identifies gaps, and generates recommendations for specific questions that you review in the next step.
+The {{< var validmind.checker >}} analyzes your documentation, identifies gaps, and generates recommendations for specific questions that you review in the next step. Results are saved automatically as a private run that only you can see.
 
 #### 2. Review observations
 
@@ -159,9 +161,9 @@ a. In the {{< var vm.checker >}} modal, select a **Regulation or Policy** and an
 
    A list of regulation-based questions appears for your review.
 
-a. Scroll to the bottom and click **Check Validation Document**.
+a. Scroll to the bottom and click **Check Document**.
 
-The {{< var validmind.checker >}} analyzes your report, identifies gaps, and generates recommendations for specific questions that you review in the next step.
+The {{< var validmind.checker >}} analyzes your report, identifies gaps, and generates recommendations for specific questions that you review in the next step. Results are saved automatically as a private run that only you can see.
 
 #### 2. Review observations
 

--- a/site/guide/documentation/check-documents-for-compliance.qmd
+++ b/site/guide/documentation/check-documents-for-compliance.qmd
@@ -39,6 +39,75 @@ Use the {{< var validmind.checker >}} to analyze your completed documents by com
 
 {{< include /guide/documentation/_check-documents.qmd >}}
 
+## Manage {{< var vm.checker >}} runs {#manage-document-checker-runs}
+
+Each completed check is saved automatically as a run. Runs are private by default — only you can see your own runs until you publish them to your organization. Published runs are visible to everyone in your organization.
+
+### View previous runs
+
+a. On your document, locate the {{< var vm.checker >}} box on the right and click **See Previous Runs**.
+
+a. Select a tab:
+
+   - **My Runs** — Your private runs for this document.
+   - **Organization** — Runs published to your organization by any user.
+
+a. Click on a run to review its saved results.
+
+Each run displays its name, when it was created or shared, the number of gaps and partial gaps identified, and the number of artifacts created from the run.[^4]
+
+### Rename or delete a run
+
+You can rename or delete your own private runs. Once a run is published to your organization, it can no longer be renamed or deleted.
+
+- To rename a run, open the run, click on the run's name, enter a new name, and click **Save**.
+- To delete a run, click **{{< fa ellipsis-vertical >}}** on the run and select **Delete Run**, then confirm with **Delete**.
+
+::: {.callout-important title="Deleting a run cannot be undone."}
+Deleted runs are permanently removed, including their saved results.
+:::
+
+### Publish a run to your organization
+
+To share a private run with your organization, open the run and click **Publish to Organization**.
+
+After you publish a run:
+
+- The run moves from **My Runs** to the **Organization** tab and becomes visible to everyone in your organization.
+- The run can no longer be renamed or deleted, and cannot be made private again.
+- You can create artifacts from the run's questions.[^5]
+
+::: {.callout}
+You must have sufficient permissions to publish runs to your organization.[^6]
+:::
+
+### Create artifacts from a run
+
+Turn gaps identified by the {{< var vm.checker >}} into artifacts that you can track and resolve in the {{< var validmind.platform >}}:[^7]
+
+a. Open a published run.
+
+   Runs must be published to your organization before artifacts can be created from them.
+
+a. Expand the question you want to create an artifact for, click **Add Artifact**, and select an artifact type.
+
+a. Complete the artifact's details.
+
+   The title and description are pre-filled from the question and its observation and recommendation, and can be edited before saving.
+
+You can create one artifact per question for each run. After an artifact is created, it appears under the question in the run, and alongside your record's other artifacts.[^8]
+
+Artifacts created from runs are traceable back to their source:
+
+- On artifact listings, the **Source** column shows the document and run the artifact was created from. Click on the source to open the run.
+- On the artifact's detail page, the **Source** section links to the document and run, and shows the regulation or policy assessment and the question that generated the artifact.
+
+### Export run results
+
+To export a run's results to a `.pdf` file, open the run and click **{{< fa download >}} Export All**, or select individual questions and click **Export _n_ selected**.
+
+The exported file reflects the saved results of that run, including any artifacts created from it.
+
 ## Learn more
 
 ::: {#check-documents}
@@ -50,5 +119,15 @@ Use the {{< var validmind.checker >}} to analyze your completed documents by com
 [^2]: [Customize {{< var validmind.checker >}}](/guide/templates/customize-document-checker.qmd)
 
 [^3]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
+
+[^4]: For what gaps and partial gaps mean, see [Review the observations](#review-the-observations).
+
+[^5]: [Create artifacts from a run](#create-artifacts-from-a-run)
+
+[^6]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
+
+[^7]: [Working with artifacts](/guide/validation/working-with-artifacts.qmd)
+
+[^8]: [View and filter artifacts](/guide/validation/view-filter-artifacts.qmd)
 
 

--- a/site/training/validator-fundamentals/finalizing-validation-reports.qmd
+++ b/site/training/validator-fundamentals/finalizing-validation-reports.qmd
@@ -550,7 +550,7 @@ Use the {{< var vm.checker >}}
 2. On the left sidebar that appears for your model, click **Validation** under {{< fa file >}} Documents.
 3. Locate {{< fa file-circle-check >}} Check Document on the right and click to expand the menu, then click **{{< fa check >}} Check Document**.
 4. Select a **Regulation** and an associated **Assessment** from the drop-down menus to check your report against.
-5. Scroll to the bottom and click **Check Validation Document**.
+5. Scroll to the bottom and click **Check Document**.
 6. After the {{< var vm.checker >}} has completed its analysis, expand individual questions or click **Expand All** to look through the observations.
 
 When you're done, click [{{< fa chevron-right >}}]() to continue.


### PR DESCRIPTION
# Pull Request Description

## What and why?

Documents the **Modular Document Checker: Runs + Artifacts** feature ([SC-16823](https://app.shortcut.com/validmind/story/16823/documentation-modular-document-checker-viewing-publishing-doc-checker-runs-generating-artifacts-from-runs), epic [SC-15986](https://app.shortcut.com/validmind/epic/15986)).

Before, the docs covered only the one-shot check flow (select regulation → review observations → export). The shipped feature persists every check as a **run**, so this PR:

- Adds a new **Manage Document Checker runs** section to *Check documents for compliance* covering:
  - Viewing previous runs (**My Runs** / **Organization** tabs, private vs. shared visibility)
  - Renaming and deleting private runs (published runs are immutable)
  - Publishing a run to the organization (one-way, permission-gated)
  - Creating artifacts from a published run's questions (pre-filled details, one artifact per question per run, **Source** traceability on artifact listings and detail pages)
  - Run-scoped PDF export (**Export All** / **Export _n_ selected**)
- Updates the shared `_check-documents.qmd` include (guide + developer/validator training decks): the results of a check are now saved automatically as a private run, the check button reads **Check Document**, and export supports selected questions.
- Fixes the stale **Check Validation Document** button label in the validator training interactive slide.

The instructions live in a shared source used by the compliance guide and both training decks.

## How to test

Rendered every affected page with the repository helper:

```bash
skills/validmind-docs-coverage/scripts/render-pages.sh \
  guide/documentation/check-documents-for-compliance.qmd \
  training/developer-fundamentals/finalizing-documentation.qmd \
  training/validator-fundamentals/finalizing-validation-reports.qmd
```

All three pages render successfully; `git diff --check` is clean. The pre-existing unresolved `validmind/validmind.qmd` link warnings are unrelated to this change.

## Documentation preview

Review the documentation changes live after the latest `validate` run completes:

- [Check documents for compliance — Manage Document Checker runs](https://docs-staging.validmind.ai/pr_previews/panchicore/sc-16823-document-checker-runs/guide/documentation/check-documents-for-compliance.html#manage-document-checker-runs)
- [Developer fundamentals — Document Checker slide](https://docs-staging.validmind.ai/pr_previews/panchicore/sc-16823-document-checker-runs/training/developer-fundamentals/finalizing-documentation.html#/section-5)
- [Validator fundamentals — Document Checker slide](https://docs-staging.validmind.ai/pr_previews/panchicore/sc-16823-document-checker-runs/training/validator-fundamentals/finalizing-validation-reports.html#/section-18)

## What needs special review?

- Terminology: the UI publishes a run (**Publish to Organization**) and then labels it as *shared* (**Shared by**, **Shared on**). The new section uses *publish* as the verb and *published/shared* for the state — confirm this reads naturally.
- The permissions callout for publishing is intentionally vague ("sufficient permissions") because the backend gate is an RBAC action not otherwise documented — confirm this is the right level of detail.
- No new screenshots are included; the existing Document Checker screenshots still match the check flow. Happy to add run-management screenshots as a follow-up if the docs team wants them.

## Dependencies, breaking changes, and deployment notes

Documents behavior delivered by:

- [validmind/backend#3327](https://github.com/validmind/backend/pull/3327) — persist runs with private/shared visibility (SC-16987)
- [validmind/backend#3336](https://github.com/validmind/backend/pull/3336) / [#3342](https://github.com/validmind/backend/pull/3342) — link artifacts (findings) to runs (SC-17028)
- [validmind/backend#3343](https://github.com/validmind/backend/pull/3343) — soft-delete assessments + delete-conflict details (SC-17086)
- [validmind/frontend#2715](https://github.com/validmind/frontend/pull/2715) — previous runs, run management, artifacts from runs (SC-16560, SC-16561)
- [validmind/frontend#2735](https://github.com/validmind/frontend/pull/2735) — run rename Save fix (SC-17253)

All implementation PRs are merged. No breaking changes or special deployment steps.

## Release notes

The ValidMind Document Checker now saves every check as a run. Review previous runs for a document, publish a run to share it with your organization, create trackable artifacts directly from a published run's questions, and export any run's saved results to PDF. [Learn more about managing Document Checker runs.](/guide/documentation/check-documents-for-compliance.html#manage-document-checker-runs)

## Checklist

- [x] What and why
- [x] Screenshots or videos (Frontend) — Not applicable
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [x] Unit tests added (Backend) — Not applicable
- [x] Tested locally
- [x] Documentation updated (if required)
- [x] Environment variable additions/changes documented (if required) — Not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
