### PR TITLE
[SC-16661] Document monitoring threshold breach workflow trigger

### DIFF
--- a/site/guide/_sidebar.yaml
+++ b/site/guide/_sidebar.yaml
@@ -195,6 +195,7 @@ website:
                 - guide/monitoring/review-monitoring-results.qmd
                 - guide/monitoring/work-with-metrics-over-time.qmd
                 - guide/monitoring/set-thresholds-and-alerts.qmd
+                - guide/monitoring/trigger-workflows-on-threshold-breach.qmd
         - text: "---"
         - section: "Attestation"
           contents:

--- a/site/guide/monitoring/ongoing-monitoring.qmd
+++ b/site/guide/monitoring/ongoing-monitoring.qmd
@@ -16,6 +16,7 @@ listing:
       - review-monitoring-results.qmd
       - work-with-metrics-over-time.qmd
       - set-thresholds-and-alerts.qmd
+      - trigger-workflows-on-threshold-breach.qmd
   - id: ongoing-monitoring-code-samples
     type: grid
     grid-columns: 2

--- a/site/guide/monitoring/trigger-workflows-on-threshold-breach.qmd
+++ b/site/guide/monitoring/trigger-workflows-on-threshold-breach.qmd
@@ -1,0 +1,96 @@
+---
+# Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+# Refer to the LICENSE file in the root of this repository for details.
+# SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
+title: "Trigger workflows on threshold breach"
+date: last-modified
+---
+
+When an ongoing monitoring metric breaches its threshold, you can start a workflow automatically in addition to the email alert notifications stakeholders already receive.[^1] This lets remediation, review, or escalation begin without anyone having to notice the alert first.
+
+Because the workflow starts from a metric logged against an inventory record, this trigger is available for record workflows only.
+
+::: {.attn}
+
+## Prerequisites
+
+- [x] {{< var link.login >}}
+- [x] Metrics over time have already been logged via the {{< var validmind.developer >}} for your record.[^2]
+- [x] Your metrics set the `passed` parameter.[^1]
+- [x] You are a [{{< fa hand >}} Customer Admin]{.bubble} or assigned another role with sufficient permissions to perform the tasks in this guide.[^3]
+
+:::
+
+## Set up the trigger
+
+Add a record workflow[^4] and under **Workflow Start**, select **On Monitoring Threshold Breach**. Then choose which metrics the workflow watches:
+
+| Option | Description |
+|---:|---|
+| **Any metric breach** | Enabled by default. The workflow starts when any ongoing monitoring metric on the record breaches its threshold. |
+| Specific metrics | Disable **Any metric breach**, then select one or more metrics under **Metrics to monitor**. The workflow starts only for the metrics you select. |
+: **On Monitoring Threshold Breach** configuration {.hover tbl-colwidths="[30,70]"}
+
+The **Metrics to monitor** list offers the metrics already logged by records in your organization, along with metrics included in a monitoring template. Metrics that appear because they are in a template but have no readings yet are marked as not yet recorded — you can still select one, and the workflow starts once that metric is logged and breaches.
+
+::: {.callout}
+More than one workflow can use this trigger, so you can route different metrics to different processes — for example, sending a drift breach to a recalibration workflow and a performance breach to a review workflow.
+:::
+
+## When the workflow starts
+
+The workflow starts when a metric **enters** a breached state, that is when a metric is logged with `passed=False` and the previous reading for that same metric on that same record was not already failing.
+
+This means:
+
+- A metric that goes from passing to failing starts the workflow.
+- The first reading ever logged for a metric starts the workflow if it is already failing.
+- A metric logged as failing again, having already failed, does **not** start the workflow a second time. A monitoring job that runs hourly and keeps reporting the same breach starts one workflow, not one per run.
+- A metric returning to passing and later failing again starts the workflow again.
+
+The trigger reads the `passed` parameter you set and does not re-evaluate your thresholds. A metric that defines thresholds but never sets `passed` does not start a workflow, in the same way that it does not send an alert notification.[^1]
+
+::: {.callout}
+While a workflow started this way is still in progress for a record, a further breach does not start a second run of that same workflow on that record. Later breaches start a new run once the first one completes.
+:::
+
+## Review the breach that started a workflow
+
+For a workflow started by a breach, the execution details show which reading was responsible:
+
+- The metric name and the value that breached
+- The thresholds defined for that metric
+- When the reading was recorded
+- A link to the record's monitoring document
+
+## Include breach details in notifications
+
+A [{{< fa bullhorn >}} Broadcast]{.bubble} step[^5] in a breach-triggered workflow can include the breach in the email it sends, so recipients know which metric is at fault without opening the record first. When the workflow uses this trigger, these variables become available under **Monitoring Breach**:
+
+| Variable | Description |
+|---:|---|
+| Breached Metric Name | The display name of the metric that breached. |
+| Breached Metric Key | The full key of the metric, as logged. |
+| Breached Metric Value | The value recorded for the breaching reading. |
+| Breached Metric Thresholds | The thresholds defined for that metric. |
+| Monitoring Document URL | A link to the record's monitoring document. |
+: **Monitoring Breach** broadcast variables {.hover tbl-colwidths="[35,65]"}
+
+Since these variables can be resolved only for a workflow started by a breach, they are offered for this trigger only.
+
+## What's next
+
+- [Set thresholds and alerts](/guide/monitoring/set-thresholds-and-alerts.qmd)
+- [Working with workflows](/guide/workflows/working-with-workflows.qmd)
+
+<!-- FOOTNOTES -->
+
+[^1]: [Set thresholds and alerts](/guide/monitoring/set-thresholds-and-alerts.qmd#alert-notifications)
+
+[^2]: [Work with metrics over time](/guide/monitoring/work-with-metrics-over-time.qmd)
+
+[^3]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
+
+[^4]: [Add new workflows](/guide/workflows/configure-workflows.qmd#add-new-workflows)
+
+[^5]: [Workflow step types](/guide/workflows/workflow-step-types.qmd#broadcast)

--- a/site/guide/monitoring/trigger-workflows-on-threshold-breach.qmd
+++ b/site/guide/monitoring/trigger-workflows-on-threshold-breach.qmd
@@ -69,7 +69,7 @@ A [{{< fa bullhorn >}} Broadcast]{.bubble} step[^5] in a breach-triggered workfl
 
 | Variable | Description |
 |---:|---|
-| Breached Metric Name | The display name of the metric that breached. |
+| Breached Metric Name | The metric that breached, named as it appears when you select it: its display name followed by its full key, unless the two are the same. Two metrics can share a display name, so the key is what tells them apart. |
 | Breached Metric Key | The full key of the metric, as logged. |
 | Breached Metric Value | The value recorded for the breaching reading. |
 | Breached Metric Thresholds | The thresholds defined for that metric. |
@@ -77,6 +77,17 @@ A [{{< fa bullhorn >}} Broadcast]{.bubble} step[^5] in a breach-triggered workfl
 : **Monitoring Breach** broadcast variables {.hover tbl-colwidths="[35,65]"}
 
 Since these variables can be resolved only for a workflow started by a breach, they are offered for this trigger only.
+
+## What a breach sends
+
+The alert email and the workflow follow different rhythms, so it is worth knowing what a breach produces before you add a [{{< fa bullhorn >}} Broadcast]{.bubble} step to a breach-triggered workflow:
+
+- The **alert email** is sent for every breaching reading.[^1] A metric that keeps failing keeps sending it.
+- The **workflow** starts only on the transition into breach. A metric that was already failing does not start it again.
+
+One person can therefore receive three things for a single breach: the alert email, the broadcast email your workflow sends, and the in-app broadcast notification.
+
+To reduce that, a [{{< fa hand >}} Customer Admin]{.bubble} can turn off **Monitoring breach** or **Broadcast notifications** under {{< fa gear >}} Settings.[^6] Two limits are worth knowing: the toggles apply to your whole organization rather than to a single record or workflow, and they suppress emails only — the in-app notification is unaffected.
 
 ## What's next
 
@@ -94,3 +105,5 @@ Since these variables can be resolved only for a workflow started by a breach, t
 [^4]: [Add new workflows](/guide/workflows/configure-workflows.qmd#add-new-workflows)
 
 [^5]: [Workflow step types](/guide/workflows/workflow-step-types.qmd#broadcast)
+
+[^6]: [Customize email notifications](/guide/configuration/manage-platform-notifications.qmd#customize-email-notifications)

--- a/site/guide/workflows/_add-new-workflows.qmd
+++ b/site/guide/workflows/_add-new-workflows.qmd
@@ -29,6 +29,7 @@ iii. Under **Workflow Start**, select when the workflow should be initiated:
 - **Manually** — Start this workflow manually.^[[Initiate workflows](/guide/workflows/manage-workflows.qmd#initiate-workflows)]
 - **On Inventory Record Registration** — Start this workflow when a record is registered in your inventory.[^on-registration]
 - **On Field Change** — Start this workflow on a change to a specific record inventory field.[^on-field-change] To configure, select a field under **Inventory Record Field To Monitor**.
+- **On Monitoring Threshold Breach** — Start this workflow when an ongoing monitoring metric breaches its threshold.[^on-threshold-breach] To configure, keep **Any metric breach** enabled, or disable it and select the metrics to watch under **Metrics to monitor**.
 - **Via Webhook** — Start this workflow when a webhook event is received.
 
 iv. Under **Workflow Expected Duration**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
@@ -81,6 +82,12 @@ vi. Click **Save Draft** to save your blank workflow, and then [configure your w
     <br></br>
     When selecting date or date time fields, check **Schedule workflow start for this date** to set the workflow to trigger on the existing date captured in the field rather than when its value changes.
 
+[^on-threshold-breach]:
+
+    [Trigger workflows on threshold breach](/guide/monitoring/trigger-workflows-on-threshold-breach.qmd)
+    <br></br>
+    The workflow starts when a metric enters a breached state, not on every breaching reading — a monitoring job that keeps reporting the same breach starts one workflow, not one per run.
+
 [^on-artifact-field-change]:
 
     [Manage artifact fields](/guide/validation/manage-artifact-fields.qmd)
@@ -124,6 +131,7 @@ iii. Under **Workflow Start**, select when the workflow should be initiated:
 - **Manually** — Start this workflow manually.
 - **On Inventory Record Registration** — Start this workflow when a record is registered in your inventory.
 - **On Field Change** — Start this workflow on a change to a specific record inventory field. To configure, select a field under **Inventory Record Field To Monitor**.
+- **On Monitoring Threshold Breach** — Start this workflow when an ongoing monitoring metric breaches its threshold. To configure, keep **Any metric breach** enabled, or disable it and select the metrics to watch under **Metrics to monitor**.
 - **Via Webhook** — Start this workflow when a webhook event is received.
 
 iv. Under **Workflow Expected Duration**, define the SLA for the workflow based on the start date in days, weeks, months, or years.

--- a/site/llm/chatbot-product-map.md
+++ b/site/llm/chatbot-product-map.md
@@ -495,14 +495,14 @@
   - Sections: Can I customize workflows within }?; What record stages are available for use in workflows?; Can we work with disconnected workflows?; You can also leverage the } once you are ready to document a specific record (model) for review and validation.; Learn more
 - `/guide/integrations/integrations-examples/use-webhooks-with-workflows.html`
   - Sections: Prerequisites; Start a workflow via webhook; 1. Configure workflow in }; 2. Start workflow from external system; Trigger a paused workflow to continue; 1. Configure workflow in }; 2. Trigger workflow to continue from external system
+- `/guide/monitoring/trigger-workflows-on-threshold-breach.html`
+  - Sections: Prerequisites; Set up the trigger; When the workflow starts; Review the breach that started a workflow; Include breach details in notifications; What a breach sends; What's next
 - `/guide/workflows/conditional-step-requirements.html`
   - Sections: Prerequisites; Configure conditional requirements
 - `/guide/workflows/configure-workflows.html`
   - Sections: Prerequisites; Create custom workflows; 1. Add new workflows; 2. Configure workflow steps; 3. Link workflow together; Workflow steps relationship unclear on your canvas?; 4. Publish workflow; Clone existing workflows
 - `/guide/workflows/introduction-to-workflows.html`
   - Sections: Workflow elements; What's next
-- `/guide/workflows/manage-record-stages.html`
-  - Sections: Prerequisites; Add record stages; Edit or delete record stages
 
 #### `/settings/workflows` — Workflows
 
@@ -517,14 +517,14 @@
   - Sections: Can I customize workflows within }?; What record stages are available for use in workflows?; Can we work with disconnected workflows?; You can also leverage the } once you are ready to document a specific record (model) for review and validation.; Learn more
 - `/guide/integrations/integrations-examples/use-webhooks-with-workflows.html`
   - Sections: Prerequisites; Start a workflow via webhook; 1. Configure workflow in }; 2. Start workflow from external system; Trigger a paused workflow to continue; 1. Configure workflow in }; 2. Trigger workflow to continue from external system
+- `/guide/monitoring/trigger-workflows-on-threshold-breach.html`
+  - Sections: Prerequisites; Set up the trigger; When the workflow starts; Review the breach that started a workflow; Include breach details in notifications; What a breach sends; What's next
 - `/guide/workflows/conditional-step-requirements.html`
   - Sections: Prerequisites; Configure conditional requirements
 - `/guide/workflows/configure-workflows.html`
   - Sections: Prerequisites; Create custom workflows; 1. Add new workflows; 2. Configure workflow steps; 3. Link workflow together; Workflow steps relationship unclear on your canvas?; 4. Publish workflow; Clone existing workflows
 - `/guide/workflows/introduction-to-workflows.html`
   - Sections: Workflow elements; What's next
-- `/guide/workflows/manage-record-stages.html`
-  - Sections: Prerequisites; Add record stages; Edit or delete record stages
 
 ## Main application
 
@@ -555,8 +555,8 @@
   - Sections: Prerequisites; Steps; Example monitoring test results; [} Satisfactory]; [} Requires Attention]
 - `/guide/monitoring/set-thresholds-and-alerts.html`
   - Sections: Prerequisites; Use a custom function; Set the `passed` parameter; Output examples; Alert notifications
