### PR TITLE
[SC-16959] Documentation: workflow execution taken path and Step Detail panels

### DIFF
--- a/site/guide/workflows/_review-active-workflows.qmd
+++ b/site/guide/workflows/_review-active-workflows.qmd
@@ -24,7 +24,10 @@ To review details for workflows currently active:
     - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
     - **Activity** — History of updates to the workflow on that record, including notes submitted during transitions.[^notes]
     - **Artifacts** — Artifacts for that record created within the duration of that workflow's runtime.
-    - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted on this view.
+    - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
+        - Click on any visited step to open its **Step Detail** panel, showing when that step ran. If a step ran more than once in a loop, use the run pager (**Run 1 of 2**) to page through each pass.
+        - For approval steps, the panel shows the decision — **Approved**, **Rejected**, or **Pending** — with a vote count (e.g. **2 of 3**) and each participant's vote, notes, and vote time. Participants who haven't voted yet appear dimmed below the voters.
+        - For user action steps, the panel shows the values submitted and who submitted them.
 
 #### On artifacts
 
@@ -36,7 +39,10 @@ To review details for workflows currently active:
 
     - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
     - **Activity** — History of updates to the workflow on that artifact, including notes submitted during transitions.[^notes]
-    - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted on this view.
+    - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
+        - Click on any visited step to open its **Step Detail** panel, showing when that step ran. If a step ran more than once in a loop, use the run pager (**Run 1 of 2**) to page through each pass.
+        - For approval steps, the panel shows the decision — **Approved**, **Rejected**, or **Pending** — with a vote count (e.g. **2 of 3**) and each participant's vote, notes, and vote time. Participants who haven't voted yet appear dimmed below the voters.
+        - For user action steps, the panel shows the values submitted and who submitted them.
 
 
 :::
@@ -70,7 +76,10 @@ To review details for workflows currently active on records:
     - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
     - **Activity** — History of updates to the workflow on that record, including notes submitted during transitions.
     - **Artifacts** — Artifacts for that record created within the duration of that workflow's runtime.
-    - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted on this view.
+    - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
+        - Click on any visited step to open its **Step Detail** panel, showing when that step ran. If a step ran more than once in a loop, use the run pager (**Run 1 of 2**) to page through each pass.
+        - For approval steps, the panel shows the decision — **Approved**, **Rejected**, or **Pending** — with a vote count (e.g. **2 of 3**) and each participant's vote, notes, and vote time. Participants who haven't voted yet appear dimmed below the voters.
+        - For user action steps, the panel shows the values submitted and who submitted them.
 
 ::::
 
@@ -93,7 +102,10 @@ To review details for workflows currently active:
     - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
     - **Activity** — History of updates to the workflow on that record, including notes submitted during transitions.
     - **Artifacts** — Artifacts for that record created within the duration of that workflow's runtime.
-    - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted on this view.
+    - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
+        - Click on any visited step to open its **Step Detail** panel, showing when that step ran. If a step ran more than once in a loop, use the run pager (**Run 1 of 2**) to page through each pass.
+        - For approval steps, the panel shows the decision — **Approved**, **Rejected**, or **Pending** — with a vote count (e.g. **2 of 3**) and each participant's vote, notes, and vote time. Participants who haven't voted yet appear dimmed below the voters.
+        - For user action steps, the panel shows the values submitted and who submitted them.
 
 #### On artifacts
 
@@ -105,7 +117,10 @@ To review details for workflows currently active:
 
     - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
     - **Activity** — History of updates to the workflow on that artifact, including notes submitted during transitions.
-    - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted on this view.
+    - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
+        - Click on any visited step to open its **Step Detail** panel, showing when that step ran. If a step ran more than once in a loop, use the run pager (**Run 1 of 2**) to page through each pass.
+        - For approval steps, the panel shows the decision — **Approved**, **Rejected**, or **Pending** — with a vote count (e.g. **2 of 3**) and each participant's vote, notes, and vote time. Participants who haven't voted yet appear dimmed below the voters.
+        - For user action steps, the panel shows the values submitted and who submitted them.
 
 ::::
 

--- a/site/guide/workflows/_view-workflow-executions.qmd
+++ b/site/guide/workflows/_view-workflow-executions.qmd
@@ -35,7 +35,10 @@ Monitor every workflow execution across your organization on a single timeline:^
     - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
     - **Activity** — History of updates to the workflow on that record, including notes submitted during transitions.[^activity-notes]
     - **Artifacts** [record workflows only]{.smallercaps .pink} — Artifacts for that record created within the duration of that workflow's runtime.
-    - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted on this view.
+    - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
+        - Click on any visited step to open its **Step Detail** panel, showing when that step ran. If a step ran more than once in a loop, use the run pager (**Run 1 of 2**) to page through each pass.
+        - For approval steps, the panel shows the decision — **Approved**, **Rejected**, or **Pending** — with a vote count (e.g. **2 of 3**) and each participant's vote, notes, and vote time. Participants who haven't voted yet appear dimmed below the voters.
+        - For user action steps, the panel shows the values submitted and who submitted them.
 
 [^timeline-shortcuts-all]:
 
