### PR TITLE
Artifact activity log: core-field and stakeholder change details (sc-17622)

### DIFF
--- a/site/guide/reporting/_view-record-activity-overview.qmd
+++ b/site/guide/reporting/_view-record-activity-overview.qmd
@@ -9,7 +9,7 @@ Record activity shows a history of activities for inventory records, including a
 - Updates to documents: documentation, validation reports, ongoing monitoring reports, or custom documents
 - Test results or metrics added via the {{< var vm.developer >}}
 - Artifacts added, updated, or removed
-- Artifact field changes, including before and after values
+- Artifact field changes with before and after values — including core fields (Title, Description, Severity, Status, Risk Area, Due Date) and stakeholders (Assignee, Creator)
 - User comment creation and replies on documents
 - Stakeholders added or removed
 - Workflow activity

--- a/site/guide/validation/update-artifacts.qmd
+++ b/site/guide/validation/update-artifacts.qmd
@@ -99,7 +99,7 @@ The default maximum upload size is 100 MB per file. The limit shown in {{< var v
 
 ## View artifact activity
 
-Changes to artifact fields are logged so that you can audit who changed which field, when, and what the values were before and after the change:
+Changes to artifact fields — including core fields such as Severity, Status, Due Date, and stakeholders such as Assignee and Creator — are logged so that you can audit who changed which field, when, and what the values were before and after the change:
 
 1. Locate the artifact whose activity you want to view.[^view-activity-locate]
 


### PR DESCRIPTION
## Summary

Updated activity log guidance to clarify that artifact core field and stakeholder changes now display with before/after diffs in the Activity tab and field history popover.

- **Backend PR:** validmind/backend#3423 (per-field diff events for core fields and stakeholders)
- **Story:** https://app.shortcut.com/validmind/story/17622
- **Tracker:** https://app.shortcut.com/validmind/story/17996

## Changes

Updated two pages:
1. `site/guide/reporting/_view-record-activity-overview.qmd` — clarified that artifact field changes now include core fields and stakeholders with before/after values
2. `site/guide/validation/update-artifacts.qmd` — specified which core fields (Severity, Status, Due Date, Risk Area, Title, Description) and stakeholders (Assignee, Creator) now show change diffs

Pages validated with quarto render.

## Release notes

`documentation`

The Activity Log now shows before and after values when artifact core fields (Severity, Status, Due Date, Risk Area, Title, Description) and stakeholders (Assignee, Creator) change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmPREobo2AJE6PBnGkvWWC