### PR TITLE
docs: artifact field change activity with before/after values [sc-16552]

### DIFF
--- a/site/guide/reporting/_view-record-activity-overview.qmd
+++ b/site/guide/reporting/_view-record-activity-overview.qmd
@@ -9,6 +9,7 @@ The record **{{< fa wifi >}} Activity** page shows a history of activities for t
 - Updates to documents: documentation, validation reports, ongoing monitoring reports, or custom documents
 - Test results or metrics added via the {{< var vm.developer >}}
 - Artifacts added, updated, or removed
+- Artifact field changes, including before and after values
 - User comment creation and replies on documents
 - Stakeholders added or removed
 - Workflow activity

--- a/site/guide/reporting/view-record-activity.qmd
+++ b/site/guide/reporting/view-record-activity.qmd
@@ -69,6 +69,7 @@ Filter to narrow down record activity by category or specific values:
    Shows all events in a category:
 
    - **Logged Artifacts**[^6] — Artifacts logged on the record, by type.[^7] Only types of artifacts logged on the record will appear for selection.
+   - **Artifact Fields**[^artifact-fields-category] — Custom field changes on artifacts logged on the record, including before and after values.
    - **Logged Metrics**[^8] — Metrics over time logged on the record.
    - **Record Stakeholders**[^9] — Stakeholders added or removed from the record.
    - **Record Fields**[^10] — Inventory fields updated on the record *(label reflects current UI)*.
@@ -81,6 +82,7 @@ Filter to narrow down record activity by category or specific values:
    Shows events for specific values in a category you select. Select a value key, then choose one or more specific values from the secondary dropdown:
 
    - **Logged Artifacts**[^15] — Artifacts logged on the record, by type.[^16] Only types of artifacts logged on the record will appear for selection.
+   - **Artifact Fields**[^artifact-fields-value] — Custom field changes on artifacts logged on the record, by artifact. Only artifacts logged on the record will appear for selection.
    - **Record Fields**[^17] — Inventory fields updated on the record. Only inventory fields populated on the record will appear for selection.
    - **Record Documents**[^18] — Updates made to documents on the record, including any logged test results from the {{< var validmind.developer >}}.[^19] Only documents with activity will appear for selection.
    - **Record Workflows**[^20] — Workflow activity on the record. Only workflows applied to the record will appear for selection.
@@ -116,6 +118,8 @@ Filters persist in the URL, so you can share or bookmark a filtered view.
 
 [^7]: For example, selecting **Artifacts: Validation Issue** shows all validation issue artifact type events.
 
