### PR TITLE
Document Checker: DOCX/PDF export and question selection (sc-17831)

### DIFF
--- a/site/guide/documentation/_check-documents.qmd
+++ b/site/guide/documentation/_check-documents.qmd
@@ -74,7 +74,16 @@ Use the feedback provided by the {{< var validmind.checker >}} to review the app
 
 ### 4. (Optional) Export results
 
-To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**. To export only some questions, select the questions you want and click **Export _n_ selected**, where `n` is the number of questions you selected.
+To export the results of the {{< var vm.checker >}} for usage outside of the {{< var validmind.platform >}}, follow these steps:
+
+a. To export all questions, click **{{< fa download >}} Export All**. To export only some questions, first select the questions you want by clicking their checkboxes, then click **Export _n_ selected**, where `n` is the number of questions you selected.
+
+a. In the **Export Document Checker** modal that appears, choose your file format:
+
+   - **DOCX** — Microsoft Word format (recommended for editing)
+   - **PDF** — Portable Document Format (recommended for sharing and printing)
+
+a. Click **{{< fa file-arrow-down >}} Download File** to download the exported file.
 
 The exported file reflects the saved results of that run, including any artifacts created from it.^[[Create artifacts from a run](/guide/documentation/check-documents-for-compliance.qmd#create-artifacts-from-a-run)]
 
@@ -130,7 +139,7 @@ Use the feedback provided by the {{< var validmind.checker >}} to review the app
 
 #### 3. (Optional) Export results
 
-To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**.
+To export the results of the {{< var vm.checker >}} for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All** to export all questions, or select specific questions first and then click **Export _n_ selected**. In the **Export Document Checker** modal, choose **DOCX** (Microsoft Word) or **PDF** (Portable Document Format), then click **Download File**.
 
 :::
 
@@ -184,7 +193,7 @@ Use the feedback provided by the {{< var validmind.checker >}} to review the app
 
 #### 3. (Optional) Export results
 
-To export the results of the {{< var vm.checker >}} to a `.pdf` (Portable Document Format) file for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All**.
+To export the results of the {{< var vm.checker >}} for usage outside of the {{< var validmind.platform >}}, click **{{< fa download >}} Export All** to export all questions, or select specific questions first and then click **Export _n_ selected**. In the **Export Document Checker** modal, choose **DOCX** (Microsoft Word) or **PDF** (Portable Document Format), then click **Download File**.
 
 :::
 


### PR DESCRIPTION
## Summary

Updated Document Checker export guidance to document the new DOCX/PDF export modal and per-question selection feature shipped in sc-17831.

- **Frontend PRs:** validmind/frontend#2809 (checkbox fix + docs links), validmind/frontend#2810 (export modal)
- **Backend PR:** validmind/backend#3479 (DOCX generation)
- **Story:** https://app.shortcut.com/validmind/story/17831
- **Tracker:** https://app.shortcut.com/validmind/story/17996

## Changes

Updated `site/guide/documentation/_check-documents.qmd` to document:
- DOCX and PDF export format selection (new modal)
- Per-question selection via checkboxes for scoped exports
- Download workflow with file format preview

The include is consumed by three pages:
1. `guide/documentation/check-documents-for-compliance.qmd`
2. `training/developer-fundamentals/finalizing-documentation.qmd`
3. `training/validator-fundamentals/finalizing-validation-reports.qmd`

All three pages validated with quarto render.

## Release notes

`documentation`

Document Checker results can now be exported as DOCX or PDF, with the option to select which questions to include in the export.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmPREobo2AJE6PBnGkvWWC