### PR TITLE
docs: MCP guide updates for current tool surface [sc-17040]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ This page explains:
 
 If you are an AI agent embedded in ValidMind, your capabilities are documented here:
 
-**[Chatbot capabilities](https://docs.validmind.ai/guide/chatbot-capabilities.html)**
+**[ValidMind in-app assistant](https://docs.validmind.ai/guide/chatbot-capabilities.html)**
 
 This page describes what the assistant can and cannot do, including context-aware features and current limitations.
 

--- a/site/about/glossary/mcp/_mcp-server.qmd
+++ b/site/about/glossary/mcp/_mcp-server.qmd
@@ -3,4 +3,4 @@ Refer to the LICENSE file in the root of this repository for details.
 SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 
 MCP server
-: A service that exposes tools and resources to AI assistants via the MCP protocol. The {{< var vm.product >}} MCP server provides access to model inventory operations.
+: A service that exposes tools and resources to AI assistants via the MCP protocol. The {{< var vm.product >}} MCP server provides access to inventory records, artifacts, templates, custom fields, and supporting schemas or lookups.

--- a/site/about/glossary/mcp/_mcp-tool.qmd
+++ b/site/about/glossary/mcp/_mcp-tool.qmd
@@ -3,4 +3,4 @@ Refer to the LICENSE file in the root of this repository for details.
 SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 
 MCP tool
-: An operation exposed by an MCP server that AI assistants can invoke to perform actions, such as querying models or updating artifacts.
+: An operation exposed by an MCP server that AI assistants can invoke to perform actions, such as listing records, creating findings, or updating templates.

--- a/site/faq/faq-integrations.qmd
+++ b/site/faq/faq-integrations.qmd
@@ -66,7 +66,7 @@ Supported connections include:[^10]
 - **Analytics and reporting** — Microsoft Power BI, plus scheduled data exports to cloud storage for use with external BI and reporting tools.[^18]
 - **Workflow automation** — HTTP requests from {{< var vm.product >}} to external services and webhooks from external systems into {{< var vm.product >}}.[^19]
 - **Testing and documentation** — {{< var validmind.developer >}} integrations with development platforms, including MLflow and AWS SageMaker.[^20]
-- **AI assistants** — Claude Desktop and Cursor IDE through the Model Context Protocol (MCP).[^21]
+- **AI assistants** — Claude Code and Cursor IDE through the Model Context Protocol (MCP).[^21]
 
 If your system isn't supported out-of-the-box, you can build a custom integration that implements the {{< var vm.product >}} reference API.[^22]
 

--- a/site/guide/_sidebar.yaml
+++ b/site/guide/_sidebar.yaml
@@ -51,6 +51,7 @@ website:
                 - guide/integrations/implement-custom-integrations.qmd
                 - guide/integrations/link-external-records.qmd
                 - guide/mcp/connect-ai-assistants-via-mcp.qmd
+                - guide/chatbot-capabilities.qmd
                 - guide/integrations/configure-data-exports.qmd
                 - file: guide/integrations/integrations-examples.qmd
                   contents:

--- a/site/guide/chatbot-capabilities.qmd
+++ b/site/guide/chatbot-capabilities.qmd
@@ -47,7 +47,7 @@ Keep these limitations in mind when using the assistant:
 |---------|------------------|-----------------|
 | Access method | Floating chat window in platform | AI assistants (Cursor, Claude Code) |
 | Primary use | Product help and guidance | Inventory management |
-| Data access | Documentation + your current context | Your records (models), artifacts (findings), templates |
+| Data access | Documentation + your current context | Your records, artifacts (findings), templates, custom fields, and related schemas |
 | Actions | Read-only guidance | Create, read, update operations |
 
 The in-app assistant (described on this page) is focused on helping you use the platform. For programmatic access to your inventory, refer to [Connect AI assistants via MCP](/guide/mcp/connect-ai-assistants-via-mcp.qmd).

--- a/site/guide/chatbot-capabilities.qmd
+++ b/site/guide/chatbot-capabilities.qmd
@@ -2,9 +2,8 @@
 # Copyright © 2023-2026 ValidMind Inc. All rights reserved.
 # Refer to the LICENSE file in the root of this repository for details.
 # SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
-title: "Chatbot capabilities"
+title: "ValidMind in-app assistant"
 date: last-modified
-search: false
 ---
 
 The {{< var vm.product >}} in-app assistant helps you navigate the platform and find answers to product questions. This page describes what the assistant can and cannot do.

--- a/site/guide/integrations/managing-integrations.qmd
+++ b/site/guide/integrations/managing-integrations.qmd
@@ -259,7 +259,7 @@ Connect AI assistants to {{< var vm.product >}} using the Model Context Protocol
 :::: {.flex .flex-wrap .justify-around}
 
 ::: {.w-33-ns}
-- Claude Desktop
+- Claude Code
 :::
 
 ::: {.w-33-ns}

--- a/site/guide/mcp/connect-ai-assistants-via-mcp.qmd
+++ b/site/guide/mcp/connect-ai-assistants-via-mcp.qmd
@@ -6,7 +6,7 @@ title: "Connect AI assistants via MCP"
 date: last-modified
 ---
 
-The {{< var vm.product >}} MCP (Model Context Protocol) server enables AI assistants to query and manage your inventory through natural language, providing seamless access to records (models), artifacts (findings), templates, and custom fields.
+The {{< var vm.product >}} MCP (Model Context Protocol) server enables AI assistants to query and manage your inventory through natural language. Assistants can work with records (models and other inventory types), artifacts (findings), templates, custom fields, and the supporting lookups needed to create and update those objects safely.
 
 ## Key concepts
 
@@ -30,21 +30,23 @@ graph LR
     end
     
     subgraph vm [ValidMind Platform]
-        Models[Models]
+        Records[Records]
         Artifacts[Artifacts]
         Templates[Templates]
-        CustomFields[Custom fields]
+        Fields[Custom fields]
+        Lookups[Schemas and lookups]
     end
     
     Claude --> MCPServer
     Cursor --> MCPServer
-    MCPServer --> Models
+    MCPServer --> Records
     MCPServer --> Artifacts
     MCPServer --> Templates
-    MCPServer --> CustomFields
+    MCPServer --> Fields
+    MCPServer --> Lookups
 ```
 
-Your AI assistant sends natural language queries through the MCP protocol. The {{< var vm.product >}} MCP server translates these into API calls, authenticates using your API key, and returns data from the {{< var validmind.platform >}}.
+Your AI assistant sends natural language queries through the MCP protocol. The {{< var vm.product >}} MCP server translates these into API calls, authenticates using your API credentials, and returns data from the {{< var validmind.platform >}}.
 
 ### What can I do with {{< var vm.product >}} MCP?
 
@@ -52,18 +54,23 @@ The MCP server exposes tools for working with your {{< var vm.product >}} invent
 
 ::: {.panel-tabset}
 
-#### Record and artifact operations
+#### Records and artifacts
 
-- List and get records (models)
-- List and get artifacts (findings)
-- Filter by risk level, deployment region, or ownership
+- List, get, and summarize records across inventory record types
+- Create and update records
+- List, get, and summarize artifacts (currently findings)
+- Create and update findings linked to a record
+- Filter records by search text, tiering, status, use case, business unit, owners, developers, validators, and related flags
+- Filter artifacts by severity, status, assignee, risk area, due date, and related criteria
 
-#### Custom field operations
+#### Schemas and lookups
 
-- List custom fields for records and artifacts
-- Update custom field values
+- Discover primary record types, use cases, business units, groups, model stages, and organization users
+- Read core field schemas and artifact types
+- Discover custom field schemas for records and artifacts
+- Read and update custom field values on records and artifacts
 
-#### Template operations
+#### Templates
 
 - List available templates
 - Get template details
@@ -73,11 +80,21 @@ The MCP server exposes tools for working with your {{< var vm.product >}} invent
 :::
 
 ::: {.callout title="Example queries you can ask"}
-- "Show me all model-type records that are high risk"
+- "Show me all tier 1 model-type records"
 - "Find all the records I am an owner for"
-- "List my validation artifacts"
+- "Summarize findings by severity for this model"
+- "Register a new model-type record called Customer Churn"
+- "Create a finding on that record and assign it to me"
 - "What templates are available for credit risk models?"
 
+:::
+
+::: {.callout-note}
+## Current limitations
+
+- The MCP server covers inventory records, artifacts, templates, custom fields, and supporting schemas or lookups. It does not write documentation content or run ValidMind Library tests.
+- Artifact operations currently support the `finding` artifact type only.
+- Requests may be rate limited depending on your environment.
 :::
 
 ::: {.attn}
@@ -93,6 +110,14 @@ The MCP server exposes tools for working with your {{< var vm.product >}} invent
 :::
 
 ## Configure your AI assistant
+
+For {{< var vm.product >}} Cloud production, use:
+
+```text
+https://api.prod.validmind.ai/mcp
+```
+
+If your organization uses a different cloud host or a private deployment, use the MCP URL provided for your environment.
 
 ::: {.panel-tabset}
 
@@ -164,9 +189,9 @@ The MCP server exposes tools for working with your {{< var vm.product >}} invent
 
 ### Connection refused or timeout errors
 
-- Verify your network can reach `api.prod.validmind.ai`.
+- Verify your network can reach `api.prod.validmind.ai` (or your environment's MCP host).
 - Check if your organization uses a firewall or proxy that blocks MCP connections.
-- Ensure you are using the correct MCP URL for your environment.
+- Ensure you are using the correct MCP URL for your environment. For {{< var vm.product >}} Cloud production, use `https://api.prod.validmind.ai/mcp`.
 
 ### Authentication errors (401 or 403)
 
@@ -180,6 +205,11 @@ The MCP server exposes tools for working with your {{< var vm.product >}} invent
 - Validate the JSON syntax in your configuration file.
 - Reload Cursor after making configuration changes.
 - Check **Cursor Settings > MCP** to verify the server appears and is enabled. You may need to manually toggle the server on after adding it to the configuration.
+
+### Rate limiting or unexpected denials
+
+- If requests fail intermittently under heavy use, wait briefly and retry.
+- Confirm your credentials still have access to the records, artifacts, or templates you are requesting.
 
 :::
 


### PR DESCRIPTION
## What and why?

Updates the ValidMind MCP documentation to match the shipped `backend/mcp` tool surface (17 tools on `origin/main`), and reconciles supported-client wording across related pages.

**Before**
- Capabilities covered only list/get + custom-field updates + templates
- Filters incorrectly mentioned risk level and deployment region
- Integrations overview / FAQ listed Claude Desktop instead of Claude Code
- No limitations, multi-environment URL note, or create/summarize/schema coverage

**After**
- Capabilities cover record/artifact read+write (including create and summarize), schemas/lookups, custom field schema + value read/write, and templates
- Filters match the MCP record/artifact filter surface (tiering, ownership roles, status, use case, business unit, etc.)
- Supported clients aligned to Cursor IDE + Claude Code
- Limitations callout for inventory/templates scope, findings-only artifacts, and rate limiting
- Production MCP URL called out explicitly, with a note for other environments

Shortcut: https://app.shortcut.com/validmind/story/17040

Implementation evidence (authoritative tool surface):
- `validmind/backend` `mcp/mcp_service/tool_ids.py` and `mcp/mcp_service/tooling.py` on `origin/main`
- Notable related backend work includes multi-record-type MCP support ([SC-16816](https://app.shortcut.com/validmind/story/16816) / backend `#3281`) and earlier MCP inventory write/read expansions

## How to test

```bash
skills/validmind-docs-coverage/scripts/render-pages.sh \
  guide/mcp/connect-ai-assistants-via-mcp.qmd \
  guide/integrations/managing-integrations.qmd \
  faq/faq-integrations.qmd \
  guide/chatbot-capabilities.qmd \
  about/glossary/glossary.qmd
```

Hosted preview in docs-staging - will be available once the validate check completes:

- [Connect AI assistants via MCP](https://docs-staging.validmind.ai/pr_previews/emma/sc-17040-documentation-mcp-updates/guide/mcp/connect-ai-assistants-via-mcp.html)
- [Managing integrations](https://docs-staging.validmind.ai/pr_previews/emma/sc-17040-documentation-mcp-updates/guide/integrations/managing-integrations.html)
- [Integrations and support FAQ](https://docs-staging.validmind.ai/pr_previews/emma/sc-17040-documentation-mcp-updates/faq/faq-integrations.html)
- [ValidMind in-app assistant](https://docs-staging.validmind.ai/pr_previews/emma/sc-17040-documentation-mcp-updates/guide/chatbot-capabilities.html)
- [Glossary](https://docs-staging.validmind.ai/pr_previews/emma/sc-17040-documentation-mcp-updates/about/glossary/glossary.html)
## What needs special review?

- **Auth:** Customer docs continue to document API key + secret as the supported production setup path. OAuth / PAT bearer modes exist in the MCP service and eng README, but are not published here as a customer setup path.
- **Clients:** Claude Desktop was removed from integrations/FAQ so those pages match the setup guide (Cursor + Claude Code). Codex appears in the eng README only and is intentionally omitted from customer docs.
- **Artifacts:** Documented as findings-only, matching the current `artifact_type` enum.

## Dependencies, breaking changes, and deployment notes

- No product/code dependencies
- Docs-only change; follows normal `main` → staging → prod documentation delivery

## Release notes

Expanded the ValidMind MCP setup guide so AI assistants can create and update inventory records and findings, discover schemas and lookups, and use accurate filters — plus clarified supported clients and current limitations. [Learn more ...](/guide/mcp/connect-ai-assistants-via-mcp.html)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
