### PR TITLE
Workflow capacity docs

### DIFF
--- a/site/guide/_sidebar.yaml
+++ b/site/guide/_sidebar.yaml
@@ -81,6 +81,7 @@ website:
                 - guide/workflows/manage-workflows.qmd
                 - guide/workflows/transition-workflows.qmd
                 - guide/workflows/manage-workflow-tasks.qmd
+                - guide/workflows/assign-workflow-executions.qmd
         - text: "---"
         - section: "Inventory"
           contents:

--- a/site/guide/workflows/_initiate-workflows.qmd
+++ b/site/guide/workflows/_initiate-workflows.qmd
@@ -25,6 +25,7 @@ To initiate workflows manually:[^initiate-workflows]
 
     - **Run Now** — Workflow starts instantly.
     - **Scheduled Run** — Set a future date to run the workflow.
+    - Optionally, under **Stakeholder**, select who this run is assigned to.[^workflow-assignee]
 
 1. Click **{{< fa arrow-right >}} Run Workflow Now** to confirm.
 
@@ -38,6 +39,7 @@ To initiate workflows manually:[^initiate-workflows]
 
     - **Run Now** — Workflow starts instantly.
     - **Scheduled Run** — Set a future date to run the workflow.
+    - Optionally, under **Stakeholder**, select who this run is assigned to.[^workflow-assignee]
 
 1. Click **{{< fa arrow-right >}} Run Workflow Now** to confirm.
 
@@ -50,6 +52,8 @@ To initiate workflows manually:[^initiate-workflows]
     ::: {.callout title="Workflows can be set to run automatically on specific triggers."}
     Refer to [Configure workflows](/guide/workflows/configure-workflows.qmd) for more details.
     :::
+
+[^workflow-assignee]: [Assign workflow executions](/guide/workflows/assign-workflow-executions.qmd)
 
 ::::
 
@@ -74,6 +78,7 @@ To initiate workflows manually:
 
     - **Run Now** — Workflow starts instantly.
     - **Scheduled Run** — Set a future date to run the workflow.
+    - Optionally, under **Stakeholder**, select who this run is assigned to ([more on assigning workflow executions](/guide/workflows/assign-workflow-executions.qmd){target="_blank"}).
 
 1. Click **{{< fa arrow-right >}} Run Workflow Now** to confirm.
 
@@ -87,6 +92,7 @@ To initiate workflows manually:
 
     - **Run Now** — Workflow starts instantly.
     - **Scheduled Run** — Set a future date to run the workflow.
+    - Optionally, under **Stakeholder**, select who this run is assigned to ([more on assigning workflow executions](/guide/workflows/assign-workflow-executions.qmd){target="_blank"}).
 
 1. Click **{{< fa arrow-right >}} Run Workflow Now** to confirm.
 

--- a/site/guide/workflows/_review-active-workflows.qmd
+++ b/site/guide/workflows/_review-active-workflows.qmd
@@ -21,7 +21,7 @@ To review details for workflows currently active:
 
 1. Click on the tab you would like to review:
 
-    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
+    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started. On scheduled, active, or waiting workflows, edit the **Start Date** and **Workflow Assignee** in place.[^workflow-assignee-active]
     - **Activity** — History of updates to the workflow on that record, including notes submitted during transitions.[^notes]
     - **Artifacts** — Artifacts for that record created within the duration of that workflow's runtime.
     - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
@@ -37,7 +37,7 @@ To review details for workflows currently active:
 
 1. Click on the tab you would like to review:
 
-    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
+    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started. On scheduled, active, or waiting workflows, edit the **Start Date** and **Workflow Assignee** in place.[^workflow-assignee-active]
     - **Activity** — History of updates to the workflow on that artifact, including notes submitted during transitions.[^notes]
     - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
         - Click on any visited step to open its **Step Detail** panel, showing when that step ran. If a step ran more than once in a loop, use the run pager (**Run 1 of 2**) to page through each pass.
@@ -57,6 +57,8 @@ To review details for workflows currently active:
     <br><br>
     [Transition workflows](/guide/workflows/transition-workflows.qmd)
 
+[^workflow-assignee-active]: [Assign workflow executions](/guide/workflows/assign-workflow-executions.qmd)
+
 ::::
 
 