-- `/guide/monitoring/work-with-metrics-over-time.html`
-  - Sections: **Log metrics over time }**; Prerequisites; Add metrics over time; Add integration metrics; Use the global time range; View metric over time metadata
+- `/guide/monitoring/trigger-workflows-on-threshold-breach.html`
+  - Sections: Prerequisites; Set up the trigger; When the workflow starts; Review the breach that started a workflow; Include breach details in notifications; What a breach sends; What's next
 
 - *No direct help link in frontend; related docs inferred from keywords.*
 
@@ -619,14 +619,14 @@
   - Sections: Can I customize workflows within }?; What record stages are available for use in workflows?; Can we work with disconnected workflows?; You can also leverage the } once you are ready to document a specific record (model) for review and validation.; Learn more
 - `/guide/integrations/integrations-examples/use-webhooks-with-workflows.html`
   - Sections: Prerequisites; Start a workflow via webhook; 1. Configure workflow in }; 2. Start workflow from external system; Trigger a paused workflow to continue; 1. Configure workflow in }; 2. Trigger workflow to continue from external system
+- `/guide/monitoring/trigger-workflows-on-threshold-breach.html`
+  - Sections: Prerequisites; Set up the trigger; When the workflow starts; Review the breach that started a workflow; Include breach details in notifications; What a breach sends; What's next
 - `/guide/workflows/conditional-step-requirements.html`
   - Sections: Prerequisites; Configure conditional requirements
 - `/guide/workflows/configure-workflows.html`
   - Sections: Prerequisites; Create custom workflows; 1. Add new workflows; 2. Configure workflow steps; 3. Link workflow together; Workflow steps relationship unclear on your canvas?; 4. Publish workflow; Clone existing workflows
 - `/guide/workflows/introduction-to-workflows.html`
   - Sections: Workflow elements; What's next