@@ -140,7 +143,11 @@ History of updates to the workflow on that record, including notes submitted dur
 
 #### Workflow
 
-Overview of the entire workflow. The current workflow step is highlighted on this view.
+Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
+
+- Click on any visited step to open its **Step Detail** panel, showing when that step ran. If a step ran more than once in a loop, use the run pager (**Run 1 of 2**) to page through each pass.
+- For approval steps, the panel shows the decision — **Approved**, **Rejected**, or **Pending** — with a vote count (e.g. **2 of 3**) and each participant's vote, notes, and vote time. Participants who haven't voted yet appear dimmed below the voters.
+- For user action steps, the panel shows the values submitted and who submitted them.
 
 :::
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

Documents the workflow execution viewer improvements shipped in [SC-16959](https://app.shortcut.com/validmind/story/16959) ([frontend#2682](https://github.com/validmind/frontend/pull/2682)) and its predecessor SC-16932 ([frontend#2680](https://github.com/validmind/frontend/pull/2680)).

Before, the **Workflow** tab bullet in both shared includes said only "The current workflow step is highlighted on this view." The shipped viewer does much more, none of it documented:

- The path the execution has taken is drawn in green; branches it did not take are dimmed (line and label).
- Clicking any visited step opens its **Step Detail** panel, with a run pager (**Run 1 of 2**) when a loop ran the step multiple times.
- For approval steps, the panel shows the decision — **Approved**, **Rejected**, or **Pending** — a vote count (e.g. **2 of 3**), and each participant's vote, notes, and vote time, with non-voters dimmed below the voters.
- For user action steps, the panel shows the submitted values and who submitted them.

Edited the two shared sources (guide + RevealJS training variants kept in sync):

- `site/guide/workflows/_view-workflow-executions.qmd`
- `site/guide/workflows/_review-active-workflows.qmd`

Copy is anchored to the shipped code, not the ticket: the panel header is **"Step Detail"** (the PR diagram said "Run details"), and a pending approval *does* open the panel in its live **Pending** state (the story's AC predated that behavior).

Intentionally out of scope: per-field Set Field statuses (Set/Declined/Error), the LaunchDarkly kill-switch for the overlay (default on), and the ring/check/border visual distinction — summarized as the green taken path.

## How to test

Rendered every consumer of both includes one page at a time:

```bash
skills/validmind-docs-coverage/scripts/render-pages.sh \
  guide/workflows/working-with-workflows.qmd \
  guide/workflows/manage-workflows.qmd \
  guide/documentation/submit-documents.qmd \
  training/administrator-fundamentals/organizational-oversight-reporting.qmd \
  training/developer-fundamentals/finalizing-documentation.qmd \
  training/validator-fundamentals/finalizing-validation-reports.qmd
```

All six rendered successfully; grepped each output in `site/_site/` for the new copy (present in every variant). `git diff --check` clean. The `validmind/validmind.qmd` link warnings are pre-existing and unrelated.

## Documentation preview

Review the changes live after the `validate` run completes:

- [View all workflow executions](https://docs-staging.validmind.ai/pr_previews/panchicore/sc-16959-execution-viewer-docs/guide/workflows/working-with-workflows.html#view-all-workflow-executions)
- [Manage workflows — Review active workflows](https://docs-staging.validmind.ai/pr_previews/panchicore/sc-16959-execution-viewer-docs/guide/workflows/manage-workflows.html#review-active-workflows)
- [Submit documents — Verify workflows](https://docs-staging.validmind.ai/pr_previews/panchicore/sc-16959-execution-viewer-docs/guide/documentation/submit-documents.html#verify-workflows)
- [Administrator training — slides 4 and 6](https://docs-staging.validmind.ai/pr_previews/panchicore/sc-16959-execution-viewer-docs/training/administrator-fundamentals/organizational-oversight-reporting.html#/section-4)
- [Developer training — slide 7](https://docs-staging.validmind.ai/pr_previews/panchicore/sc-16959-execution-viewer-docs/training/developer-fundamentals/finalizing-documentation.html#/section-7)
- [Validator training — slide 20](https://docs-staging.validmind.ai/pr_previews/panchicore/sc-16959-execution-viewer-docs/training/validator-fundamentals/finalizing-validation-reports.html#/section-20)

## What needs special review?

Whether the approval-panel detail level is right for the training decks — the same copy is used in all formats to keep the shared includes from diverging.

## Dependencies, breaking changes, and deployment notes

None. Docs-only; the documented behavior is live (frontend#2682 merged and backported to release/26.07).

## Release notes

The workflow execution viewer documentation now covers the taken-path view — the executed path in green with non-taken branches dimmed — and the **Step Detail** panel, including approval decisions with each participant's vote and notes. [Learn more ...](/guide/workflows/working-with-workflows.html#view-all-workflow-executions)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)