### PR TITLE
Refine validmind-docs-coverage skill: var-in-heading anchors + author-prefixed branches

### DIFF
--- a/skills/validmind-docs-coverage/SKILL.md
+++ b/skills/validmind-docs-coverage/SKILL.md
@@ -46,10 +46,11 @@ For a verification-only request, stop after reporting the classification, eviden
 ## 3. Implement an approved update
 
 1. Confirm the worktree and current branch before editing.
-2. Start from current `origin/main` on a `codex/sc-<story-id>-<slug>` branch.
+2. Start from current `origin/main` on an author-prefixed branch, e.g. `<author>/sc-<story-id>-<slug>`.
 3. Update the smallest authoritative source.
 4. Preserve Quarto variables, `.qmd` cross-references, conditional HTML/RevealJS variants, and existing terminology.
-5. If editing an include, find every consumer:
+5. Headings that contain `{{< var >}}` shortcodes get unusable auto-generated ids — add an explicit `{#id}` to any heading used as a link target.
+6. If editing an include, find every consumer:
 
 ```bash
 rg -n "_source-name\\.qmd" site --glob '*.qmd'


### PR DESCRIPTION
# Pull Request Description

## What and why?

Implements the two refinements proposed in #1435, both verified empirically (see [issue comment](https://github.com/validmind/documentation/issues/1435#issuecomment-5073509751)):

1. **§3 new step 5** — warn that headings containing `{{< var >}}` shortcodes render unusable auto-generated ids (reproduced on `main`: `manage-b58fc729-...7b7b3c20...-runs`), and to add an explicit `{#id}` to any heading used as a link target.
2. **§3 step 2** — branch naming generalized from `codex/sc-<story-id>-<slug>` to author-prefixed `<author>/sc-<story-id>-<slug>`, matching existing practice (#1425 `juan/...`, #1434 and #1436 `panchicore/...`) — `pr_previews/<branch>/` works identically.

Closes #1435.

## How to test

Skill-text-only change; no site sources touched. Both behaviors verified against current `main` as documented in the issue comment.

## What needs special review?

Wording only — @cachafla as skill author.

## Dependencies, breaking changes, and deployment notes

None.

## Release notes

Internal tooling change; no release notes.

## Checklist
- [x] What and why
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [ ] PR linked to Shortcut

🤖 Generated with [Claude Code](https://claude.com/claude-code)