-- `/guide/workflows/manage-record-stages.html`
-  - Sections: Prerequisites; Add record stages; Edit or delete record stages
 
 - *No direct help link in frontend; related docs inferred from keywords.*
 


### PR DESCRIPTION
## What and why?

Documents the new **On Monitoring Threshold Breach** workflow trigger, which starts a record workflow automatically when an ongoing monitoring metric enters a breached state.

**Before:** Ongoing monitoring covered thresholds and stakeholder email alerts only. The Workflow Start list covered Manually / On Inventory Record Registration / On Field Change / Via Webhook.

**After:**

- New page: Trigger workflows on threshold breach, listed under Ongoing monitoring below Set thresholds and alerts
- Workflow Start list now includes the trigger, in both the HTML guide and the RevealJS training deck
- Covers metric scoping (any metric vs. selected metrics), the transition-only firing rule, the breach details on an execution, and the Monitoring Breach broadcast variables

Shortcut: https://app.shortcut.com/validmind/story/16661

Implementation: `validmind/backend` https://github.com/validmind/backend/pull/3458, `validmind/frontend` https://github.com/validmind/frontend/pull/2797

## How to test

```bash
skills/validmind-docs-coverage/scripts/render-pages.sh \
  guide/monitoring/trigger-workflows-on-threshold-breach.qmd \
  guide/monitoring/ongoing-monitoring.qmd \
  guide/workflows/configure-workflows.qmd \
  training/administrator-fundamentals/using-validmind-for-risk-management.qmd
```