+[^artifact-fields-category]: [Update artifacts](/guide/validation/update-artifacts.qmd#view-artifact-activity)
+
 [^8]: [Work with metrics over time](/guide/monitoring/work-with-metrics-over-time.qmd)
 
 [^9]: [Manage record stakeholder types](/guide/configuration/manage-record-stakeholder-types.qmd#manage-stakeholder-types-on-records)
@@ -133,6 +137,8 @@ Filters persist in the URL, so you can share or bookmark a filtered view.
 [^15]: [Working with artifacts](/guide/validation/working-with-artifacts.qmd)
 
 [^16]: For example, selecting **Artifacts: Validation Issue** shows a secondary selection for the names of validation issue artifact type events.
+
+[^artifact-fields-value]: [Update artifacts](/guide/validation/update-artifacts.qmd#view-artifact-activity)
 
 [^17]: [Edit inventory fields](/guide/inventory/edit-inventory-fields.qmd)
 

--- a/site/guide/validation/update-artifacts.qmd
+++ b/site/guide/validation/update-artifacts.qmd
@@ -97,6 +97,36 @@ The default maximum upload size is 100 MB per file. The limit shown in {{< var v
 
 4. Enter your comment and click **Submit** to save the comment.
 
+## View artifact activity
+
+Changes to artifact fields are logged so that you can audit who changed which field, when, and what the values were before and after the change:
+
+1. Locate the artifact whose activity you want to view.[^view-activity-locate]
+
+2. On the artifact details page, select the **Activity** tab.
+
+3. Click **View Details** on a field update event to expand the previous and new values for that field.
+
+::: {.callout}
+Artifact fields restricted by permissions[^view-activity-permissions] are hidden from activity for users without access to those fields.
+
+:::
+
+### View individual field activity
+
+To view the change history for a single artifact field:
+
+1. Locate the artifact whose field history you want to view.[^field-activity-locate]
+
+2. On the artifact details page, select the **Overview** or **Artifact Fields** tab.
+
+3. Hover over an artifact field, then click **{{< fa clock >}}** to view the change history for that field, including previous and new values.
+
+::: {.callout title="You can also filter record activity by artifact field changes."}
+Learn more: [Filter record activity](/guide/reporting/view-record-activity.qmd#filter-record-activity)
+
+:::
+
 ## Track artifact resolution
 
 As you prepare validation reports, review logged artifacts and close any artifacts that have been resolved:
@@ -135,6 +165,12 @@ If you logged an artifact in error or otherwise no longer need to track that art
 [^6]: [Manage attachments on artifacts](#manage-attachments)
 
 [^7]: [View and filter artifacts](view-filter-artifacts.qmd)
+
+[^view-activity-locate]: [View and filter artifacts](view-filter-artifacts.qmd)
+
+[^view-activity-permissions]: [Manage roles](/guide/configuration/manage-roles.qmd#manage-role-permissions)
+
+[^field-activity-locate]: [View and filter artifacts](view-filter-artifacts.qmd)
 
 [^8]: [View record activity](/guide/reporting/view-record-activity.qmd)
 


### PR DESCRIPTION
# Pull Request Description

Shortcut: https://app.shortcut.com/validmind/story/16552
Implementation: validmind/backend#3313, validmind/frontend#2675

## What and why?

[sc-16552] shipped artifact Activity parity: artifact custom field edits now emit `updated-field` events with before/after values, shown on the artifact **Activity** tab, in a per-field change history popover ({{< fa clock >}} on hover), and filterable on record Activity via a new **Artifact Fields** event category. Restricted artifact fields are hidden from activity for users without access. None of this was documented.

**Before:** Docs only mentioned coarse "Artifacts added, updated, or removed" on record activity; no artifact-scoped activity coverage at all.
**After:**

- `guide/validation/update-artifacts.qmd` — new **View artifact activity** section: the Activity tab, **View Details** before/after expansion, per-field change history on hover, and the permission-redaction limitation.
- `guide/reporting/view-record-activity.qmd` — **Artifact Fields** added to both the Event Category and Filter by Value tabsets, with footnotes to the new section.
- `guide/reporting/_view-record-activity-overview.qmd` (shared include) — added artifact field changes with before/after values to what record activity tracks.

## Pages to review

Updated content appears on these rendered pages (hosted preview, `validate` ✅):

| Page | What changed |
|---|---|
| [Update artifacts → View artifact activity](https://docs-staging.validmind.ai/pr_previews/andres/sc-16552-artifact-activity-docs/guide/validation/update-artifacts.html#view-artifact-activity) | New section: Activity tab, **View Details** before/after values, per-field change history, permission redaction callout |
| [View record activity → Filter record activity](https://docs-staging.validmind.ai/pr_previews/andres/sc-16552-artifact-activity-docs/guide/reporting/view-record-activity.html#filter-record-activity) | **Artifact Fields** added to both the Event Category and Filter by Value tabsets |
| [View record activity → What is tracked](https://docs-staging.validmind.ai/pr_previews/andres/sc-16552-artifact-activity-docs/guide/reporting/view-record-activity.html#what-is-tracked-on-record-activity) | Overview include now lists artifact field changes with before/after values |
| [Training: Developer Fundamentals — Finalizing documentation](https://docs-staging.validmind.ai/pr_previews/andres/sc-16552-artifact-activity-docs/training/developer-fundamentals/finalizing-documentation.html#/section-11) | Slide consuming the updated shared include |
| [Training: Administrator Fundamentals — Organizational oversight](https://docs-staging.validmind.ai/pr_previews/andres/sc-16552-artifact-activity-docs/training/administrator-fundamentals/organizational-oversight-reporting.html#/section-2) | Slide consuming the updated shared include |
| [Training: Validator Fundamentals — Finalizing validation reports](https://docs-staging.validmind.ai/pr_previews/andres/sc-16552-artifact-activity-docs/training/validator-fundamentals/finalizing-validation-reports.html#/section-24) | Slide consuming the updated shared include |

## How to test

```
skills/validmind-docs-coverage/scripts/render-pages.sh \
  guide/reporting/view-record-activity.qmd \
  guide/validation/update-artifacts.qmd \
  training/developer-fundamentals/finalizing-documentation.qmd \
  training/administrator-fundamentals/organizational-oversight-reporting.qmd \
  training/validator-fundamentals/finalizing-validation-reports.qmd
```

All five pages (the two guides plus the three training consumers of the shared include) render cleanly. The only warning (`Unable to resolve link target: validmind/validmind.qmd` in the validator training deck) is pre-existing and unrelated to these lines.

## What needs special review?

- UI wording is taken from the merged frontend implementation (tab names, **View Details**, clock icon on field hover). Worth a quick sanity check against the live app.
- Placement of the new section in `update-artifacts.qmd` (between commenting and tracking resolution).

## Dependencies, breaking changes, and deployment notes

None. Docs-only.

## Release notes

Artifact field changes are now fully auditable: view before and after values on the artifact **Activity** tab, hover over any artifact field to see its change history, and filter record activity by the new **Artifact Fields** category. [Learn more ...](/guide/validation/update-artifacts.qmd#view-artifact-activity)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

