### PR TITLE
Inventory fields: deletion no longer blocked by deleted records (sc-17845)

### DIFF
--- a/site/guide/inventory/manage-inventory-fields.qmd
+++ b/site/guide/inventory/manage-inventory-fields.qmd
@@ -110,7 +110,14 @@ To group inventory fields, first create an inventory field group:
 ## Delete inventory fields
 
 ::: {.callout-important title="Inventory field deletion is permanent."}
-Deleting an inventory field will remove it from all records using that field, even if the field has been populated.
+Deleting an inventory field will remove it from all records using that field, even if the field has been populated. A field can only be deleted if it is not actively used by any:
+
+- Active (non-deleted, non-archived) inventory records
+- Active (non-archived) workflows
+- Calculation fields
+- Risk-tier templates
+
+Deleted records and archived workflows no longer block field deletion, even if they contain references to the field.
 :::
 
 1. In the left sidebar, click **{{< fa gear >}} Settings**.
@@ -121,7 +128,11 @@ Deleting an inventory field will remove it from all records using that field, ev
 
 4. When the **{{< fa ellipsis-vertical >}}** menu appears under the Actions column, click on it and select [**{{< fa trash-can >}} Delete Field**]{.red}.
 
-5. Click **Yes, Delete Field** to confirm permanent deletion.
+5. If the field has any active dependencies (workflows or records), a modal will show which active records or workflows are blocking the deletion. Review these dependencies, and then either:
+   - Resolve the dependency by removing the field from the blocking workflow or records, then retry the deletion.
+   - Or, if you want to keep these dependencies, cancel the deletion.
+
+6. If the field has no active dependencies, click **Yes, Delete Field** to confirm permanent deletion.
 
 
 <!-- FOOTNOTES -->


### PR DESCRIPTION
## Summary

Updated inventory field deletion guidance to clarify that deleted records and archived workflows no longer block field deletion. Only active records, active workflows, calculation fields, and risk-tier templates can block deletion now.

- **Backend PR:** validmind/backend#3485 (ignore deleted records and archived workflows in dependency checks)
- **Story:** https://app.shortcut.com/validmind/story/17845
- **Tracker:** https://app.shortcut.com/validmind/story/17996

## Changes

Updated `site/guide/inventory/manage-inventory-fields.qmd`:
- Clarified what can block field deletion (active records, active workflows, calculation fields, risk-tier templates)
- Noted that deleted records and archived workflows no longer block deletion
- Added step-by-step guidance for handling dependency warnings when attempting deletion
- Expanded callout to list deletion prerequisites

Page validated with quarto render.

## Release notes

`documentation`

Inventory fields that were only referenced by deleted records or archived workflows can now be deleted. The field deletion dependency check no longer treats deleted records and archived workflows as blocking dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmPREobo2AJE6PBnGkvWWC