@@ -73,7 +75,7 @@ To review details for workflows currently active on records:
 
 1. Click on the tab you would like to review:
 
-    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
+    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started. On scheduled, active, or waiting workflows, edit the **Start Date** and [**Workflow Assignee**](/guide/workflows/assign-workflow-executions.qmd){target="_blank"} in place.
     - **Activity** — History of updates to the workflow on that record, including notes submitted during transitions.
     - **Artifacts** — Artifacts for that record created within the duration of that workflow's runtime.
     - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
@@ -99,7 +101,7 @@ To review details for workflows currently active:
 
 1. Click on the tab you would like to review:
 
-    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
+    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started. On scheduled, active, or waiting workflows, edit the **Start Date** and [**Workflow Assignee**](/guide/workflows/assign-workflow-executions.qmd){target="_blank"} in place.
     - **Activity** — History of updates to the workflow on that record, including notes submitted during transitions.
     - **Artifacts** — Artifacts for that record created within the duration of that workflow's runtime.
     - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
@@ -115,7 +117,7 @@ To review details for workflows currently active:
 
 1. Click on the tab you would like to review:
 
-    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
+    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started. On scheduled, active, or waiting workflows, edit the **Start Date** and [**Workflow Assignee**](/guide/workflows/assign-workflow-executions.qmd){target="_blank"} in place.
     - **Activity** — History of updates to the workflow on that artifact, including notes submitted during transitions.
     - **Workflow** — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
         - Click on any visited step to open its **Step Detail** panel, showing when that step ran. If a step ran more than once in a loop, use the run pager (**Run 1 of 2**) to page through each pass.

--- a/site/guide/workflows/_view-workflow-executions.qmd
+++ b/site/guide/workflows/_view-workflow-executions.qmd
@@ -9,8 +9,9 @@ Monitor every workflow execution across your organization on a single timeline:^
 
 2. Under the **Inventory Record Type** drop-down, select the type of record you want to view all workflow executions for:^[[Manage inventory record types](/guide/inventory/manage-inventory-record-types.qmd)]
 