All four render with no new warnings.

Hosted preview: [Trigger workflows on threshold breach](https://docs-staging.validmind.ai/pr_previews/juan/sc-16661/document-monitoring-breach-workflow-trigger/guide/monitoring/trigger-workflows-on-threshold-breach.html)

## What needs special review?

- **The feature ships behind a dark LaunchDarkly flag** (`launchdarkly.rollout.monitoring-breach-trigger`, off by default, enforced on both the UI and the firing path). This page describes behaviour customers cannot see until the flag is enabled, so it should not be promoted to **prod** ahead of the rollout. Merging to `main` is fine.
- `_add-new-workflows.qmd` is a shared include with two format variants; both were edited. Consumers are `guide/workflows/configure-workflows.qmd` (HTML) and `training/administrator-fundamentals/using-validmind-for-risk-management.qmd` (RevealJS) — both rendered and checked.
- Please sanity-check the firing-rule wording. The trigger reads the `passed` parameter and does not re-evaluate thresholds, so a metric that defines thresholds but never sets `passed` never starts a workflow. That is easy for a customer to misread.

## Dependencies, breaking changes, and deployment notes

- Documentation only; no changes in this repository outside `site/`.
- Depends on the two implementation PRs above and on the LaunchDarkly flag being enabled for the audience.

## Release notes

Documented how to start a workflow automatically when an ongoing monitoring metric breaches its threshold. [Learn more ...](/guide/monitoring/trigger-workflows-on-threshold-breach.html)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)

