### PR TITLE
Template PDF upload: cancel stuck parse jobs (sc-17216)

### DIFF
--- a/site/guide/templates/manage-documents.qmd
+++ b/site/guide/templates/manage-documents.qmd
@@ -67,9 +67,9 @@ c. Choose to:
 
         If you need to stop an in-progress PDF conversion:
 
-        i. In the conversion progress banner that appears at the top of the document page, click **Cancel**.
-        ii. On the Cancel File Conversion modal, optionally toggle **Delete file from this document** on to also remove the uploaded PDF file.[^13]
-        iii. Click **Cancel Conversion** to confirm.
+        i. **Option 1 — During conversion**: In the conversion progress banner that appears at the top of the document page, click **Cancel**. On the modal that appears, optionally toggle **Delete file from this document** on to also remove the uploaded PDF file,[^13] then click **Cancel Conversion** to confirm.
+
+        ii. **Option 2 — From My Inbox**: Open **My Inbox** in the top navigation. Find the active PDF conversion item and click **Cancel**. The item will show "cancelled" status and will not resume later — even if background workers become available after a temporary outage.
 
 ::: {.callout-button .pl4 .nt4}
 ::: {.callout collapse="true" appearance="minimal"}
@@ -113,7 +113,12 @@ PDF upload completes but conversion fails
 ::: {.embed-tip}
 ### My PDF conversion is stuck. What can I do?
 
-If a conversion appears to be stuck, click **Cancel** in the conversion progress banner to stop processing and try again with a revised PDF.
+If a conversion appears to be stuck, you have two options:
+
+1. If the progress banner is still visible at the top of the document page, click **Cancel** to stop processing immediately.
+2. If the banner is not visible, open **My Inbox** and find the active conversion item, then click **Cancel** to stop it from there. A cancelled conversion will not resume later, even if background workers were temporarily unavailable.
+
+After cancelling, try again with a revised PDF or check the error message to see what may have caused the failure.
 :::
 
 <br>


### PR DESCRIPTION
## Summary

Updated PDF template upload guidance to document cancellation of stuck or queued parse jobs via My Inbox, with assurance that cancelled conversions won't be resumed later.

- **Backend PR:** validmind/backend#3415 (durable cancel markers, better error handling)
- **Frontend PR:** validmind/frontend#2767 (Cancel button in My Inbox)
- **Story:** https://app.shortcut.com/validmind/story/17216
- **Tracker:** https://app.shortcut.com/validmind/story/17996

## Changes

Updated `site/guide/templates/manage-documents.qmd`:
- Documented two cancellation paths: banner (during active conversion) and My Inbox (for stuck/queued jobs)
- Clarified that cancelled conversions won't be resumed later
- Expanded "stuck conversion" tip with both methods and recovery guidance

Page validated with quarto render.

## Release notes

`documentation`

Template PDF conversions can now be cancelled from My Inbox if they get stuck or queued. Cancelled conversions stay cancelled and won't resume later even if background workers become available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmPREobo2AJE6PBnGkvWWC