### PR TITLE
docs: document org-wide record activity views and filters [sc-17354]

### DIFF
--- a/site/faq/_faq-settings-activity.qmd
+++ b/site/faq/_faq-settings-activity.qmd
@@ -5,4 +5,4 @@ SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 ## Are updates to organization settings or configuration tracked?
 
 - Yes, the {{< var validmind.platform >}} provides an audit trail functionality, enabling you to track or audit all the events associated with a specific organization's settings.
-- You can review a full history of updates to organization settings, such as changes to users and groups, permissions and roles, inventory record or artifact settings, document settings, governance settings, workflow and integration setup, and more.^[[View settings activity](/guide/reporting/view-settings-activity.qmd)]
+- You can review a full history of updates to organization settings, such as changes to users and groups, permissions and roles, inventory record or artifact settings, document settings, governance settings, risk tiering, workflow and integration setup, and more.^[[View settings activity](/guide/reporting/view-settings-activity.qmd)]

--- a/site/guide/reporting/_view-record-activity-overview.qmd
+++ b/site/guide/reporting/_view-record-activity-overview.qmd
@@ -2,11 +2,10 @@
 Refer to the LICENSE file in the root of this repository for details.
 SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 
-The record **{{< fa wifi >}} Activity** page shows a history of activities for the selected inventory record, including actions performed by users in your organization, activity from automated workflows, and updates generated via the {{< var validmind.developer >}}, such as:
+Record activity shows a history of activities for inventory records, including actions performed by users in your organization, activity from automated workflows, and updates generated via the {{< var validmind.developer >}}, such as:
 
 - Fields updated
 - Stage transitions
-- Risk tier assessments created, updated, published, archived, versioned, or deleted
 - Updates to documents: documentation, validation reports, ongoing monitoring reports, or custom documents
 - Test results or metrics added via the {{< var vm.developer >}}
 - Artifacts added, updated, or removed