-    - In the left column, workflows are grouped by inventory record.
+    - In the left column, workflows are grouped by inventory record. Click **View by Workflow Assignee** to group them by who they're assigned to instead, with an **Unassigned** group for runs with no assignee.[^workflow-assignee-view]
     - Workflows past their **Expected End Date** are color-coded in [red]{.red}.^[[Manage workflows](/guide/workflows/manage-workflows.qmd#edit-workflow-end-dates)]
+    - Hover over any execution to see its details, including its assigned stakeholder if one is set.
     - Use the buttons or keyboard shortcuts[^timeline-shortcuts-all] to control the timeline:
       - **{{< fa magnifying-glass-plus >}}** — Zoom in
       - **{{< fa magnifying-glass-minus >}}** — Zoom out
@@ -19,6 +20,7 @@ Monitor every workflow execution across your organization on a single timeline:^
       - **{{< fa arrow-right >}}** — Move later to the right
      - **{{< fa magnifying-glass >}} Search** — Search for records using keywords in the record name.
      - **{{< fa filter >}} Filter** — Filter the view to display only runs from specific types and statuses of workflows.[^filter-criteria]
+     - **Export** — Download a CSV of the current search and filters, including each execution's assigned stakeholder.[^workflow-assignee-view]
 
 <br>
 
@@ -32,7 +34,7 @@ Monitor every workflow execution across your organization on a single timeline:^
 
 3. Click on any listed workflow to review the details of that specific workflow:
 
-    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
+    - **Details** — Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started. On scheduled, active, or waiting workflows, edit the **Start Date** and **Workflow Assignee** in place.[^workflow-assignee-view]
     - **Activity** — History of updates to the workflow on that record, including notes submitted during transitions.[^activity-notes]
     - **Artifacts** [record workflows only]{.smallercaps .pink} — Artifacts for that record created within the duration of that workflow's runtime.
     - **Workflow**^[Hover over a workflow step to view an animation of the steps connecting to and from that step.] — Overview of the entire workflow. The current workflow step is highlighted, the path the execution has taken is shown in [green]{.green}, and branches the execution did not take are dimmed.
@@ -62,12 +64,15 @@ Monitor every workflow execution across your organization on a single timeline:^
             - Finished
             - Active
             - Scheduled
+        - By **Workflow Assignee**, including **Unassigned** runs.[^workflow-assignee-view]
 
 [^activity-notes]:
 
     Click **{{< fa chevron-down >}}** to reveal notes, and **{{< fa chevron-up >}}** to hide them.
     <br><br>
     [Transition workflows](/guide/workflows/transition-workflows.qmd)
+
+[^workflow-assignee-view]: [Assign workflow executions](/guide/workflows/assign-workflow-executions.qmd)
 
 ::::
 
@@ -79,8 +84,9 @@ Monitor every workflow execution across your organization on a single timeline:
 
 2. Under the **Inventory Record Type** drop-down, select the type of record you want to view all workflow executions for:
 
-    - In the left column, workflows are grouped by inventory record.
+    - In the left column, workflows are grouped by inventory record. Click **View by Workflow Assignee** to group them by who they're assigned to instead, with an **Unassigned** group for runs with no assignee.
     - Workflows past their **Expected End Date** are color-coded in [red]{.red}.
+    - Hover over any execution to see its details, including its assigned stakeholder if one is set.
 
 ::: {.panel-tabset}
 
@@ -121,7 +127,11 @@ Use the buttons or keyboard shortcuts to control the timeline:
 
 #### Filter the timeline
 
-**{{< fa filter >}} Filter** — Filter the view to display only runs from specific types and statuses of workflows.
+**{{< fa filter >}} Filter** — Filter the view to display only runs from specific types and statuses of workflows, including by [Workflow Assignee](/guide/workflows/assign-workflow-executions.qmd){target="_blank"}, with an **Unassigned** option.
+
+#### Export the timeline
+
+**Export** — Download a CSV of the current search and filters, including each execution's assigned stakeholder.
 
 :::
 
@@ -131,7 +141,7 @@ Use the buttons or keyboard shortcuts to control the timeline:
 
 #### Details
 
-Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started.
+Name and description (if present) of the workflow, the workflow's status and progress (if applicable), when it was created, and when it was started. On scheduled, active, or waiting workflows, edit the **Start Date** and [**Workflow Assignee**](/guide/workflows/assign-workflow-executions.qmd){target="_blank"} in place.
 
 #### Activity
 

--- a/site/guide/workflows/assign-workflow-executions.qmd
+++ b/site/guide/workflows/assign-workflow-executions.qmd
@@ -1,0 +1,78 @@
+---
+# Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+# Refer to the LICENSE file in the root of this repository for details.
+# SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
+title: "Assign workflow executions"
+date: last-modified
+---
+
+Assign a stakeholder to an individual workflow run to track who's responsible for it, then view, filter, and export workflows across your organization by that assignment.
+
+::: {.attn}
+
+## Prerequisites
+
+- [x] {{< var link.login >}}
+- [x] Workflows have already been set up for use with your records or artifacts.[^1]
+- [x] The record or artifact you're assigning against has at least one stakeholder.[^2]
+- [x] You are assigned a role with sufficient permissions to run and manage workflows on records or artifacts.[^3]
+
+:::
+
+## Assign or change a workflow assignee
+
+### When starting or rescheduling a workflow
+
+While [initiating a workflow](manage-workflows.qmd#initiate-workflows),[^4] the **Run Workflow** dialog includes a **Stakeholder** field, populated from the target record or artifact's existing stakeholders.[^2] Leave it as **Unassigned** to skip assignment, or choose a person to make them that execution's *workflow assignee*.
+
+The workflow assignee is separate from any stakeholder-type role — such as Record Owner — that person may separately hold on the record itself.[^5]
+
+### On scheduled, active, or waiting workflows
+
+Change the assignee, or the run's kickoff date, without creating a new execution:
+
+1. Open the workflow execution you want to update.[^6]
+
+2. On the **Details** tab, update either or both:
+
+    - **Start Date** — For a scheduled workflow, this must be a future date. For an active or waiting workflow, this is the actual kickoff time: it can be backdated, but not moved more than 24 hours into the future.
+    - **Workflow Assignee** — Choose a new person, or **Unassigned** to clear the assignment.
+
+3. Click **Save Changes** to apply your edits, or **Cancel** to discard them.
+
+Changes to the assignee or kickoff date are recorded on the workflow's **Activity** tab.[^7]
+
+## View workflows by assignee
+
+On the [global Workflows timeline](working-with-workflows.qmd#view-all-workflow-executions),[^8] click **View by Workflow Assignee** to group executions by who they're assigned to instead of by record:
+
+- Workflows with no assignee are grouped under **Unassigned**.
+- The sidebar shows a running count of the workflow assignees represented in the current view.
+- Hover over any execution bar to see who it's **Assigned** to, along with their stakeholder role.
+
+## Filter workflows by assignee
+
+In the timeline's filter panel, use the **Workflow Assignee** field to narrow the view to a specific person, or select **Unassigned** to see only unassigned runs.
+
+## Export workflows by assignee
+
+Click **Export** to download a CSV of the currently searched and filtered view, including each execution's assignee. The file downloads automatically once it's ready; large exports may take a few moments to generate.
+
+
+<!-- FOOTNOTES -->
+
+[^1]: [Configure workflows](configure-workflows.qmd)
+
+[^2]: [Manage stakeholder types on records](/guide/configuration/manage-record-stakeholder-types.qmd#manage-stakeholder-types-on-records)
+
+[^3]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
+
+[^4]: [Manage workflows](manage-workflows.qmd#initiate-workflows)
+
+[^5]: [Manage record stakeholder types](/guide/configuration/manage-record-stakeholder-types.qmd)
+
+[^6]: [Review active workflows](manage-workflows.qmd#review-active-workflows), or from the [global Workflows timeline](working-with-workflows.qmd#view-all-workflow-executions)
+
+[^7]: [Review workflow histories](manage-workflows.qmd#review-workflow-histories)
+
+[^8]: [View all workflow executions](working-with-workflows.qmd#view-all-workflow-executions)

--- a/site/guide/workflows/assign-workflow-executions.qmd
+++ b/site/guide/workflows/assign-workflow-executions.qmd
@@ -40,13 +40,18 @@ Change the assignee, or the run's kickoff date, without creating a new execution
 
 3. Click **Save Changes** to apply your edits, or **Cancel** to discard them.
 
-Changes to the assignee or kickoff date are recorded on the workflow's **Activity** tab.[^7]
+::: {.callout title="Note"}
+On a scheduled workflow, **Reschedule** is still available as a separate action for moving the run's date or starting it immediately — the Details tab is for quick corrections, while Reschedule also offers **Run Now**.
+:::
+
+Changes to the assignee or kickoff date are recorded on the workflow's **Activity** tab, including the execution ID and the previous and new values for each change.[^7]
 
 ## View workflows by assignee
 
 On the [global Workflows timeline](working-with-workflows.qmd#view-all-workflow-executions),[^8] click **View by Workflow Assignee** to group executions by who they're assigned to instead of by record:
 
 - Workflows with no assignee are grouped under **Unassigned**.
+- Each section is headed by the assignee's name and a count of their workflows (for example, "Kam Lall — 4 workflows").
 - The sidebar shows a running count of the workflow assignees represented in the current view.
 - Hover over any execution bar to see who it's **Assigned** to, along with their stakeholder role.
 

--- a/site/guide/workflows/working-with-workflows.qmd
+++ b/site/guide/workflows/working-with-workflows.qmd
@@ -15,6 +15,7 @@ listing:
     - manage-workflows.qmd
     - transition-workflows.qmd
     - manage-workflow-tasks.qmd
+    - assign-workflow-executions.qmd
 aliases:
   - /guide/working-with-model-workflows.html
   - /guide/model-workflows/working-with-model-workflows.html

--- a/site/llm/chatbot-product-map-frontend-snapshot.json
+++ b/site/llm/chatbot-product-map-frontend-snapshot.json
@@ -1,16 +1,10 @@
 {
   "version": 1,
-  "generated_at": "2026-06-09T21:25:44.848926+00:00",
+  "generated_at": "2026-08-24T20:42:34.503551+00:00",
   "settings": [
     {
       "path": "/settings/profile",
       "label": "Profile",
-      "group": "Your Account",
-      "primary_docs": []
-    },
-    {
-      "path": "/settings/theme-customization",
-      "label": "Theme Customization",
       "group": "Your Account",
       "primary_docs": []
     },
@@ -132,6 +126,12 @@
       "primary_docs": []
     },
     {
+      "path": "/settings/risk-tier-stages",
+      "label": "Risk Tier Stages",
+      "group": "Governance",
+      "primary_docs": []
+    },
+    {
       "path": "/settings/workflows",
       "label": "Workflows",
       "group": "Governance",
@@ -188,14 +188,20 @@
       "primary_docs": []
     },
     {
-      "path": "/attestations",
-      "label": "Attestations",
+      "path": "/artifacts",
+      "label": "Artifacts",
       "group": "Main navigation",
       "primary_docs": []
     },
     {
-      "path": "/artifacts",
-      "label": "Artifacts",
+      "path": "/activity",
+      "label": "Activity",
+      "group": "Main navigation",
+      "primary_docs": []
+    },
+    {
+      "path": "/attestations",
+      "label": "Attestations",
       "group": "Main navigation",
       "primary_docs": []
     },
@@ -206,8 +212,50 @@
       "primary_docs": []
     },
     {
-      "path": "/activity",
-      "label": "Activity",
+      "path": "/agent-authority/invocations",
+      "label": "Agent Authority",
+      "group": "Main navigation",
+      "primary_docs": []
+    },
+    {
+      "path": "/risk-intelligence",
+      "label": "Risk Intelligence",
+      "group": "Main navigation",
+      "primary_docs": []
+    },
+    {
+      "path": "/agent-authority/invocations",
+      "label": "Invocations",
+      "group": "Main navigation",
+      "primary_docs": []
+    },
+    {
+      "path": "/agent-authority/agents",
+      "label": "Agents",
+      "group": "Main navigation",
+      "primary_docs": []
+    },
+    {
+      "path": "/agent-authority/servers",
+      "label": "Servers",
+      "group": "Main navigation",
+      "primary_docs": []
+    },
+    {
+      "path": "/agent-authority/rules",
+      "label": "Rules",
+      "group": "Main navigation",
+      "primary_docs": []
+    },
+    {
+      "path": "/agent-authority/charters",
+      "label": "Charters",
+      "group": "Main navigation",
+      "primary_docs": []
+    },
+    {
+      "path": "/agent-authority/settings",
+      "label": "Settings",
       "group": "Main navigation",
       "primary_docs": []
     },

--- a/site/llm/chatbot-product-map.md
+++ b/site/llm/chatbot-product-map.md
@@ -66,7 +66,7 @@
 **Docs (primary):**
 
 - `/installation/security/configure-single-sign-on-sso.html`
-  - Sections: What is SSO?; Prerequisites; Step 1: Set up Microsoft Entra for SSO; Step 2: Contact ValidMind to enable SSO
+  - Note: no matching `.qmd` source found
 
 **Docs (related):**
 
@@ -388,6 +388,10 @@
 - `/guide/model-validation/manage-validation-guidelines.html`
   - Note: no matching `.qmd` source found
 
+#### `/settings/risk-tier-stages` — Risk Tier Stages
+
+- *No direct help link; content may be covered under scattered guide sections.*
+
 #### `/settings/risk-tier-templates` — Risk Tier Templates
 
 **Docs (related):**
@@ -463,12 +467,6 @@
 - `/guide/templates/manage-text-block-library.html`
   - Sections: Prerequisites; Add text blocks; Add existing text blocks to library; Duplicate text blocks; Edit text blocks; Delete text blocks
 
-### Your Account
-
-#### `/settings/theme-customization` — Theme Customization
-
-- *No direct help link; content may be covered under scattered guide sections.*
-
 ### Users & Access
 
 #### `/settings/user-directory` — User Directory
@@ -495,14 +493,14 @@
   - Sections: Can I customize workflows within }?; What record stages are available for use in workflows?; Can we work with disconnected workflows?; You can also leverage the } once you are ready to document a specific record (model) for review and validation.; Learn more
 - `/guide/integrations/integrations-examples/use-webhooks-with-workflows.html`
   - Sections: Prerequisites; Start a workflow via webhook; 1. Configure workflow in }; 2. Start workflow from external system; Trigger a paused workflow to continue; 1. Configure workflow in }; 2. Trigger workflow to continue from external system
+- `/guide/workflows/assign-workflow-executions.html`
+  - Sections: Prerequisites; Assign or change a workflow assignee; When starting or rescheduling a workflow; On scheduled, active, or waiting workflows; View workflows by assignee; Filter workflows by assignee; Export workflows by assignee
 - `/guide/workflows/conditional-step-requirements.html`
   - Sections: Prerequisites; Configure conditional requirements
 - `/guide/workflows/configure-workflows.html`
   - Sections: Prerequisites; Create custom workflows; 1. Add new workflows; 2. Configure workflow steps; 3. Link workflow together; Workflow steps relationship unclear on your canvas?; 4. Publish workflow; Clone existing workflows
 - `/guide/workflows/introduction-to-workflows.html`
   - Sections: Workflow elements; What's next
-- `/guide/workflows/manage-record-stages.html`
-  - Sections: Prerequisites; Add record stages; Edit or delete record stages
 
 #### `/settings/workflows` — Workflows
 
@@ -517,14 +515,14 @@
   - Sections: Can I customize workflows within }?; What record stages are available for use in workflows?; Can we work with disconnected workflows?; You can also leverage the } once you are ready to document a specific record (model) for review and validation.; Learn more
 - `/guide/integrations/integrations-examples/use-webhooks-with-workflows.html`
   - Sections: Prerequisites; Start a workflow via webhook; 1. Configure workflow in }; 2. Start workflow from external system; Trigger a paused workflow to continue; 1. Configure workflow in }; 2. Trigger workflow to continue from external system
+- `/guide/workflows/assign-workflow-executions.html`
+  - Sections: Prerequisites; Assign or change a workflow assignee; When starting or rescheduling a workflow; On scheduled, active, or waiting workflows; View workflows by assignee; Filter workflows by assignee; Export workflows by assignee
 - `/guide/workflows/conditional-step-requirements.html`
   - Sections: Prerequisites; Configure conditional requirements
 - `/guide/workflows/configure-workflows.html`
   - Sections: Prerequisites; Create custom workflows; 1. Add new workflows; 2. Configure workflow steps; 3. Link workflow together; Workflow steps relationship unclear on your canvas?; 4. Publish workflow; Clone existing workflows
 - `/guide/workflows/introduction-to-workflows.html`
   - Sections: Workflow elements; What's next
-- `/guide/workflows/manage-record-stages.html`
-  - Sections: Prerequisites; Add record stages; Edit or delete record stages
 
 ## Main application
 
@@ -540,6 +538,30 @@
   - Sections: What is tracked on settings activity?; Prerequisites; View settings activity
 
 - *No direct help link in frontend; related docs inferred from keywords.*
+
+#### `/agent-authority/agents` — Agents
+
+- *No direct help link; content may be covered under scattered guide sections.*
+
+#### `/agent-authority/charters` — Charters
+
+- *No direct help link; content may be covered under scattered guide sections.*
+
+#### `/agent-authority/invocations` — Agent Authority
+
+- *No direct help link; content may be covered under scattered guide sections.*
+
+#### `/agent-authority/rules` — Rules
+
+- *No direct help link; content may be covered under scattered guide sections.*
+
+#### `/agent-authority/servers` — Servers
+
+- *No direct help link; content may be covered under scattered guide sections.*
+
+#### `/agent-authority/settings` — Settings
+
+- *No direct help link; content may be covered under scattered guide sections.*
 
 #### `/analytics` — sidebar.analytics
 
@@ -607,6 +629,10 @@
 
 - *No direct help link in frontend; related docs inferred from keywords.*
 
+#### `/risk-intelligence` — Risk Intelligence
+
+- *No direct help link; content may be covered under scattered guide sections.*
+
 #### `/validation-issues` — Validation Issues
 
 - *No direct help link; content may be covered under scattered guide sections.*
@@ -619,14 +645,14 @@
   - Sections: Can I customize workflows within }?; What record stages are available for use in workflows?; Can we work with disconnected workflows?; You can also leverage the } once you are ready to document a specific record (model) for review and validation.; Learn more
 - `/guide/integrations/integrations-examples/use-webhooks-with-workflows.html`
   - Sections: Prerequisites; Start a workflow via webhook; 1. Configure workflow in }; 2. Start workflow from external system; Trigger a paused workflow to continue; 1. Configure workflow in }; 2. Trigger workflow to continue from external system
