### PR TITLE
[SC-17811] Document the Create Artifact workflow step

### DIFF
--- a/site/guide/workflows/_workflow-step-types.qmd
+++ b/site/guide/workflows/_workflow-step-types.qmd
@@ -54,7 +54,7 @@ Typical **Manual review** pattern: earlier in the intake workflow, a reviewer ch
 | **Artifact Type** (required) | The type of artifact to create. |
 | **Title** (required) | The artifact's title. |
 | **Description** (required) | The artifact's description. |
-| **Severity** (optional) | The severity assigned to the artifact. |
+| **Severity** (optional) | The severity assigned to the artifact. While a step uses a severity, that severity cannot be deleted in settings.^[[Manage artifact severities](/guide/validation/manage-artifact-severities.qmd)] |
 | **Assignee** (optional) | Who the artifact is assigned to. Leave it empty and the artifact is assigned to the user the workflow runs as — the workflow's author on a scheduled run, or the person whose action triggered it. |
 | **Artifact Fields** (optional) | Values for the artifact type's fields. If the artifact type marks a field as required on registration, give it a value here — the workflow cannot be saved until you do, because an artifact cannot be created without it. |
 : **{{< fa expand >}} Create Artifact** step configuration {.hover tbl-colwidths="[40,60]"}

--- a/site/guide/workflows/_workflow-step-types.qmd
+++ b/site/guide/workflows/_workflow-step-types.qmd
@@ -55,8 +55,8 @@ Typical **Manual review** pattern: earlier in the intake workflow, a reviewer ch
 | **Title** (required) | The artifact's title. |
 | **Description** (required) | The artifact's description. |
 | **Severity** (optional) | The severity assigned to the artifact. |
-| **Assignee** (optional) | Who the artifact is assigned to. Defaults to the user the workflow runs as. |
-| **Artifact Fields** (optional) | Values for the artifact type's fields. |
+| **Assignee** (optional) | Who the artifact is assigned to. Leave it empty and the artifact is assigned to the user the workflow runs as — the workflow's author on a scheduled run, or the person whose action triggered it. |
+| **Artifact Fields** (optional) | Values for the artifact type's fields. If the artifact type marks a field as required on registration, give it a value here — the workflow cannot be saved until you do, because an artifact cannot be created without it. |
 : **{{< fa expand >}} Create Artifact** step configuration {.hover tbl-colwidths="[40,60]"}
 
 ::: {.callout-important title="This step creates a new artifact every time it is reached"}
@@ -69,7 +69,7 @@ Take more care with conditions describing a **continuing state** — such as *no
 Note also that when a condition on this step does not pass, the workflow does not continue past that point — it stops there without reaching an **{{< fa circle-stop >}} End** step. Use a **{{< fa maximize >}} Condition Branch** ahead of the step when something else should happen on the other path, or when you want the workflow to finish cleanly either way.
 :::
 
-An artifact created by this step shows the workflow as its creator in the activity feed, and its detail page shows a **Source** section naming the workflow that raised it.
+An artifact created by this step shows the workflow as its creator in the activity feed, and its detail page shows a **Source** section naming the workflow that raised it, what triggered that workflow, when the artifact was raised, and a link to the run that created it.
 
 ### {{< fa tag >}} Artifact Status Change
 <span id="artifact-status-change">

--- a/site/guide/workflows/_workflow-step-types.qmd
+++ b/site/guide/workflows/_workflow-step-types.qmd
@@ -56,18 +56,17 @@ Typical **Manual review** pattern: earlier in the intake workflow, a reviewer ch
 | **Description** (required) | The artifact's description. |
 | **Severity** (optional) | The severity assigned to the artifact. |
 | **Assignee** (optional) | Who the artifact is assigned to. Defaults to the user the workflow runs as. |