@@ -16,3 +15,4 @@ The record **{{< fa wifi >}} Activity** page shows a history of activities for t
 - Workflow activity
 - Record Intake lifecycle events when an intake inventory record type is configured — submitted for intake, classified or reclassified (including automated routing, manual review, or admin changes), and rejected and archived^[[Record Intake](/guide/inventory/record-intake.qmd#track-intake-activity)]
 
+You can review this history **organization-wide** on **{{< fa wifi >}} Activity** → **Record Activity**, or for a **single inventory record** from that record's **{{< fa wifi >}} Activity** page.

--- a/site/guide/reporting/_view-settings-activity-overview.qmd
+++ b/site/guide/reporting/_view-settings-activity-overview.qmd
@@ -6,12 +6,11 @@ The organization **{{< fa wifi >}} Activity** page shows a history of updates to
 
 - Organization settings, including management of business units, authentication configuration, email notifications, and general settings for documents
 - Management of groups and group membership, users and invitations, permissions and roles
-- Inventory record settings, including management of inventory record types, record stages, record fields, and custom fields
-- Artifact settings, including management of artifact types, severities, fields, and finding statuses
+- Inventory record settings, including management of inventory record types, stages, custom fields, and related stakeholder types
+- Artifact settings, including management of artifact types, severities, fields, and statuses
 - Document settings, including management of document types, templates, and library blocks
-- Governance settings, including management of regulations or policies and related assessments, as well as risk areas and validation guidelines
+- Governance settings, including management of regulations or policies and related assessments, risk areas and validation guidelines, and attestation templates and schedules
 - Risk tiering settings, including management of risk tier templates and risk assessments
-- Workflow settings, including workflow creations, publications, and deletions, as well as workflow states
+- Workflow settings, including workflow creations, updates, publications, and deletions, as well as workflow states
 - Integration settings, including integration setup and secret management
 - Webhook settings, including webhook secret management
-- Global charter settings, including charter creation, updates, moves, and deletions

--- a/site/guide/reporting/_view-settings-activity-overview.qmd
+++ b/site/guide/reporting/_view-settings-activity-overview.qmd
@@ -2,14 +2,16 @@
 Refer to the LICENSE file in the root of this repository for details.
 SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 
-The organization **{{< fa bolt >}} Activity** page shows a history of updates to configuration settings for the selected organization, such as activity related to:
+The organization **{{< fa wifi >}} Activity** page shows a history of updates to configuration settings for the selected organization, such as activity related to:
 
 - Organization settings, including management of business units, authentication configuration, email notifications, and general settings for documents
 - Management of groups and group membership, users and invitations, permissions and roles
-- Inventory record settings, including management of inventory record types and record fields
-- Artifact settings, including management of artifact types, severities, and fields
+- Inventory record settings, including management of inventory record types, record stages, record fields, and custom fields
+- Artifact settings, including management of artifact types, severities, fields, and finding statuses
 - Document settings, including management of document types, templates, and library blocks
-- Governance settings, including management of regulations or polices and related assessments, as well as risk areas and validation guidelines
-- Workflow settings, including workflow creations, publications, and deletions
+- Governance settings, including management of regulations or policies and related assessments, as well as risk areas and validation guidelines
+- Risk tiering settings, including management of risk tier templates and risk assessments
+- Workflow settings, including workflow creations, publications, and deletions, as well as workflow states
 - Integration settings, including integration setup and secret management
 - Webhook settings, including webhook secret management
+- Global charter settings, including charter creation, updates, moves, and deletions

--- a/site/guide/reporting/_view-settings-activity-steps.qmd
+++ b/site/guide/reporting/_view-settings-activity-steps.qmd
@@ -11,28 +11,43 @@ To review settings activity for your organization:
 
    ::: {.panel-tabset}
 
-   ### Filter settings activity by category
+   ### Filter settings activity
 
-   To narrow down settings activity by category:
+   To narrow down settings activity, click **{{< fa filter >}} Filter** to open the filter popover. Add rules against event dimensions for settings and configuration changes:
 
-   1. Click **{{< fa filter >}} Filter** to open the filter popover.
+   - **Category** — Settings event category (for example users, workflows, or inventory record configuration).
+   - **Action** — Specific audit action recorded for the event.
+   - **Actor** — User who made the change.
+   - **Target Type** — Type of configuration object that changed.
 
-   2. Select the **Event Type**s you want to filter by from the drop-down menu:
+   1. Click **{{< fa plus >}} Add Rule** (or add a group) to build your filter conditions.
 
-      - **Artifacts** to view activity related to creation of, updates to, and deletions of artifact types,^[[Manage artifact types](/guide/validation/manage-artifact-types.qmd)] severities,^[[Manage artifact severities](/guide/validation/manage-artifact-severities.qmd)] and fields.^[[Manage artifact fields](/guide/validation/manage-artifact-fields.qmd)]
-      - **Business Units** to view activity related to business unit creation, updates, and deletions.^[[Set up your organization](/guide/configuration/set-up-your-organization.qmd#manage-business-units)]
-      - **Documents** to view activity related to creation of, updates to, and deletions of document types,^[[Manage document types](/guide/templates/manage-document-types.qmd)] templates,^[[Manage document templates](/guide/templates/manage-document-templates.qmd)] and library blocks.^[[Manage text block library](/guide/templates/manage-text-block-library.qmd)]
-      - **Governance** to view activity related to creation of, updates to, and deletions of regulations or policies,^[[Customize {{< var validmind.checker >}}](/guide/templates/customize-document-checker.qmd)] as well as risk areas and validation guidelines.^[[Manage validation guidelines](/guide/validation/manage-validation-guidelines.qmd)]
-      - **Groups** to view activity related to group creation, updates, deletions, and group membership changes.^[[Manage groups](/guide/configuration/manage-groups.qmd)]
-      - **Integration Connections** to view activity related to integration connection creation, update, and removal.^[[Managing integrations](/guide/integrations/managing-integrations.qmd)]
-      - **Integration Secrets** to view activity related to integration secret creation, revocation, and deletion.
-      - **Inventory Records** to view activity related to inventory record type^[[Manage inventory record types](/guide/inventory/manage-inventory-record-types.qmd)] or record field^[[Manage inventory fields](/guide/inventory/manage-inventory-fields.qmd)] creation, updates, and deletions.
-      - **Organization Settings** to view activity related to authentication configuration, email notifications,^[[Manage platform notifications](/guide/configuration/manage-platform-notifications.qmd#customize-email-notifications)] and general settings for documents.^[[Managing documents](/guide/templates/managing-documents.qmd#manage-document-defaults)]
-      - **Permissions** to view activity related to permission changes on roles.^[[Manage permissions](/guide/configuration/manage-permissions.qmd)]
-      - **Roles** to view activity related to role creation, updates, deletions, and user role assignments.^[[Manage roles](/guide/configuration/manage-roles.qmd)]
-      - **Users** to view activity related to user information updates and user invitations.^[[Manage users](/guide/configuration/manage-users.qmd)]
-      - **Webhook Secrets** to view activity related to webhook secret creation, revocation, and deletion.^[[Manage secrets](/guide/integrations/manage-secrets.qmd#webhook-secrets)]
-      - **Workflows** to view activity related to workflow creation, publications, and deletions.^[[Setting up workflows](/guide/workflows/setting-up-workflows.qmd)]
+   2. Click **Apply Filters**.
+
+   Active filters appear as chips. Click {{< fa xmark >}} on a chip to remove that filter, or clear all filters from the popover.
+
+   Common **Category** values include:
+
+   - **Artifacts** — Creation of, updates to, and deletions of artifact types,^[[Manage artifact types](/guide/validation/manage-artifact-types.qmd)] severities,^[[Manage artifact severities](/guide/validation/manage-artifact-severities.qmd)] fields,^[[Manage artifact fields](/guide/validation/manage-artifact-fields.qmd)] and finding statuses.
+   - **Business Units** — Business unit creation, updates, and deletions.^[[Set up your organization](/guide/configuration/set-up-your-organization.qmd#manage-business-units)]
+   - **Documents** — Creation of, updates to, and deletions of document types,^[[Manage document types](/guide/templates/manage-document-types.qmd)] templates,^[[Manage document templates](/guide/templates/manage-document-templates.qmd)] and library blocks.^[[Manage text block library](/guide/templates/manage-text-block-library.qmd)]
+   - **Global Charters** — Global charter creation, updates, moves, and deletions.
+   - **Governance** — Creation of, updates to, and deletions of regulations or policies,^[[Customize {{< var validmind.checker >}}](/guide/templates/customize-document-checker.qmd)] as well as risk areas and validation guidelines.^[[Manage validation guidelines](/guide/validation/manage-validation-guidelines.qmd)]
+   - **Groups** — Group creation, updates, deletions, and group membership changes.^[[Manage groups](/guide/configuration/manage-groups.qmd)]
+   - **Integration Connections** — Integration connection creation, update, and removal.^[[Managing integrations](/guide/integrations/managing-integrations.qmd)]
+   - **Integration Secrets** — Integration secret creation, revocation, and deletion.
+   - **Inventory Record Types** — Inventory record type creation, updates, and deletions.^[[Manage inventory record types](/guide/inventory/manage-inventory-record-types.qmd)]
+   - **Inventory Records** — Record stage^[[Manage record stages](/guide/workflows/manage-record-stages.qmd)] and record field^[[Manage inventory fields](/guide/inventory/manage-inventory-fields.qmd)] creation, updates, and deletions.
+   - **Organization Settings** — Authentication configuration, email notifications,^[[Manage platform notifications](/guide/configuration/manage-platform-notifications.qmd#customize-email-notifications)] and general settings for documents.^[[Managing documents](/guide/templates/managing-documents.qmd#manage-document-defaults)]
+   - **Permissions** — Permission changes on roles.^[[Manage permissions](/guide/configuration/manage-permissions.qmd)]
+   - **Record Fields** — Custom field creation, updates, renames, and deletions.
+   - **Risk Assessments** — Risk tier assessment creation, updates, status changes, new versions, and deletions.^[[Manage risk tier assessments](/guide/risk-tiering/manage-risk-tier-assessments.qmd)]
+   - **Risk Tier Templates** — Risk tier template creation, updates, deletions, duplication, and stage changes.^[[Manage risk tier templates](/guide/risk-tiering/manage-risk-tier-templates.qmd)]
+   - **Roles** — Role creation, updates, deletions, and user role assignments.^[[Manage roles](/guide/configuration/manage-roles.qmd)]
+   - **Users** — User information updates and user invitations.^[[Manage users](/guide/configuration/manage-users.qmd)]
+   - **Webhook Secrets** — Webhook secret creation, revocation, and deletion.^[[Manage secrets](/guide/integrations/manage-secrets.qmd#webhook-secrets)]
+   - **Workflow States** — Workflow state creation, updates, and deletions.^[[Workflow states](/guide/workflows/workflow-states.qmd)]
+   - **Workflows** — Workflow creation, publications, and deletions.^[[Setting up workflows](/guide/workflows/setting-up-workflows.qmd)]
 
    ### View more details about specific activity
 
@@ -49,7 +64,7 @@ To review settings activity for your organization:
 1. In the left sidebar, click **{{< fa wifi >}} Activity**.
 2. Select the **Settings Activity** tab:
 
-- Click **{{< fa filter >}} Filter** to open the filter popover and select the **Event Type**s you want to filter by from the drop-down menu.
+- Click **{{< fa filter >}} Filter** to open the filter popover, then add rules for **Category**, **Action**, **Actor**, or **Target Type**.
  - Click **{{< fa chevron-down >}} View Details** to reveal more details about the activity when the option is available on an entry.
 
 ::::

--- a/site/guide/reporting/_view-settings-activity-steps.qmd
+++ b/site/guide/reporting/_view-settings-activity-steps.qmd
@@ -31,8 +31,7 @@ To review settings activity for your organization:
    - **Artifacts** — Creation of, updates to, and deletions of artifact types,^[[Manage artifact types](/guide/validation/manage-artifact-types.qmd)] severities,^[[Manage artifact severities](/guide/validation/manage-artifact-severities.qmd)] fields,^[[Manage artifact fields](/guide/validation/manage-artifact-fields.qmd)] and finding statuses.
    - **Business Units** — Business unit creation, updates, and deletions.^[[Set up your organization](/guide/configuration/set-up-your-organization.qmd#manage-business-units)]
    - **Documents** — Creation of, updates to, and deletions of document types,^[[Manage document types](/guide/templates/manage-document-types.qmd)] templates,^[[Manage document templates](/guide/templates/manage-document-templates.qmd)] and library blocks.^[[Manage text block library](/guide/templates/manage-text-block-library.qmd)]
-   - **Global Charters** — Global charter creation, updates, moves, and deletions.
-   - **Governance** — Creation of, updates to, and deletions of regulations or policies,^[[Customize {{< var validmind.checker >}}](/guide/templates/customize-document-checker.qmd)] as well as risk areas and validation guidelines.^[[Manage validation guidelines](/guide/validation/manage-validation-guidelines.qmd)]
+   - **Governance** — Creation of, updates to, and deletions of regulations or policies,^[[Customize {{< var validmind.checker >}}](/guide/templates/customize-document-checker.qmd)] risk areas and validation guidelines,^[[Manage validation guidelines](/guide/validation/manage-validation-guidelines.qmd)] and attestation templates and schedules^[[Manage attestations](/guide/attestation/manage-attestations.qmd)]
    - **Groups** — Group creation, updates, deletions, and group membership changes.^[[Manage groups](/guide/configuration/manage-groups.qmd)]
    - **Integration Connections** — Integration connection creation, update, and removal.^[[Managing integrations](/guide/integrations/managing-integrations.qmd)]
    - **Integration Secrets** — Integration secret creation, revocation, and deletion.
@@ -47,7 +46,7 @@ To review settings activity for your organization:
    - **Users** — User information updates and user invitations.^[[Manage users](/guide/configuration/manage-users.qmd)]
    - **Webhook Secrets** — Webhook secret creation, revocation, and deletion.^[[Manage secrets](/guide/integrations/manage-secrets.qmd#webhook-secrets)]
    - **Workflow States** — Workflow state creation, updates, and deletions.^[[Workflow states](/guide/workflows/workflow-states.qmd)]
-   - **Workflows** — Workflow creation, publications, and deletions.^[[Setting up workflows](/guide/workflows/setting-up-workflows.qmd)]
+   - **Workflows** — Workflow creation, updates, publications, and deletions.^[[Setting up workflows](/guide/workflows/setting-up-workflows.qmd)]
 
    ### View more details about specific activity
 

--- a/site/guide/reporting/tracking-organization-activity.qmd
+++ b/site/guide/reporting/tracking-organization-activity.qmd
@@ -18,6 +18,8 @@ listing:
 
 Review activity logs for your organization relating to records and settings configurations.
 
+Use **{{< fa wifi >}} Activity** in the left sidebar for organization-wide **Record Activity** and **Settings Activity**, or open a record's **Activity** page for a single inventory record.
+
 ::::{#activity .intro-listing}
 ::::
 

--- a/site/guide/reporting/view-record-activity.qmd
+++ b/site/guide/reporting/view-record-activity.qmd
@@ -11,7 +11,7 @@ aliases:
   - /guide/inventory/view-record-activity.html
 ---
 
-Track information events associated with a specific record. Audit a history of updates made to the record, including stage or workflow transitions, updates on associated documents, activity on logged artifacts, and more.
+Track information events for inventory records across your organization or for a single record. Audit updates such as stage or workflow transitions, document changes, logged artifact activity, and more.
 
 ## What is tracked on record activity?
 
@@ -26,13 +26,29 @@ Track information events associated with a specific record. Audit a history of u
 
 :::
 
-## View record activity
+## View record activity {#view-record-activity}
+
+:::: {.panel-tabset}
+
+### Organization-wide Record Activity
+
+Use the organization **{{< fa wifi >}} Activity** page to review record and artifact updates across all inventory records you can access:
+
+1. In the left sidebar, click **{{< fa wifi >}} Activity**.
+
+2. Select the **Record Activity** tab.
+
+The feed shows recent record and artifact events organization-wide. For configuration and settings changes, use the **Settings Activity** tab.[^settings-activity]
+
+### Activity for a specific record
 
 {{< include _view-record-activity-steps.qmd >}}
 
+::::
+
 ### View individual field activity
 
-To view activity for individual inventory fields:[^2]
+To view activity for individual inventory fields on a specific record:[^2]
 
 1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
 
@@ -44,9 +60,56 @@ To view activity for individual inventory fields:[^2]
 
 5. Hover over **{{< fa circle-info >}}** to view individual activity for that field.
 
-## Filter record activity
+## Filter record activity {#filter-record-activity}
 
-Filter to narrow down record activity by category or specific values:
+Narrow activity by event dimensions, record or artifact attributes, or both. Available filters differ between the organization-wide feed and a single record's Activity page.
+
+:::: {.panel-tabset}
+
+### Organization-wide filters
+
+On **{{< fa wifi >}} Activity** → **Record Activity**, click **{{< fa filter >}} Filter** to open the filter popover. The popover has two tabs; rules from both tabs combine with AND when you apply them:
+
+::: {.panel-tabset}
+
+### Activity Filter
+
+Filter by dimensions of the activity event itself:
+
+- **Event Category** — Category of the activity event.
+- **Actor** — User who performed the activity.
+- **Artifact Type** — Type of artifact involved in the event.
+- **Changed Field** — Inventory or artifact field that changed.
+- **Document** — Document associated with the event.
+- **Workflow** — Workflow associated with the event.
+
+### Record/Artifact Filter
+
+Filter by the **current** values of related inventory records and artifacts. Grouped fields include:
+
+- **Record** — For example Business Unit, Group, Model ID, Model Stage, Name, Inventory Record Type, Purpose, Tier, Use, and vendor fields.
+- **Finding** — For example Severity, Status, Owner, Created on, and Due date.
+- **Workflow** — For example Workflow name, Status, and Started on.
+- **Document** — For example Owner and Last updated.
+- **User** — For example Name and Email for the acting user.
+
+:::
+
+::: {.callout-note}
+## Record filters include downstream artifact activity
+
+Filtering by a record attribute (for example **Business Unit**) returns activity on matching records **and** on artifacts logged to those records, such as validation issues.
+:::
+
+1. Click **{{< fa plus >}} Add Rule** (or add a group) to build your filter conditions in either tab.
+
+2. Click **Apply Filters**.
+
+Active filters appear as chips. Click {{< fa xmark >}} on a chip to remove that filter, or clear all filters from the popover. Organization-wide filters persist in the URL (`qbfilters`), so you can share or bookmark a filtered view.
+
+### Filters for a specific record
+
+On a record's **{{< fa wifi >}} Activity** page, filter by category or specific values:
 
 1. In the left sidebar, click **{{< fa cubes >}} Inventory**.
 
@@ -92,7 +155,7 @@ Filter to narrow down record activity by category or specific values:
 
    (Optional) Add more rules by repeating steps 5 and 6. Multiple rules combine with AND logic.[^22]
 
-6. Click **Apply Filters** to apply your filter rules.
+8. Click **Apply Filters** to apply your filter rules.
 
 #### Remove active filters
 
@@ -101,6 +164,8 @@ After applying filters, active conditions appear as chips below the header. Clic
 #### Share filtered views
 
 Filters persist in the URL, so you can share or bookmark a filtered view.
+
+::::
 
 <!-- FOOTNOTES -->
 
@@ -151,3 +216,5 @@ Filters persist in the URL, so you can share or bookmark a filtered view.
 [^21]: [Manage users](/guide/configuration/manage-users.qmd)
 
 [^22]: For example, filter by an event category AND a specific user to see only that user's activity in that category.
+
+[^settings-activity]: [View settings activity](/guide/reporting/view-settings-activity.qmd)

--- a/site/llm/chatbot-product-map.md
+++ b/site/llm/chatbot-product-map.md
@@ -530,7 +530,14 @@
 
 #### `/activity` — Activity
 
-- *No direct help link; content may be covered under scattered guide sections.*
+**Docs (related):**
+
+- `/guide/reporting/view-record-activity.html`
+  - Sections: What is tracked on record activity?; Prerequisites; View record activity; Organization-wide Record Activity; Activity for a specific record; Filter record activity; Organization-wide filters; Filters for a specific record
+- `/guide/reporting/view-settings-activity.html`
+  - Sections: What is tracked on settings activity?; Prerequisites; View settings activity
+- `/guide/reporting/tracking-organization-activity.html`
+  - Sections: What's next
 
 #### `/analytics` — sidebar.analytics
 

--- a/site/llm/chatbot-product-map.md
+++ b/site/llm/chatbot-product-map.md
@@ -530,7 +530,16 @@
 
 #### `/activity` — Activity
 
-- *No direct help link; content may be covered under scattered guide sections.*
+**Docs (related):**
+
+- `/guide/reporting/tracking-organization-activity.html`
+  - Sections: What's next
+- `/guide/reporting/view-record-activity.html`
+  - Sections: What is tracked on record activity?; Prerequisites; View record activity; Organization-wide Record Activity; Activity for a specific record; View individual field activity; Filter record activity; Organization-wide filters
+- `/guide/reporting/view-settings-activity.html`
+  - Sections: What is tracked on settings activity?; Prerequisites; View settings activity
+
+- *No direct help link in frontend; related docs inferred from keywords.*
 
 #### `/analytics` — sidebar.analytics
 

--- a/site/llm/chatbot-product-map.md
+++ b/site/llm/chatbot-product-map.md
@@ -530,14 +530,7 @@
 
 #### `/activity` — Activity
 
-**Docs (related):**
-
-- `/guide/reporting/view-record-activity.html`
-  - Sections: What is tracked on record activity?; Prerequisites; View record activity; Organization-wide Record Activity; Activity for a specific record; Filter record activity; Organization-wide filters; Filters for a specific record
-- `/guide/reporting/view-settings-activity.html`
-  - Sections: What is tracked on settings activity?; Prerequisites; View settings activity
-- `/guide/reporting/tracking-organization-activity.html`
-  - Sections: What's next
+- *No direct help link; content may be covered under scattered guide sections.*
 
 #### `/analytics` — sidebar.analytics
 

--- a/site/scripts/generate_chatbot_product_map.py
+++ b/site/scripts/generate_chatbot_product_map.py
@@ -110,6 +110,11 @@ RELATED_DOC_KEYWORDS: dict[str, list[str]] = {
     "profile": ["configuration/manage-your-profile", "configuration/personalizing-validmind"],
     "analytics": ["reporting", "monitoring"],
     "dashboard": ["configuration/customize-your-dashboard"],
+    "activity": [
+        "reporting/view-record-activity",
+        "reporting/view-settings-activity",
+        "reporting/tracking-organization-activity",
+    ],
 }
 
 

--- a/site/training/administrator-fundamentals/organizational-oversight-reporting.qmd
+++ b/site/training/administrator-fundamentals/organizational-oversight-reporting.qmd
@@ -133,7 +133,7 @@ View settings activity
 
 1. In the left sidebar, click **{{< fa wifi >}} Activity**.
 2. Select the **Settings Activity** tab:
-  -  Click **{{< fa filter >}} Filter** to open the filter popover and select the **Event Type**s you want to filter by from the drop-down menu.
+  -  Click **{{< fa filter >}} Filter** to open the filter popover, then add rules for **Category**, **Action**, **Actor**, or **Target Type**.
   -  Click **{{< fa chevron-down >}} View Details** to reveal more details about the activity when the option is available on an entry.
 
 When you're done, click [{{< fa chevron-right >}}]() to continue.


### PR DESCRIPTION
## What and why?

Documents organization-wide **Record Activity** vs per-record Activity for [SC-17354](https://app.shortcut.com/validmind/story/17354) / [SC-16807](https://app.shortcut.com/validmind/story/16807) ([epic 15038](https://app.shortcut.com/validmind/epic/15038)), and updates **Settings Activity** for the same filter rollout.

Implementation: [frontend#2734](https://github.com/validmind/frontend/pull/2734), [backend#3380](https://github.com/validmind/backend/pull/3380).

**Before:** [View record activity](https://docs.validmind.com/guide/reporting/view-record-activity.html) only described opening Activity from a single inventory record and its Event Category / Filter by Value popover. [View settings activity](https://docs.validmind.com/guide/reporting/view-settings-activity.html) still described an Event Type-only filter and omitted several shipped audit scopes.

**After:**
- Intro and overview clarify organization-wide **Activity → Record Activity** vs a record's **Activity** page
- **View record activity** uses tabs for both entry points
- **Filter record activity** documents org-wide **Activity Filter** + **Record/Artifact Filter** (including downstream artifact behavior) separately from per-record filters
- **View settings activity** documents the query-builder filters (**Category**, **Action**, **Actor**, **Target Type**) and expands what is tracked (risk tiering, record stages/custom fields, finding statuses, workflow states, global charters)
- Tracking landing blurb and chatbot product map (`/activity`) updated via keyword mapping so regenerate keeps the links

## How to test

1. Mark this PR ready for review (draft PRs skip the preview `validate` job).
2. Wait for the `validate` check to pass and deploy the hosted preview.
3. Review the updated pages on the PR preview (compare with production as needed):
   - [View record activity](https://docs-staging.validmind.ai/pr_previews/emma/sc-17354/docs-for-sc-16807/guide/reporting/view-record-activity.html)
   - [View settings activity](https://docs-staging.validmind.ai/pr_previews/emma/sc-17354/docs-for-sc-16807/guide/reporting/view-settings-activity.html)
   - [Tracking organization activity](https://docs-staging.validmind.ai/pr_previews/emma/sc-17354/docs-for-sc-16807/guide/reporting/tracking-organization-activity.html)
   - [Organizational Oversight & Reporting (training)](https://docs-staging.validmind.ai/pr_previews/emma/sc-17354/docs-for-sc-16807/training/administrator-fundamentals/organizational-oversight-reporting.html)
4. Confirm Record Activity distinguishes:
   - Org-wide: left sidebar **Activity** → **Record Activity**
   - Per-record: **Inventory** → record → **Activity**
5. Confirm org-wide record filters document **Activity Filter** and **Record/Artifact Filter**, and that record-attribute filters include downstream artifact activity.
6. Confirm Settings Activity documents query-builder fields (**Category**, **Action**, **Actor**, **Target Type**) instead of Event Type-only, and that **What is tracked** includes risk tiering and the other expanded scopes.
7. Confirm per-record filters still document Event Category / Filter by Value.

Production for side-by-side comparison:
- https://docs.validmind.com/guide/reporting/view-record-activity.html
- https://docs.validmind.com/guide/reporting/view-settings-activity.html

Optional local render:
```bash
skills/validmind-docs-coverage/scripts/render-pages.sh \
  guide/reporting/view-record-activity.qmd \
  guide/reporting/view-settings-activity.qmd \
  guide/reporting/tracking-organization-activity.qmd \
  training/administrator-fundamentals/organizational-oversight-reporting.qmd
```

## What needs special review?

- Org-wide record filter field lists follow the shipped `field_schema` (hidden FE fields such as Linked Model / Template / Current step are omitted).
- Settings **Category** labels follow FE display names (`formatScopeDisplay`) where they differ from raw scopes (for example Inventory Records, Risk Assessments, Record Fields).
- Shared overview/steps includes are used by training slides — wording kept compatible with RevealJS consumers.

## Dependencies, breaking changes, and deployment notes

- Depends on merged FE/BE work for SC-16807 (org-wide activity filters; LD flag `launchdarkly.rollout.org-wide-activity-filters`, offline default on)
- No breaking docs changes

## Release notes

You can review and filter record and artifact activity organization-wide from **Activity**, including filters on event dimensions and current record or artifact fields. Settings Activity uses the same query-builder style filters for configuration audit events. [Learn more ...](/guide/reporting/view-record-activity.html)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied (`documentation`)
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