+- `/guide/workflows/assign-workflow-executions.html`
+  - Sections: Prerequisites; Assign or change a workflow assignee; When starting or rescheduling a workflow; On scheduled, active, or waiting workflows; View workflows by assignee; Filter workflows by assignee; Export workflows by assignee
 - `/guide/workflows/conditional-step-requirements.html`
   - Sections: Prerequisites; Configure conditional requirements
 - `/guide/workflows/configure-workflows.html`
   - Sections: Prerequisites; Create custom workflows; 1. Add new workflows; 2. Configure workflow steps; 3. Link workflow together; Workflow steps relationship unclear on your canvas?; 4. Publish workflow; Clone existing workflows
 - `/guide/workflows/introduction-to-workflows.html`
   - Sections: Workflow elements; What's next
-- `/guide/workflows/manage-record-stages.html`
-  - Sections: Prerequisites; Add record stages; Edit or delete record stages
 
 - *No direct help link in frontend; related docs inferred from keywords.*
 

--- a/site/llm/chatbot-product-map.md
+++ b/site/llm/chatbot-product-map.md
@@ -66,7 +66,7 @@
 **Docs (primary):**
 
 - `/installation/security/configure-single-sign-on-sso.html`
-  - Note: no matching `.qmd` source found
+  - Sections: What is SSO?; Prerequisites; Step 1: Set up Microsoft Entra for SSO; Step 2: Contact ValidMind to enable SSO
 
 **Docs (related):**
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