-| **Field Values** (optional) | Values for the artifact type's fields. |
+| **Artifact Fields** (optional) | Values for the artifact type's fields. |
 : **{{< fa expand >}} Create Artifact** step configuration {.hover tbl-colwidths="[40,60]"}
 
 ::: {.callout-important title="This step creates a new artifact every time it is reached"}
 If the workflow runs repeatedly while the same situation persists, each run creates another artifact.
 
-Whether that is right depends on what your condition means:
+This suits conditions describing a **recurring event** — such as *the quarterly attestation was missed* — where each occurrence is a separate failure closed on its own terms, and one artifact per occurrence is what you want.
 
-- **A continuing state** — such as *no validator is assigned* — stays true until someone fixes it. A monthly workflow would raise the same artifact every month, so you want only the first one.
-- **A recurring event** — such as *the quarterly attestation was missed* — happens separately each time. Two missed quarters are two separate failures, each closed on its own terms, so you want one artifact per occurrence.
+Take more care with conditions describing a **continuing state** — such as *no validator is assigned* — which stays true until someone fixes it. A monthly workflow would raise the same artifact every month.
 
-To raise only one artifact while a state persists, add a **When These Conditions Are Met** condition on this step that checks a field counting open artifacts of that type — see [Raise only one artifact while a condition persists](/guide/workflows/workflow-configuration-examples.qmd#raise-only-one-artifact-while-a-condition-persists).
+Note also that when a condition on this step does not pass, the workflow does not continue past that point — it stops there without reaching an **{{< fa circle-stop >}} End** step. Use a **{{< fa maximize >}} Condition Branch** ahead of the step when something else should happen on the other path, or when you want the workflow to finish cleanly either way.
 :::
 
 An artifact created by this step shows the workflow as its creator in the activity feed, and its detail page shows a **Source** section naming the workflow that raised it.

--- a/site/guide/workflows/_workflow-step-types.qmd
+++ b/site/guide/workflows/_workflow-step-types.qmd
@@ -41,6 +41,37 @@ SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
 Typical **Manual review** pattern: earlier in the intake workflow, a reviewer chooses the path (for example with a **{{< fa arrow-pointer >}} User Action** or **{{< fa maximize >}} Condition Branch**). Configure each path's **Inventory Record Type Change** step with the matching fixed target type and **Manual review** so activity labels the conversion as after manual review.
 :::
 
+### {{< fa expand >}} Create Artifact
+<span id="create-artifact">
+
+- Creates an artifact on the inventory record the workflow is running against.
+- Available on **inventory record workflows only**. An artifact created by this step starts its own artifact workflow, so artifact workflows cannot themselves create artifacts.
+- Requires an artifact type that applies to the workflow's inventory record type.^[[Manage artifact types](/guide/validation/manage-artifact-types.qmd)]
+
+| Field | Description |
+|---:|---|
+| **When These Conditions Are Met** (optional) | Add conditional requirements to qualify for this step.^[ [Conditional step requirements](/guide/workflows/conditional-step-requirements.qmd#create-artifact)]  |
+| **Artifact Type** (required) | The type of artifact to create. |
+| **Title** (required) | The artifact's title. |
+| **Description** (required) | The artifact's description. |
+| **Severity** (optional) | The severity assigned to the artifact. |
+| **Assignee** (optional) | Who the artifact is assigned to. Defaults to the user the workflow runs as. |
+| **Field Values** (optional) | Values for the artifact type's fields. |
+: **{{< fa expand >}} Create Artifact** step configuration {.hover tbl-colwidths="[40,60]"}
+
+::: {.callout-important title="This step creates a new artifact every time it is reached"}
+If the workflow runs repeatedly while the same situation persists, each run creates another artifact.
+
+Whether that is right depends on what your condition means:
+
+- **A continuing state** — such as *no validator is assigned* — stays true until someone fixes it. A monthly workflow would raise the same artifact every month, so you want only the first one.
+- **A recurring event** — such as *the quarterly attestation was missed* — happens separately each time. Two missed quarters are two separate failures, each closed on its own terms, so you want one artifact per occurrence.
+
+To raise only one artifact while a state persists, add a **When These Conditions Are Met** condition on this step that checks a field counting open artifacts of that type — see [Raise only one artifact while a condition persists](/guide/workflows/workflow-configuration-examples.qmd#raise-only-one-artifact-while-a-condition-persists).
+:::
+
+An artifact created by this step shows the workflow as its creator in the activity feed, and its detail page shows a **Source** section naming the workflow that raised it.
+
 ### {{< fa tag >}} Artifact Status Change
 <span id="artifact-status-change">
 

--- a/site/guide/workflows/workflow-configuration-examples.qmd
+++ b/site/guide/workflows/workflow-configuration-examples.qmd
@@ -259,54 +259,7 @@ In this example, the workflow is designated to stop after running an additional 
 ::::
 
 
-## Raise only one artifact while a condition persists
-<span id="raise-only-one-artifact-while-a-condition-persists">
-
-The **{{< fa expand >}} Create Artifact** step creates a new artifact every time the workflow reaches it. When your workflow runs on a schedule and the situation it detects has not been resolved yet, that means a new artifact on every run.
-
-Whether you want that depends on what your condition means:
-
-| Your condition describes | Example | What you want |
-|---|---|---|
-| A **state** that stays true until fixed | *This inventory record has no validator assigned* | One artifact, until it is resolved |
-| An **event** that happens separately each time | *The Q1 attestation was missed* | A new artifact each time it happens |
-
-For the **event** case, no extra configuration is needed — the step already behaves this way.
-
-For the **state** case, tell the step to run only when there is not already an open artifact. This takes two parts, and the first is usually done by an administrator:
-
-**1. Add a field that counts open artifacts**
-
-Add an aggregate inventory field[^20] on the inventory record that counts its artifacts, filtered to the ones you care about — for example:
-
-> **Open Validator Issues** — count of *Validator Issue* artifacts with status *Open*
-
-Every inventory record now carries that count, and ValidMind keeps it up to date as artifacts are created and closed.
-
-**2. Add the condition to the step**
-
-Open the **{{< fa expand >}} Create Artifact** step and, under **When These Conditions Are Met**, add:
-
-> **Open Validator Issues** is **0**
-
-The workflow now creates the artifact the first time the situation is detected. On later runs, while that artifact is still open, the count is no longer `0`, the condition does not pass, the step does not run, and no duplicate is created. Once someone closes the artifact, the count returns to `0` and a fresh artifact can be raised if the situation happens again.
-
-::: {.callout-tip}
-Because this is an ordinary condition, you are not limited to "none open". You can require that fewer than a certain number are open, or combine the count with other inventory record fields.
-:::
-
-### When to use a Condition Branch instead
-
-The condition on the step decides whether *that step* runs. When it does not pass, the workflow does not continue past that point — it stops there without reaching an **{{< fa circle-stop >}} End** step.
-
-That is usually fine for a workflow whose only job is to raise an artifact when needed. Use a **{{< fa maximize >}} Condition Branch** ahead of the step instead when:
-
-- something else should happen when no artifact is raised — a notification, a field update, another step; or
-- you want the workflow to finish cleanly on both paths, by routing the other branch to an **{{< fa circle-stop >}} End** step.
-
 <!-- FOOTNOTES -->
-
-[^20]: [Manage inventory fields](/guide/inventory/manage-inventory-fields.qmd)
 
 [^1]: ![Adding a workflow that initiates on model registration](example_model-registration.png){fig-alt="A screenshot showing the modal for adding a workflow that initiates on model registration" .screenshot group="model-registration"}
 

--- a/site/guide/workflows/workflow-configuration-examples.qmd
+++ b/site/guide/workflows/workflow-configuration-examples.qmd
@@ -259,7 +259,54 @@ In this example, the workflow is designated to stop after running an additional 
 ::::
 
 
+## Raise only one artifact while a condition persists
+<span id="raise-only-one-artifact-while-a-condition-persists">
+
+The **{{< fa expand >}} Create Artifact** step creates a new artifact every time the workflow reaches it. When your workflow runs on a schedule and the situation it detects has not been resolved yet, that means a new artifact on every run.
+
+Whether you want that depends on what your condition means:
+
+| Your condition describes | Example | What you want |
+|---|---|---|
+| A **state** that stays true until fixed | *This inventory record has no validator assigned* | One artifact, until it is resolved |
+| An **event** that happens separately each time | *The Q1 attestation was missed* | A new artifact each time it happens |
+
+For the **event** case, no extra configuration is needed — the step already behaves this way.
+
+For the **state** case, tell the step to run only when there is not already an open artifact. This takes two parts, and the first is usually done by an administrator:
+
+**1. Add a field that counts open artifacts**
+
+Add an aggregate inventory field[^20] on the inventory record that counts its artifacts, filtered to the ones you care about — for example:
+
+> **Open Validator Issues** — count of *Validator Issue* artifacts with status *Open*
+
+Every inventory record now carries that count, and ValidMind keeps it up to date as artifacts are created and closed.
+
+**2. Add the condition to the step**
+
+Open the **{{< fa expand >}} Create Artifact** step and, under **When These Conditions Are Met**, add:
+
+> **Open Validator Issues** is **0**
+
+The workflow now creates the artifact the first time the situation is detected. On later runs, while that artifact is still open, the count is no longer `0`, the condition does not pass, the step does not run, and no duplicate is created. Once someone closes the artifact, the count returns to `0` and a fresh artifact can be raised if the situation happens again.
+
+::: {.callout-tip}
+Because this is an ordinary condition, you are not limited to "none open". You can require that fewer than a certain number are open, or combine the count with other inventory record fields.
+:::
+
+### When to use a Condition Branch instead
+
+The condition on the step decides whether *that step* runs. When it does not pass, the workflow does not continue past that point — it stops there without reaching an **{{< fa circle-stop >}} End** step.
+
+That is usually fine for a workflow whose only job is to raise an artifact when needed. Use a **{{< fa maximize >}} Condition Branch** ahead of the step instead when:
+
+- something else should happen when no artifact is raised — a notification, a field update, another step; or
+- you want the workflow to finish cleanly on both paths, by routing the other branch to an **{{< fa circle-stop >}} End** step.
+
 <!-- FOOTNOTES -->
+
+[^20]: [Manage inventory fields](/guide/inventory/manage-inventory-fields.qmd)
 
 [^1]: ![Adding a workflow that initiates on model registration](example_model-registration.png){fig-alt="A screenshot showing the modal for adding a workflow that initiates on model registration" .screenshot group="model-registration"}
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

Documents the new **Create Artifact** workflow step: what it does, what you configure on it, and where it can be used.

Also removes a section that described something you cannot actually do. It suggested suppressing repeat artifacts with a condition over a field counting open artifacts, but the workflow condition builder does not offer those fields, so the guard cannot be built in the UI. Rather than document a workaround that does not exist, the section is gone.

One useful fact was kept from it and moved into the step-types callout: when a step's condition blocks, the execution stops there without reaching an End step, so use a Condition Branch when the other path matters.

Also renames the config table row **Field Values** to **Artifact Fields**, to match the panel.

## How to test

[**Live preview of the changed page**](https://docs-staging.validmind.ai/pr_previews/juan/sc-17811/document-create-artifact-step/guide/workflows/workflow-step-types.html) — jump to the **Create Artifact** section. ([Preview home](https://docs-staging.validmind.ai/pr_previews/juan/sc-17811/document-create-artifact-step/index.html).)

Read that section against the panel in the product, and check `workflow-configuration-examples.qmd` is back to matching `main`.

## What needs special review?

Whether cutting the repeat-artifact section is the right call, or whether it should stay with a note that it is not yet buildable in the UI.

## Dependencies, breaking changes, and deployment notes

Describes a feature that is not released yet — hold until the platform change ships.

## Release notes

`documentation`

