### PR TITLE
docs: document create template and PDF outline upload [sc-17034]

### DIFF
--- a/site/faq/faq-documentation.qmd
+++ b/site/faq/faq-documentation.qmd
@@ -45,7 +45,8 @@ By default, the [{{< fa hand >}} Customer Admin]{.bubble} role[^6] has sufficien
 Yes, you can reuse content from existing documents or templates:
 
 - Build a library of reusable text blocks to insert into your documents, including content from existing documents.[^13]
-- Duplicate document templates to create new templates with the same content, then edit those duplicates to fit your needs.[^14]
+- Create blank document templates for a document type, or generate a structure-only outline from a PDF with selectable text.[^14]
+- Duplicate document templates to create new templates with the same content, then edit those duplicates to fit your needs.[^16]
 
 ## Can documents be created right in the {{< var validmind.platform >}}?
 
@@ -130,6 +131,8 @@ Yes, {{< var vm.product >}} allows you to leverage content from historical or ex
 
 [^13]: [Manage text block library](/guide/templates/manage-text-block-library.qmd)
 
-[^14]: [Manage document templates](/guide/templates/manage-document-templates.qmd)
+[^14]: [Manage document templates — Create document templates](/guide/templates/manage-document-templates.qmd#create-document-templates)
 
 [^15]: [Manage documents](/guide/templates/manage-documents.qmd#add-record-documents)
+
+[^16]: [Manage document templates — Duplicate document templates](/guide/templates/manage-document-templates.qmd#duplicate-document-templates)

--- a/site/guide/templates/_create-document-templates.qmd
+++ b/site/guide/templates/_create-document-templates.qmd
@@ -1,0 +1,67 @@
+<!-- Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+Refer to the LICENSE file in the root of this repository for details.
+SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
+
+:::: {.content-visible unless-format="revealjs"}
+Create a new blank template for a document type, then build the outline manually or generate it from a PDF:
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+2. Under {{< fa file >}} Documents, select **Templates**.
+
+3. Select the tab for the document type you want the template to belong to:
+
+   - **Development**^[[Working with documentation](/guide/documentation/working-with-documentation.qmd)]
+   - **Validation**^[[Preparing validation reports](/guide/validation/preparing-validation-reports.qmd)]
+   - **Monitoring**^[[Ongoing monitoring](/guide/monitoring/ongoing-monitoring.qmd)]
+   - **Custom**^[[Managing documents](/guide/templates/managing-documents.qmd)]
+
+4. Click **{{< fa plus >}} Create [Document Type] Template** (for example **Create Development Template**).
+
+5. In the **Create Template** modal, enter a unique **Template Name** and a **Description**, then click **Create Template**.
+
+   The new template opens with an empty outline. To use it on inventory documents, associate it with a document type.^[[Manage document types](/guide/templates/manage-document-types.qmd)]
+
+6. Choose how to start the outline:
+
+::: {.panel-tabset}
+
+### Build Outline Manually
+
+a. Select **Build Outline Manually**.
+
+b. Use the outline editor to add sections and content blocks.^[[Customize document templates](/guide/templates/customize-document-templates.qmd#edit-template-outlines)]
+
+### Start Outline From PDF
+
+a. Select **Start Outline From PDF**.
+
+b. Upload a **.pdf** file (drag and drop or choose a file), then click **Upload PDF**.
+
+   ::: {.callout-note}
+   ## PDF requirements and limits
+
+   - PDFs must contain selectable text and headings. Scanned or image-only PDFs cannot generate an outline.
+   - Maximum size: **20 MB**. Maximum length: **100 pages**.
+   - Parsing creates a **structure-only** outline (sections and subsections with empty text placeholders). Charts and other graphics are not converted into test or metric blocks.
+   :::
+
+c. Track progress in **My Inbox**. When processing finishes, the outline is saved to the template (as a new version when applied).
+
+You can also choose **Generate from PDF** later from the template outline actions when you want to regenerate structure from a PDF.
+
+:::
+
+::::
+
+
+:::: {.content-hidden unless-format="revealjs"}
+Create a new blank template for a document type, then build the outline manually or generate it from a PDF:
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+2. Under {{< fa file >}} Documents, select **Templates**.
+3. Select the tab for the [document type](/guide/templates/managing-documents.qmd){target="_blank"} you want the template to belong to.
+4. Click **{{< fa plus >}} Create [Document Type] Template**, enter a unique **Template Name** and **Description**, then click **Create Template**.
+5. On the blank outline, choose **Build Outline Manually** or **Start Outline From PDF** (selectable-text PDFs only; structure-only outline; track progress in **My Inbox**).
+
+::::

--- a/site/guide/templates/_duplicate-template.qmd
+++ b/site/guide/templates/_duplicate-template.qmd
@@ -5,22 +5,38 @@ SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 :::: {.content-visible unless-format="revealjs"}
 To duplicate an existing template and start with version one of that new template:
 
-1. In the left sidebar, click **{{< fa gear >}} Settings**. 
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-1.  Under {{< fa file >}} Documents, select **Templates**.
+2. Under {{< fa file >}} Documents, select **Templates**.
 
-1. Select one of the tabs for the type of template you want to duplicate:
+3. Select one of the tabs for the type of template you want to duplicate:
 
    - **Development**^[[Working with documentation](/guide/documentation/working-with-documentation.qmd)]
    - **Validation**^[[Preparing validation reports](/guide/validation/preparing-validation-reports.qmd)]
    - **Monitoring**^[[Ongoing monitoring](/guide/monitoring/ongoing-monitoring.qmd)]
    - **Custom**^[[Managing documents](/guide/templates/managing-documents.qmd)]
 
-1. Click on the template to duplicate and on the template details page, select **{{< fa copy >}} Duplicate Template**. 
+4. Duplicate the template from the list or from template details:
 
-1. In the Duplicate Template modal that opens, give your copy a **Template Name** and a **Template Description**.
+::: {.panel-tabset}
 
-1. Click **Duplicate Template** to create a copy of your template.
+### From the templates list
+
+a. Hover over the template until the **{{< fa ellipsis-vertical >}}** menu appears under **Actions**, then click on it.
+
+b. Select **{{< fa copy >}} Duplicate**.
+
+### From template details
+
+a. Click the template to open it.
+
+b. Select **{{< fa copy >}} Duplicate Template**.
+
+:::
+
+5. In the Duplicate Template modal that opens, give your copy a **Template Name** and a **Template Description**.
+
+6. Click **Duplicate Template** to create a copy of your template.
 
 Once duplicated, customize your new template to your needs, making it available for use with your documents.
 
@@ -30,17 +46,17 @@ Once duplicated, customize your new template to your needs, making it available 
 :::: {.content-hidden unless-format="revealjs"}
 To duplicate an existing template and start with version one of that new template:
 
-1. In the left sidebar, click **{{< fa gear >}} Settings**. 
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
 
-1.  Under {{< fa file >}} Documents, select **Templates**.
+2. Under {{< fa file >}} Documents, select **Templates**.
 
-1. Select one of the tabs for the [type of template you want to duplicate](/guide/templates/managing-documents.qmd){target="_blank"}.
+3. Select one of the tabs for the [type of template you want to duplicate](/guide/templates/managing-documents.qmd){target="_blank"}.
 
-1. Click on the template to duplicate and on the template details page, select **{{< fa copy >}} Duplicate Template**. 
+4. From the list **{{< fa ellipsis-vertical >}}** menu, select **{{< fa copy >}} Duplicate**, or open the template and select **{{< fa copy >}} Duplicate Template**.
 
-1. In the Duplicate Template modal that opens, give your copy a **Template Name** and a **Template Description**.
+5. In the Duplicate Template modal that opens, give your copy a **Template Name** and a **Template Description**.
 
-1. Click **Duplicate Template** to create a copy of your template.
+6. Click **Duplicate Template** to create a copy of your template.
 
 Once duplicated, customize your new template to your needs, making it available for use with your documents.
 

--- a/site/guide/templates/manage-document-templates.qmd
+++ b/site/guide/templates/manage-document-templates.qmd
@@ -13,21 +13,26 @@ aliases:
   - /guide/templates/view-documentation-templates.html
 ---
 
-View and swap between different document templates or template versions, or duplicate and delete templates.
+Create blank document templates or generate outlines from PDFs, then view, swap, duplicate, and delete templates for your organization.
 
 ::: {.attn}
 
 ## Prerequisites
 
 - [x] {{< var link.login >}}
-- [x] To swap between templates or template versions, more than one template or version must exist for that document type.[^1]
-- [x] You are a [{{< fa code >}} Developer]{.bubble} or [{{< fa circle-check >}} Validator]{.bubble}, or assigned another role with sufficient permissions to perform the tasks in this guide.[^2]
+- [x] To **create** or **delete** templates, you are a [{{< fa hand >}} Customer Admin]{.bubble} or assigned another role with the **Create Template** or **Delete Template** permission.[^1]
+- [x] To swap between templates or template versions, more than one template or version must exist for that document type.[^2]
+- [x] To swap templates on a record document, you are a [{{< fa code >}} Developer]{.bubble} or [{{< fa circle-check >}} Validator]{.bubble}, or assigned another role with sufficient permissions.[^1]
 
 :::
 
 ## View document templates
 
 {{< include /guide/templates/_view-document-templates.qmd >}}
+
+## Create document templates {#create-document-templates}
+
+{{< include /guide/templates/_create-document-templates.qmd >}}
 
 ## Edit document template outlines
 
@@ -58,13 +63,6 @@ Switch a document to a completely different template, or apply another version o
 
    - Click **{{< fa magnifying-glass >}} Search** to search for documents by keywords in the document title.
    - Click **{{< fa arrow-up-wide-short >}} Sort** to reorder the list using different criteria in ascending or descending order.[^6]
-
-   <!-- ::: {.column-margin}
-   **Note that searching and sorting of fields stack.**
-
-   For example, if you first search by keyword for `ValidMind` without clearing that search, any additional sorting applied will only apply to the results returned by that initial search.
-
-   ::: -->
 
 5. On your document's detail page, locate **Document Template**.
 
@@ -129,9 +127,9 @@ Delete templates no longer required by your organization:
 
 <!-- FOOTNOTES -->
 
-[^1]: [Manage document types](manage-document-types.qmd)
+[^1]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
 
-[^2]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
+[^2]: [Manage document types](manage-document-types.qmd)
 
 [^3]: [Manage document types](/guide/templates/manage-document-types.qmd)
 

--- a/site/llm/chatbot-product-map.md
+++ b/site/llm/chatbot-product-map.md
@@ -91,7 +91,7 @@
 - `/guide/templates/customize-document-templates.html`
   - Sections: Prerequisites; Edit template outlines; Configure assessment options[^4]; Edit YAML templates; Template schema; Troubleshooting YAML templates; Add text blocks to templates; Add text blocks via template outlines
 - `/guide/templates/manage-document-templates.html`
-  - Sections: Prerequisites; View document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates; Delete document templates
+  - Sections: Prerequisites; View document templates; Create document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates
 - `/guide/templates/manage-document-types.html`
   - Sections: Prerequisites; Add document types; Edit or delete document types; Development, Validation, and Monitoring document types are stock types and cannot be deleted.
 - `/guide/templates/manage-documents.html`
@@ -124,7 +124,7 @@
 - `/guide/templates/customize-document-templates.html`
   - Sections: Prerequisites; Edit template outlines; Configure assessment options[^4]; Edit YAML templates; Template schema; Troubleshooting YAML templates; Add text blocks to templates; Add text blocks via template outlines
 - `/guide/templates/manage-document-templates.html`
-  - Sections: Prerequisites; View document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates; Delete document templates
+  - Sections: Prerequisites; View document templates; Create document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates
 - `/guide/templates/manage-documents.html`
   - Sections: Prerequisites; Add record documents; How do I get the best results when converting PDFs into editable documents?; How can I trust that the conversion is accurate?; Troubleshooting; My PDF conversion is stuck. What can I do?; Edit record documents; Delete record documents
 - `/guide/templates/manage-text-block-library.html`
@@ -141,7 +141,7 @@
 - `/guide/templates/customize-document-templates.html`
   - Sections: Prerequisites; Edit template outlines; Configure assessment options[^4]; Edit YAML templates; Template schema; Troubleshooting YAML templates; Add text blocks to templates; Add text blocks via template outlines
 - `/guide/templates/manage-document-templates.html`
-  - Sections: Prerequisites; View document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates; Delete document templates
+  - Sections: Prerequisites; View document templates; Create document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates
 - `/guide/templates/manage-document-types.html`
   - Sections: Prerequisites; Add document types; Edit or delete document types; Development, Validation, and Monitoring document types are stock types and cannot be deleted.
 - `/guide/templates/manage-documents.html`
@@ -181,7 +181,7 @@
 - `/guide/templates/customize-document-templates.html`
   - Sections: Prerequisites; Edit template outlines; Configure assessment options[^4]; Edit YAML templates; Template schema; Troubleshooting YAML templates; Add text blocks to templates; Add text blocks via template outlines
 - `/guide/templates/manage-document-templates.html`
-  - Sections: Prerequisites; View document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates; Delete document templates
+  - Sections: Prerequisites; View document templates; Create document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates
 - `/guide/templates/manage-document-types.html`
   - Sections: Prerequisites; Add document types; Edit or delete document types; Development, Validation, and Monitoring document types are stock types and cannot be deleted.
 - `/guide/templates/manage-documents.html`
@@ -203,7 +203,7 @@
 - `/guide/templates/customize-document-templates.html`
   - Sections: Prerequisites; Edit template outlines; Configure assessment options[^4]; Edit YAML templates; Template schema; Troubleshooting YAML templates; Add text blocks to templates; Add text blocks via template outlines
 - `/guide/templates/manage-document-templates.html`
-  - Sections: Prerequisites; View document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates; Delete document templates
+  - Sections: Prerequisites; View document templates; Create document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates
 - `/guide/templates/manage-document-types.html`
   - Sections: Prerequisites; Add document types; Edit or delete document types; Development, Validation, and Monitoring document types are stock types and cannot be deleted.
 - `/guide/templates/manage-documents.html`
@@ -225,7 +225,7 @@
 - `/guide/templates/customize-document-templates.html`
   - Sections: Prerequisites; Edit template outlines; Configure assessment options[^4]; Edit YAML templates; Template schema; Troubleshooting YAML templates; Add text blocks to templates; Add text blocks via template outlines
 - `/guide/templates/manage-document-templates.html`
-  - Sections: Prerequisites; View document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates; Delete document templates
+  - Sections: Prerequisites; View document templates; Create document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates
 - `/guide/templates/manage-document-types.html`
   - Sections: Prerequisites; Add document types; Edit or delete document types; Development, Validation, and Monitoring document types are stock types and cannot be deleted.
 - `/guide/templates/manage-documents.html`
@@ -399,7 +399,7 @@
 - `/guide/templates/customize-document-templates.html`
   - Sections: Prerequisites; Edit template outlines; Configure assessment options[^4]; Edit YAML templates; Template schema; Troubleshooting YAML templates; Add text blocks to templates; Add text blocks via template outlines
 - `/guide/templates/manage-document-templates.html`
-  - Sections: Prerequisites; View document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates; Delete document templates
+  - Sections: Prerequisites; View document templates; Create document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates
 - `/guide/templates/manage-document-types.html`
   - Sections: Prerequisites; Add document types; Edit or delete document types; Development, Validation, and Monitoring document types are stock types and cannot be deleted.
 - `/guide/templates/manage-documents.html`
@@ -455,7 +455,7 @@
 - `/guide/templates/customize-document-checker.html`
   - Sections: Prerequisites; Manage regulations and policies; Manage assessments; Default assessments provided by } cannot be edited, only cloned.; Add or clone assessments; Add or edit assessment questions; Add assessment questions; Edit assessment questions
 - `/guide/templates/manage-document-templates.html`
-  - Sections: Prerequisites; View document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates; Delete document templates
+  - Sections: Prerequisites; View document templates; Create document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates
 - `/guide/templates/manage-document-types.html`
   - Sections: Prerequisites; Add document types; Edit or delete document types; Development, Validation, and Monitoring document types are stock types and cannot be deleted.
 - `/guide/templates/manage-documents.html`
@@ -562,7 +562,7 @@
 - `/guide/templates/customize-document-templates.html`
   - Sections: Prerequisites; Edit template outlines; Configure assessment options[^4]; Edit YAML templates; Template schema; Troubleshooting YAML templates; Add text blocks to templates; Add text blocks via template outlines
 - `/guide/templates/manage-document-templates.html`
-  - Sections: Prerequisites; View document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates; Delete document templates
+  - Sections: Prerequisites; View document templates; Create document templates; Edit document template outlines; Swap document templates; View currently applied templates; Swap between templates; Duplicate document templates
 - `/guide/templates/manage-document-types.html`
   - Sections: Prerequisites; Add document types; Edit or delete document types; Development, Validation, and Monitoring document types are stock types and cannot be deleted.
 - `/guide/templates/manage-documents.html`


### PR DESCRIPTION
## What and why?

Documents net-new document template creation for [SC-17034](https://app.shortcut.com/validmind/story/17034) covering shipped work from [SC-16316](https://app.shortcut.com/validmind/story/16316).

Implementation: [frontend#2637](https://github.com/validmind/frontend/pull/2637), [backend#3240](https://github.com/validmind/backend/pull/3240).

**Before:** [Manage document templates](https://docs.validmind.com/guide/templates/manage-document-templates.html) covered view, outline edit, swap, duplicate (details page only), and delete — but not creating a blank template or generating an outline from PDF.

**After:**
- Intro and prerequisites distinguish **Create Template** / **Delete Template** (Customer Admin) vs swap permissions
- New **Create document templates** section: create blank template under Development / Validation / Monitoring / Custom, then **Build Outline Manually** or **Start Outline From PDF**
- PDF limits and structure-only outline behavior documented; progress tracked in **My Inbox**
- **Duplicate** documents both list **Actions** menu and template details
- FAQ notes create-from-scratch / PDF outline option

## How to test

1. Mark this PR ready for review (draft PRs skip the preview `validate` job).
2. Wait for the `validate` check to pass and deploy the hosted preview.
3. Review:
   - [Manage document templates](https://docs-staging.validmind.ai/pr_previews/emma/sc-17034/documentation-net-new-document-templates/guide/templates/manage-document-templates.html) (Create section)
   - [Documents and templates FAQ](https://docs-staging.validmind.ai/pr_previews/emma/sc-17034/documentation-net-new-document-templates/faq/faq-documentation.html)
   - [Customizing Your Inventory (training)](https://docs-staging.validmind.ai/pr_previews/emma/sc-17034/documentation-net-new-document-templates/training/administrator-fundamentals/customizing-your-inventory.html) (duplicate include)
4. Confirm create flow matches Settings → Documents → Templates → **Create [Type] Template**, then blank-outline manual vs PDF options.
5. Confirm duplicate from list Actions and from details still match.

Production for comparison:
- https://docs.validmind.com/guide/templates/manage-document-templates.html

Optional local render:
```bash
skills/validmind-docs-coverage/scripts/render-pages.sh \
  guide/templates/manage-document-templates.qmd \
  training/administrator-fundamentals/customizing-your-inventory.qmd \
  faq/faq-documentation.qmd
```

## What needs special review?

- Create modal does **not** ask for template type; type comes from the active Templates tab (shipped FE), not the original AC mock that included a type dropdown.
- PDF outline is structure-only (empty text placeholders); charts/graphics are not converted to test/metric blocks.
- Follow-up [backend#3415](https://github.com/validmind/backend/pull/3415) (cancel stuck PDF parse) is not documented here.

## Dependencies, breaking changes, and deployment notes

- Depends on merged FE/BE for SC-16316
- No breaking docs changes

## Release notes

Customer Admins can create blank document templates under each document type, or generate a structure-only outline from a PDF with selectable text. Duplicate and delete remain available from the templates list and template details. [Learn more ...](/guide/templates/manage-document-templates.html#create-document-templates)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied (`documentation`)
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