Documents the workflow-execution "assign a stakeholder" feature set (internally tracked as capacity planning for workflow assignment) that has already shipped to `main` in both `backend` and `frontend`, spanning SC-17687–17690, SC-17692, SC-17693, SC-17837, and (partially — see below) SC-17838. There was previously no user documentation for any of this.

**New page** — [`guide/workflows/assign-workflow-executions.qmd`](https://github.com/validmind/documentation/blob/workflow-capacity-docs/site/guide/workflows/assign-workflow-executions.qmd), added as a new card in **Guides → Workflows → Working with workflows**, covering:

- Assigning a **Stakeholder** when starting or rescheduling a workflow (SC-17687).
- Editing the **Start Date** and **Workflow Assignee** in place on the Details tab of a scheduled, active, or waiting execution, and how that relates to the separate **Reschedule** action (SC-17688, superseded by SC-17837's inline editor).
- Grouping the global Workflows timeline by assignee via **View by Workflow Assignee**, including the per-assignee workflow count and the **Unassigned** bucket (SC-17689).
- Filtering the timeline by **Workflow Assignee**, including **Unassigned** (SC-17690).
- What's recorded on the Activity tab — execution ID plus before/after values for assignee and kickoff-date changes (SC-17692).
- Exporting the current filtered/searched view to CSV (SC-17693).

**Updated existing pages** to surface the same capability where it now shows up in the product:
- `_initiate-workflows.qmd` — the **Stakeholder** field on the Run Workflow dialog, on both the records and artifacts tabs.
- `_view-workflow-executions.qmd` — the View-by-Assignee toggle, the assignee filter, the Export action, the tooltip, and the editable Details tab.
- `_review-active-workflows.qmd` — the editable Details tab, reached from a record's or artifact's own Active Workflows section.

Both edited files carry the guide's dual HTML/training(revealjs) content, so each addition is duplicated into both blocks.

**Also regenerated** `site/llm/chatbot-product-map.md` and its frontend snapshot (`make -C site refresh-chatbot-product-map`, against a freshly `main`-synced `frontend` checkout) so the in-app assistant's route map picks up the new page under `/workflows` and `/settings/workflows`.

## How to test

Render the touched pages locally:
```
cd site && quarto render guide/workflows/assign-workflow-executions.qmd guide/workflows/working-with-workflows.qmd guide/workflows/manage-workflows.qmd --profile development
```
All three render clean (verified this session — only the pre-existing, unrelated `Unable to resolve link target: validmind/validmind.qmd` warning).

Live preview, once the PR preview build finishes:
- [Assign workflow executions](https://docs-staging.validmind.ai/pr_previews/workflow-capacity-docs/guide/workflows/assign-workflow-executions.html) (new page)
- [Working with workflows](https://docs-staging.validmind.ai/pr_previews/workflow-capacity-docs/guide/workflows/working-with-workflows.html) (new card in the grid + sidebar)
- [Manage workflows](https://docs-staging.validmind.ai/pr_previews/workflow-capacity-docs/guide/workflows/manage-workflows.html) (updated Details/Initiate/Active-workflows content)

On each, confirm: the new page appears in the sidebar and the grid listing after "Manage workflow tasks"; cross-reference links resolve (`manage-workflows.qmd#initiate-workflows`, `working-with-workflows.qmd#view-all-workflow-executions`, `manage-record-stakeholder-types.qmd#manage-stakeholder-types-on-records`); and the training/revealjs profile still renders the same content without footnotes.

## What needs special review?

- **Product-accuracy pass**: this content was verified against the merged frontend/backend source (field labels, copy strings, validation rules, `ExecutionStatus`/`canEditExecutionSchedule` gating) rather than a live click-through against a running stack. Worth a check against the actual product before merging.
- **Terminology inconsistency in the product itself**: the Run Workflow dialog labels the field **Stakeholder**; the Details-tab editor, filter, toggle, and export all call the same concept **Workflow Assignee**. The docs bridge this explicitly rather than papering over it — flagging in case this is also worth a product-side fix.
- **Scope decision on SC-17838**: only the Artifact-workflow half is documented (the Stakeholder field already covers "On artifacts"). The Risk Tier Assessment half is intentionally *not* documented — running workflows on a Risk Tier Assessment is itself a separate, still dark-launched capability (`launchdarklyRolloutRiskTierEngineWorkflows`, default off) that isn't documented as a feature anywhere in the site yet, including the recently-shipped Risk Tiering section. Documenting stakeholder assignment there first would require documenting that assessment workflows exist at all.
- **`chatbot-product-map.md` diff is broader than this feature**: the committed snapshot was stale against an older `frontend` `main`, so regenerating it also fixed a pre-existing broken reference (a deleted SSO page that now honestly reads "no matching `.qmd` source found" instead of pointing at nothing) and surfaced several unrelated new routes (`/agent-authority/*`, `/risk-intelligence`, `/settings/risk-tier-stages`) that simply didn't exist last time this was regenerated. None of that is scope creep from this PR's content — it's a byproduct of syncing to current `main`.

## Dependencies, breaking changes, and deployment notes

Documents already-merged engineering work; no companion PR required, no migrations, no environment variables.

- Backend: [#3425](https://github.com/validmind/backend/pull/3425) (SC-17687), [#3435](https://github.com/validmind/backend/pull/3435) (SC-17688), [#3447](https://github.com/validmind/backend/pull/3447) (SC-17689), [#3453](https://github.com/validmind/backend/pull/3453) (SC-17690), [#3454](https://github.com/validmind/backend/pull/3454) (SC-17692), [#3455](https://github.com/validmind/backend/pull/3455) (SC-17693), [#3480](https://github.com/validmind/backend/pull/3480) (SC-17838)
- Frontend: [#2776](https://github.com/validmind/frontend/pull/2776) (SC-17687), [#2781](https://github.com/validmind/frontend/pull/2781) (SC-17688), [#2788](https://github.com/validmind/frontend/pull/2788) (SC-17689), [#2790](https://github.com/validmind/frontend/pull/2790) (SC-17690), [#2791](https://github.com/validmind/frontend/pull/2791) (SC-17692), [#2792](https://github.com/validmind/frontend/pull/2792) (SC-17693), [#2811](https://github.com/validmind/frontend/pull/2811) (SC-17837), [#2812](https://github.com/validmind/frontend/pull/2812) (SC-17838)

## Release notes

Added documentation for assigning a stakeholder to a workflow run, editing it afterward, and viewing, filtering, and exporting workflows by assignee. [Learn more ...](/guide/workflows/assign-workflow-executions.qmd)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend) — N/A, documentation-only change
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [ ] PR linked to Shortcut — documents multiple engineering stories (see above); no single doc-tracking ticket
- [ ] Unit tests added (Backend) — N/A
- [ ] Tested locally — rendered with `quarto render`, not click-tested against a live preview or running stack; see "What needs special review"
- [x] Documentation updated (if required) — this PR is the documentation
- [x] Environment variable additions/changes documented (if required) — none
