### PR TITLE
[SC-17022] Document risk tiering workflow integration

### DIFF
--- a/site/guide/_sidebar.yaml
+++ b/site/guide/_sidebar.yaml
@@ -109,6 +109,7 @@ website:
                 - guide/risk-tiering/manage-risk-tier-templates.qmd
                 - guide/risk-tiering/configure-risk-tier-calculation.qmd
                 - guide/risk-tiering/manage-risk-tier-assessments.qmd
+                - guide/risk-tiering/set-up-risk-tiering-workflows.qmd
         - text: "---"
         - section: "Documents & templates"
           contents:

--- a/site/guide/risk-tiering/manage-risk-tier-assessments.qmd
+++ b/site/guide/risk-tiering/manage-risk-tier-assessments.qmd
@@ -90,6 +90,8 @@ The **Calculated Tier** section shows the final tier determination for this asse
 The sidebar on the assessment detail page shows:
 
 - **Status** — Draft, Active, or Archived.
+- **Assessment Stage** — the assessment's current governance stage, shown when risk tiering workflows are in use. The stage tracks review progress separately from the status and updates live as a workflow advances. See [Set up risk tiering workflows](set-up-risk-tiering-workflows.qmd).
+- **Active Workflows** — the workflow runs governing this assessment, shown when risk tiering workflows are in use. Click **See All Workflows** to start a manually triggered workflow or inspect a run.
 - **Assessment Version** — a dropdown showing the current version (for example: "13 (Latest)"). Use this to navigate to any previous version of the assessment.
 - **Risk Tier Template** — the template name and version this assessment is linked to, with a badge showing the calculation method (Scorecard or Risk Matrix).
 - **Published / Published By** — the publication date and the user who published it (shown once the assessment has been published).
@@ -107,6 +109,8 @@ When you are satisfied with the factor scores and the calculated tier:
 2. Confirm the publish. The assessment moves to **Active**, receives a version number (v1, v2, …), and becomes the record's current official risk tier. The record's **Assessed Risk Tier** field is updated automatically — see [Assessed Risk Tier field](#assessed-risk-tier-field) below.
 
 Only one assessment can be Active per record at a time.
+
+If a [risk tiering workflow](set-up-risk-tiering-workflows.qmd) is configured to start on publish for this record type, publishing also starts a governance review of the published version. Publishing a new version ends any still-running review of the previous version and starts a fresh one.
 
 :::{.callout-note}
 An assessment can only be published against an **Active** template version. If the template linked to your assessment has since been archived, you must migrate to the current template before publishing (see [Migrate a stale assessment](#migrate-a-stale-assessment)).
@@ -177,3 +181,4 @@ Only **Draft** assessments can be deleted. Active and Archived assessments are p
 - [Working with risk tiering](working-with-risk-tiering.qmd) — concepts, lifecycle overview, and roles.
 - [Manage risk tier templates](manage-risk-tier-templates.qmd) — how templates are configured and published.
 - [Configure risk tier calculation](configure-risk-tier-calculation.qmd) — how factors, scoring rules, and override rules work.
+- [Set up risk tiering workflows](set-up-risk-tiering-workflows.qmd) — govern assessments with stages, approvals, and tier-based routing.

--- a/site/guide/risk-tiering/manage-risk-tier-templates.qmd
+++ b/site/guide/risk-tiering/manage-risk-tier-templates.qmd
@@ -67,6 +67,8 @@ To publish:
 Published templates are immutable. To make changes, create a new version.
 :::
 
+If a [risk tiering workflow](set-up-risk-tiering-workflows.qmd) is configured to start on publish for this template, publishing also starts a governance review of the published version. The template's detail page then shows its current governance stage and active workflow runs.
+
 ## Create a new version
 
 Use a new version to update a published template without disrupting in-progress assessments.
@@ -126,3 +128,4 @@ Every template's detail page shows its full version history — all published ve
 
 - [Configure risk tier calculation](configure-risk-tier-calculation.qmd) — set up scoring levels, factors, components, thresholds, and override rules.
 - [Manage risk tier assessments](manage-risk-tier-assessments.qmd) — create and publish assessments for your records against a published template.
+- [Set up risk tiering workflows](set-up-risk-tiering-workflows.qmd) — govern templates and assessments with stages, approvals, and tier-based routing.

--- a/site/guide/risk-tiering/set-up-risk-tiering-workflows.qmd
+++ b/site/guide/risk-tiering/set-up-risk-tiering-workflows.qmd
@@ -1,0 +1,146 @@
+---
+# Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+# Refer to the LICENSE file in the root of this repository for details.
+# SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial
+title: "Set up risk tiering workflows"
+date: last-modified
+description: "Govern risk tier assessments and templates through workflows — define governance stages, trigger reviews on publish, advance stages with dedicated steps, and branch on the assessed risk tier."
+---
+
+Risk tiering workflows let you govern risk tier assessments and templates with the same workflow engine you use for records and artifacts. A review can start automatically when an assessment or template is published, advance a governance stage as it runs, require approvals, and route differently based on the assessed risk tier.
+
+## Prerequisites
+
+- Active {{< var vm.product >}} login
+- Customer Admin role or equivalent permissions to manage workflows
+- An active risk tier template published for at least one record type[^1]
+- Risk tiering enabled for your organization
+
+## About risk tiering workflows
+
+A risk tiering workflow applies to one of two subjects:
+
+- **Risk tier assessment workflows** govern a record type's risk tier assessments. The workflow is scoped to an inventory record type, and its stages and branch conditions come from that record type's currently active risk tier template.
+- **Risk tier template workflows** govern a specific risk tier template across the organization — for example, requiring a review before a new methodology version takes effect.
+
+Both kinds of workflow can move a **governance stage** as they run. Governance stages — for example: *In Development → In Review → Approved / Changes Requested* — track review progress and are separate from the Draft → Active → Archived lifecycle status.[^2] Publishing still moves the status; a workflow moves the stage.
+
+## Define governance stages
+
+Governance stages are defined per template, in two independent sets — one for the template itself, one for assessments made against it. Each set feeds a different workflow step:
+
+| Stage set | Applies to | Used by workflow step |
+|---|---|---|
+| **Risk Tier Template Stages** | The template itself | **{{< fa flag >}} Risk Tier Template Stage Change** |
+| **Risk Assessment Stages** | Assessments made against the template | **{{< fa flag >}} Risk Assessment Stage Change** |
+: Governance stage sets {.hover tbl-colwidths="[30,30,40]"}
+
+To define stages:
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+2. Under {{< fa shield >}} Governance, select **Risk Tier Stages**.
+
+3. Select the template to define stages for.
+
+4. Select the **Risk Tier Template Stages** or **Risk Assessment Stages** tab, depending on which stage set you want to define.
+
+5. Click **{{< fa plus >}} Add Stage**, then enter a **Name** and select a **Color**.
+
+6. Drag and drop to reorder stages into the order your review moves through them.
+
+::: {.callout title="Add stages to the set that matches your workflow's subject"}
+The two tabs are separate stage sets — a stage-change step only offers stages from its matching set. If the stage drop-down in a workflow step is empty, the step names the tab that feeds it so you can tell which set still needs stages.
+:::
+
+::: {.callout-important title="A stage in use by a workflow step cannot be deleted."}
+Remove the stage from the workflow step first, then delete the stage.
+:::
+
+## Add a risk tiering workflow
+
+1. In the left sidebar, click **{{< fa gear >}} Settings**.
+
+2. Under {{< fa shield >}} Governance, select **Workflows**.
+
+3. Select the **Risk Tiering Workflows** tab.
+
+4. Click **{{< fa plus >}} Add Risk Tiering Workflow**.
+
+5. Enter a **Title** and a **Description** for the workflow.
+
+6. Under **Applies to**, select the workflow's subject:
+
+    - **Risk Tier Assessment** — Govern a record type's risk tier assessments.
+    - **Risk Tier Template** — Govern a risk tier template across the organization.
+
+7. Select the workflow's scope:
+
+    - For assessment workflows, select the **Inventory Record Type**. Only record types with an active risk tier template are available. Stages and branch conditions in the workflow use the configuration of that record type's active template.
+    - For template workflows, select the **Risk Tier Template** to govern. Stages in the workflow use that template's configuration.
+
+8. Under **Workflow Start**, select when the workflow should be initiated:
+
+    - **Manually** — Start this workflow on demand from the assessment or template page.
+    - **On Risk Assessment Published** — Start this workflow automatically each time an assessment is published. (Assessment workflows only.)
+    - **On Risk Tier Template Published** — Start this workflow automatically each time a version of the template is published. (Template workflows only.)
+
+9. Click **Save Draft** to save your workflow, and then configure your workflow steps.[^3]
+
+::: {.callout-note}
+The subject and scope are structural and cannot be changed after the workflow is created.
+
+Only one workflow starting on publish is allowed per inventory record type (for assessments) or per template (for templates), so publishing fires exactly one governance workflow. Manually started workflows are not limited this way — you can create as many as you need.
+:::
+
+## Configure risk tiering steps
+
+Risk tiering workflows use the same workflow canvas and step types as record and artifact workflows,[^4] with these subject-specific capabilities:
+
+**Move the governance stage.** Add a **{{< fa flag >}} Risk Assessment Stage Change** step (assessment workflows) or a **{{< fa flag >}} Risk Tier Template Stage Change** step (template workflows) to move the subject's governance stage as the review runs — for example, set *In Review* when the review starts, and *Approved* or *Changes Requested* on the outcome of an **{{< fa users >}} Approval** step.[^5]
+
+**Branch on the assessed risk tier.** In an assessment workflow, a **{{< fa maximize >}} Condition Branch** can route on **Risk Assessment Field: Assessed Risk Tier** — the tier level of the assessment the workflow is running against. Use it to send high-tier models through a stricter review path than low-tier ones. The available tier values come from the record type's active template.
+
+**Require approvals.** Connect an **{{< fa users >}} Approval** step's rejection and approval paths to stage-change steps, so a vote moves the assessment or template into the matching governance stage.
+
+## Track governance on the assessment or template
+
+On the assessment detail page[^6] and the template detail page:[^7]
+
+- The [assessment stage]{.smallcaps} or [template stage]{.smallcaps} badge in the sidebar shows the current governance stage. The badge can also be set directly by users with edit access to the assessment or template.
+- The [active workflows]{.smallcaps} section lists the workflow runs for that assessment or template. Click **See All Workflows** to review available workflows, start a manually triggered workflow, or inspect a run.
+
+The stage badge and workflow list update live as a workflow advances — including right after an approval vote — without reloading the page.
+
+## How governance runs behave
+
+Risk tiering workflows are built around one principle: **an approval attests to a specific published version.**
+
+- **One published version = one governance run.** A publish-triggered workflow runs once per published version and stays bound to the exact version it judged. Publishing a new version archives the previous version, ends any of its still-active runs as aborted, and starts a fresh review of the new version — a full re-review, not a resumption.
+- **Approval does not publish.** A workflow moves stages and records approvals, but it never changes the Draft/Active/Archived status. When a review of a draft is approved, a person clicks **Publish** — the publishing decision stays with the author.
+- **Rejection ends the run.** A rejection typically moves the stage to something like *Changes Requested*, and the run ends. To address the feedback, revise and publish a new version — a publish-triggered review re-runs automatically, and a manual review can be re-run on demand.
+- **Publish-triggered and manual reviews are different tools.** Use a publish-triggered workflow as the governance backbone that runs on every publish, and manual workflows for on-demand reviews — such as governing a draft before it is published.
+
+## What's next
+
+- [Working with risk tiering](working-with-risk-tiering.qmd) — concepts, lifecycle overview, and roles.
+- [Manage risk tier assessments](manage-risk-tier-assessments.qmd) — create, publish, and version assessments.
+- [Workflow step types](/guide/workflows/workflow-step-types.qmd) — configuration reference for every workflow step.
+- [Working with workflows](/guide/workflows/working-with-workflows.qmd) — the full workflows guide.
+
+
+<!-- FOOTNOTES -->
+
+[^1]: [Manage risk tier templates](manage-risk-tier-templates.qmd)
+
+[^2]: [Working with risk tiering](working-with-risk-tiering.qmd#lifecycle)
+
+[^3]: [Configure workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps)
+
+[^4]: [Workflow step types](/guide/workflows/workflow-step-types.qmd)
+
+[^5]: [Workflow step types](/guide/workflows/workflow-step-types.qmd#risk-assessment-stage-change)
+
+[^6]: [Manage risk tier assessments](manage-risk-tier-assessments.qmd#assessment-sidebar)
+
+[^7]: [Manage risk tier templates](manage-risk-tier-templates.qmd)

--- a/site/guide/risk-tiering/set-up-risk-tiering-workflows.qmd
+++ b/site/guide/risk-tiering/set-up-risk-tiering-workflows.qmd
@@ -13,6 +13,7 @@ Risk tiering workflows let you govern risk tier assessments and templates with t
 
 - Active {{< var vm.product >}} login
 - Customer Admin role or equivalent permissions to manage workflows
+- Governance Admin or Validator role with `manage_risk_tier_template` permission to define governance stages
 - An active risk tier template published for at least one record type[^1]
 - Risk tiering enabled for your organization
 
@@ -53,8 +54,8 @@ To define stages:
 The two tabs are separate stage sets — a stage-change step only offers stages from its matching set. If the stage drop-down in a workflow step is empty, the step names the tab that feeds it so you can tell which set still needs stages.
 :::
 
-::: {.callout-important title="A stage in use by a workflow step cannot be deleted."}
-Remove the stage from the workflow step first, then delete the stage.
+::: {.callout-important title="Deleting a stage does not check workflow steps."}
+A stage cannot be deleted while an assessment or template is currently in that stage. Deleting a stage that a workflow step still references is allowed, and silently breaks that step — the run stops advancing with no error shown. Update or remove the stage-change step before deleting its stage.
 :::
 
 ## Add a risk tiering workflow
@@ -103,9 +104,11 @@ Risk tiering workflows use the same workflow canvas and step types as record and
 
 **Require approvals.** Connect an **{{< fa users >}} Approval** step's rejection and approval paths to stage-change steps, so a vote moves the assessment or template into the matching governance stage.
 
+When your steps are configured, publish the workflow to put it into effect.[^6] A draft workflow never runs — it cannot be started manually, and a publish-triggered draft does not fire when an assessment or template is published.
+
 ## Track governance on the assessment or template
 
-On the assessment detail page[^6] and the template detail page:[^7]
+On the assessment detail page[^7] and the template detail page:[^8]
 
 - The [assessment stage]{.smallcaps} or [template stage]{.smallcaps} badge in the sidebar shows the current governance stage. The badge can also be set directly by users with edit access to the assessment or template.
 - The [active workflows]{.smallcaps} section lists the workflow runs for that assessment or template. Click **See All Workflows** to review available workflows, start a manually triggered workflow, or inspect a run.
@@ -116,7 +119,7 @@ The stage badge and workflow list update live as a workflow advances — includi
 
 Risk tiering workflows are built around one principle: **an approval attests to a specific published version.**
 
-- **One published version = one governance run.** A publish-triggered workflow runs once per published version and stays bound to the exact version it judged. Publishing a new version archives the previous version, ends any of its still-active runs as aborted, and starts a fresh review of the new version — a full re-review, not a resumption.
+- **One published version = one governance run.** A publish-triggered workflow runs once per published version and stays bound to the exact version it judged. Publishing a new version archives the previous version, ends any of its still-active runs as aborted, and starts a fresh review of the new version — a full re-review, not a resumption. An archived version is terminal for governance: no workflow can start on it, so a re-run always targets the current version, not the displaced one.
 - **Approval does not publish.** A workflow moves stages and records approvals, but it never changes the Draft/Active/Archived status. When a review of a draft is approved, a person clicks **Publish** — the publishing decision stays with the author.
 - **Rejection ends the run.** A rejection typically moves the stage to something like *Changes Requested*, and the run ends. To address the feedback, revise and publish a new version — a publish-triggered review re-runs automatically, and a manual review can be re-run on demand.
 - **Publish-triggered and manual reviews are different tools.** Use a publish-triggered workflow as the governance backbone that runs on every publish, and manual workflows for on-demand reviews — such as governing a draft before it is published.
@@ -141,6 +144,8 @@ Risk tiering workflows are built around one principle: **an approval attests to 
 
 [^5]: [Workflow step types](/guide/workflows/workflow-step-types.qmd#risk-assessment-stage-change)
 
-[^6]: [Manage risk tier assessments](manage-risk-tier-assessments.qmd#assessment-sidebar)
+[^6]: [Publish workflow](/guide/workflows/configure-workflows.qmd#publish-workflow)
 
-[^7]: [Manage risk tier templates](manage-risk-tier-templates.qmd)
+[^7]: [Manage risk tier assessments](manage-risk-tier-assessments.qmd#assessment-sidebar)
+
+[^8]: [Manage risk tier templates](manage-risk-tier-templates.qmd)

--- a/site/guide/risk-tiering/working-with-risk-tiering.qmd
+++ b/site/guide/risk-tiering/working-with-risk-tiering.qmd
@@ -16,6 +16,7 @@ listing:
       - manage-risk-tier-templates.qmd
       - configure-risk-tier-calculation.qmd
       - manage-risk-tier-assessments.qmd
+      - set-up-risk-tiering-workflows.qmd
 ---
 
 Risk tiering gives your organization a structured, auditable way to classify AI models and other inventory records into discrete risk categories. Instead of relying on informal judgment calls, risk classification follows a defined methodology — configured once by administrators and applied consistently across every record in your inventory.
@@ -66,6 +67,9 @@ A per-factor setting that controls how component scores within a factor combine 
 **Assessed Risk Tier**
 A system-managed, read-only inventory field that surfaces the risk tier of a record's most recently published assessment. It is automatically updated when an assessment is published and is visible to anyone with access to the record.
 
+**Governance stage**
+A named review stage — for example: In Development, In Review, Approved — that tracks where an assessment or template sits in your review process, separate from its Draft/Active/Archived status. Stages are defined per template and are typically moved by a [risk tiering workflow](set-up-risk-tiering-workflows.qmd).
+
 ## Lifecycle
 
 Both templates and assessments follow the same three lifecycle statuses:
@@ -78,6 +82,8 @@ Both templates and assessments follow the same three lifecycle statuses:
 
 Version history is append-only — once a version is published, its configuration is immutable. A new version must be created to make changes. Only one version of a given template can be Active at a time per record type. Only one assessment can be Active per record at a time.
 
+Separately from these statuses, an assessment or template can carry a **governance stage** that tracks its progress through your review process. See [Set up risk tiering workflows](set-up-risk-tiering-workflows.qmd).
+
 ## Who does what
 
 | Role | Responsibilities |
@@ -89,6 +95,8 @@ Version history is append-only — once a version is published, its configuratio
 
 - **Risk tier templates** — navigate to **Settings → Governance → Risk Tier Templates**.
 - **Risk tier assessments** — open any record in the model inventory and select the **Risk Tier Assessments** tab.
+- **Governance stages** — navigate to **Settings → Governance → Risk Tier Stages**.
+- **Risk tiering workflows** — navigate to **Settings → Governance → Workflows** and select the **Risk Tiering Workflows** tab.
 
 ## What's next
 

--- a/site/guide/workflows/_add-new-workflows.qmd
+++ b/site/guide/workflows/_add-new-workflows.qmd
@@ -15,6 +15,7 @@ d. Select the **Workflow Target** type to add:
 
     - **Inventory Record** — Workflows that apply to records in your inventory.^[[Working with the inventory](/guide/inventory/working-with-the-inventory.qmd)]
     - **Artifact** — Workflows that apply to logged artifacts.^[[Working with artifacts](/guide/validation/working-with-artifacts.qmd)]
+    - **Risk Tiering** — Workflows that govern risk tier assessments or templates.^[[Working with risk tiering](/guide/risk-tiering/working-with-risk-tiering.qmd)] To add one, select the **Risk Tiering Workflows** tab and click **{{< fa plus >}} Add Risk Tiering Workflow**.
 
 ::: {.panel-tabset}
 
@@ -54,6 +55,22 @@ v. Under **Workflow Expected Duration**, define the SLA for the workflow based o
 
 vi. Click **Save Draft** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
 
+#### Add risk tiering workflows
+
+i. Enter a **Title** and a **Description** for the workflow.
+
+ii. Under **Applies to**, select whether the workflow governs a **Risk Tier Assessment** or a **Risk Tier Template**.[^risk-tiering-subject]
+
+iii. Select the workflow's scope — the **Inventory Record Type** (assessment workflows) or the **Risk Tier Template** (template workflows).
+
+iv. Under **Workflow Start**, select when the workflow should be initiated:
+
+- **Manually** — Start this workflow manually from the assessment or template page.
+- **On Risk Assessment Published** — Start this workflow when an assessment is published. (Assessment workflows only.)[^on-published]
+- **On Risk Tier Template Published** — Start this workflow when a version of the template is published. (Template workflows only.)[^on-published]
+
+v. Click **Save Draft** to save your blank workflow, and then [configure your workflow steps](/guide/workflows/configure-workflows.qmd#configure-workflow-steps).
+
 :::
 
 
@@ -89,6 +106,20 @@ vi. Click **Save Draft** to save your blank workflow, and then [configure your w
     <br></br>
     When selecting date or date time fields, check **Schedule workflow start for this date** to set the workflow to trigger on the existing date captured in the field rather than when its value changes.
 
+[^risk-tiering-subject]:
+
+    [Set up risk tiering workflows](/guide/risk-tiering/set-up-risk-tiering-workflows.qmd)
+    <br></br>
+    The subject and scope are structural and cannot be changed after the workflow is created.
+
+[^on-published]:
+
+    ::: {.callout title="Please note that only one workflow can be configured to start on publish for each inventory record type (assessments) or template (templates)."}
+    <br>
+    [Set up risk tiering workflows](/guide/risk-tiering/set-up-risk-tiering-workflows.qmd#add-a-risk-tiering-workflow){.button}
+
+    :::
+
 [^artifact-workflow-record-scopes]:
 
     [Manage inventory record types](/guide/inventory/manage-inventory-record-types.qmd)
@@ -112,6 +143,7 @@ d. Select the **Workflow Target** type to add:
 
     - **Inventory Record** — Workflows that apply to records in your inventory.
     - **Artifact** — Workflows that apply to logged artifacts.
+    - **Risk Tiering** — Workflows that govern risk tier assessments or templates. To add one, select the **Risk Tiering Workflows** tab and click **{{< fa plus >}} Add Risk Tiering Workflow**.
 
 #### Add record workflows
 
@@ -147,5 +179,21 @@ iv. Under **Workflow Start**, select when the workflow should be initiated:
 v. Under **Workflow Expected Duration**, define the SLA for the workflow based on the start date in days, weeks, months, or years.
 
 vi. Click **Save Draft** to save your blank workflow, and then configure your workflow steps.
+
+#### Add risk tiering workflows
+
+i. Enter a **Title** and a **Description** for the workflow.
+
+ii. Under **Applies to**, select whether the workflow governs a [**Risk Tier Assessment** or a **Risk Tier Template**](/guide/risk-tiering/set-up-risk-tiering-workflows.qmd){target="_blank"}.
+
+iii. Select the workflow's scope — the **Inventory Record Type** (assessment workflows) or the **Risk Tier Template** (template workflows).
+
+iv. Under **Workflow Start**, select when the workflow should be initiated:
+
+- **Manually** — Start this workflow manually from the assessment or template page.
+- **On Risk Assessment Published** — Start this workflow when an assessment is published. (Assessment workflows only.)
+- **On Risk Tier Template Published** — Start this workflow when a version of the template is published. (Template workflows only.)
+
+v. Click **Save Draft** to save your blank workflow, and then configure your workflow steps.
 
 ::::

--- a/site/guide/workflows/_workflow-states.qmd
+++ b/site/guide/workflows/_workflow-states.qmd
@@ -15,6 +15,7 @@ Add workflow states either while configuring a **{{< fa wifi >}} Workflow State 
 
     - **Record Workflows** — Workflow states that apply to record workflows.
     - **Artifact Workflows** — Workflow states that apply to artifact workflows.
+    - **Risk Tiering Workflows** — Workflow states that apply to risk tiering workflows.^[[Set up risk tiering workflows](/guide/risk-tiering/set-up-risk-tiering-workflows.qmd)]
 
 1. Click on the workflow you'd like to modify workflow states for.
 
@@ -34,6 +35,7 @@ Add workflow states either while configuring a **{{< fa wifi >}} Workflow State 
 
     - **Record Workflows** — Workflow states that apply to record workflows.
     - **Artifact Workflows** — Workflow states that apply to artifact workflows.
+    - **Risk Tiering Workflows** — Workflow states that apply to risk tiering workflows.
 
 1. Click on the workflow you'd like to edit the states for.
 
@@ -59,6 +61,7 @@ If a state is or was previously in use  on a workflow within a {{< fa wifi >}} W
 
     - **Record Workflows** — Workflow states that apply to record workflows.
     - **Artifact Workflows** — Workflow states that apply to artifact workflows.
+    - **Risk Tiering Workflows** — Workflow states that apply to risk tiering workflows.
 
 1. Click on the workflow you'd like to delete workflow states for.
 

--- a/site/guide/workflows/_workflow-step-types.qmd
+++ b/site/guide/workflows/_workflow-step-types.qmd
@@ -83,6 +83,32 @@ An artifact created by this step shows the workflow as its creator in the activi
 | **Set Artifact Status To** | Select the artifact type status to transition to. |
 : **{{< fa tag >}} Artifact Status Change** step configuration {.hover tbl-colwidths="[40,60]"}
 
+### {{< fa flag >}} Risk Assessment Stage Change
+<span id="risk-assessment-stage-change">
+
+- Moves a risk tier assessment into another governance stage.
+- Available on **risk tier assessment workflows only**.
+- Requires **Risk Assessment Stages** defined for the record type's active risk tier template.^[[Set up risk tiering workflows](/guide/risk-tiering/set-up-risk-tiering-workflows.qmd#define-governance-stages)]
+
+| Field | Description |
+|---:|---|
+| **When These Conditions Are Met** (optional) | Add conditional requirements to qualify for this step. |
+| **Set Assessment Stage To** | Select the governance stage to move the assessment to. |
+: **{{< fa flag >}} Risk Assessment Stage Change** step configuration {.hover tbl-colwidths="[40,60]"}
+
+### {{< fa flag >}} Risk Tier Template Stage Change
+<span id="risk-tier-template-stage-change">
+
+- Moves a risk tier template into another governance stage.
+- Available on **risk tier template workflows only**.
+- Requires **Risk Tier Template Stages** defined for the workflow's risk tier template.^[[Set up risk tiering workflows](/guide/risk-tiering/set-up-risk-tiering-workflows.qmd#define-governance-stages)]
+
+| Field | Description |
+|---:|---|
+| **When These Conditions Are Met** (optional) | Add conditional requirements to qualify for this step. |
+| **Set Template Stage To** | Select the governance stage to move the template to. |
+: **{{< fa flag >}} Risk Tier Template Stage Change** step configuration {.hover tbl-colwidths="[40,60]"}
+
 ### {{< fa wifi >}} Workflow State Change
 <span id="workflow-state-change">
 
@@ -323,6 +349,14 @@ Converts a record to a different inventory record type in place (for example Int
 #### {{< fa tag >}} Artifact Status Change
 
 Transitions an artifact into another status.
+
+#### {{< fa flag >}} Risk Assessment Stage Change
+
+Moves a risk tier assessment into another governance stage. Risk tier assessment workflows only.
+
+#### {{< fa flag >}} Risk Tier Template Stage Change
+
+Moves a risk tier template into another governance stage. Risk tier template workflows only.
 
 #### {{< fa wifi >}} Workflow State Change
 

--- a/site/llm/chatbot-product-map.md
+++ b/site/llm/chatbot-product-map.md
@@ -495,14 +495,14 @@
   - Sections: Can I customize workflows within }?; What record stages are available for use in workflows?; Can we work with disconnected workflows?; You can also leverage the } once you are ready to document a specific record (model) for review and validation.; Learn more
 - `/guide/integrations/integrations-examples/use-webhooks-with-workflows.html`
   - Sections: Prerequisites; Start a workflow via webhook; 1. Configure workflow in }; 2. Start workflow from external system; Trigger a paused workflow to continue; 1. Configure workflow in }; 2. Trigger workflow to continue from external system
+- `/guide/risk-tiering/set-up-risk-tiering-workflows.html`
+  - Sections: Prerequisites; About risk tiering workflows; Define governance stages; Add a risk tiering workflow; Configure risk tiering steps; Track governance on the assessment or template; How governance runs behave; What's next
 - `/guide/workflows/conditional-step-requirements.html`
   - Sections: Prerequisites; Configure conditional requirements
 - `/guide/workflows/configure-workflows.html`
   - Sections: Prerequisites; Create custom workflows; 1. Add new workflows; 2. Configure workflow steps; 3. Link workflow together; Workflow steps relationship unclear on your canvas?; 4. Publish workflow; Clone existing workflows
 - `/guide/workflows/introduction-to-workflows.html`
   - Sections: Workflow elements; What's next
-- `/guide/workflows/manage-record-stages.html`
-  - Sections: Prerequisites; Add record stages; Edit or delete record stages
 
 #### `/settings/workflows` — Workflows
 
@@ -517,14 +517,14 @@
   - Sections: Can I customize workflows within }?; What record stages are available for use in workflows?; Can we work with disconnected workflows?; You can also leverage the } once you are ready to document a specific record (model) for review and validation.; Learn more
 - `/guide/integrations/integrations-examples/use-webhooks-with-workflows.html`
   - Sections: Prerequisites; Start a workflow via webhook; 1. Configure workflow in }; 2. Start workflow from external system; Trigger a paused workflow to continue; 1. Configure workflow in }; 2. Trigger workflow to continue from external system
+- `/guide/risk-tiering/set-up-risk-tiering-workflows.html`
+  - Sections: Prerequisites; About risk tiering workflows; Define governance stages; Add a risk tiering workflow; Configure risk tiering steps; Track governance on the assessment or template; How governance runs behave; What's next
 - `/guide/workflows/conditional-step-requirements.html`
   - Sections: Prerequisites; Configure conditional requirements
 - `/guide/workflows/configure-workflows.html`
   - Sections: Prerequisites; Create custom workflows; 1. Add new workflows; 2. Configure workflow steps; 3. Link workflow together; Workflow steps relationship unclear on your canvas?; 4. Publish workflow; Clone existing workflows
 - `/guide/workflows/introduction-to-workflows.html`
   - Sections: Workflow elements; What's next
-- `/guide/workflows/manage-record-stages.html`
-  - Sections: Prerequisites; Add record stages; Edit or delete record stages
 
 ## Main application
 
@@ -619,14 +619,14 @@
   - Sections: Can I customize workflows within }?; What record stages are available for use in workflows?; Can we work with disconnected workflows?; You can also leverage the } once you are ready to document a specific record (model) for review and validation.; Learn more
 - `/guide/integrations/integrations-examples/use-webhooks-with-workflows.html`
   - Sections: Prerequisites; Start a workflow via webhook; 1. Configure workflow in }; 2. Start workflow from external system; Trigger a paused workflow to continue; 1. Configure workflow in }; 2. Trigger workflow to continue from external system
+- `/guide/risk-tiering/set-up-risk-tiering-workflows.html`
+  - Sections: Prerequisites; About risk tiering workflows; Define governance stages; Add a risk tiering workflow; Configure risk tiering steps; Track governance on the assessment or template; How governance runs behave; What's next
 - `/guide/workflows/conditional-step-requirements.html`
   - Sections: Prerequisites; Configure conditional requirements
 - `/guide/workflows/configure-workflows.html`
   - Sections: Prerequisites; Create custom workflows; 1. Add new workflows; 2. Configure workflow steps; 3. Link workflow together; Workflow steps relationship unclear on your canvas?; 4. Publish workflow; Clone existing workflows
 - `/guide/workflows/introduction-to-workflows.html`
   - Sections: Workflow elements; What's next
-- `/guide/workflows/manage-record-stages.html`
-  - Sections: Prerequisites; Add record stages; Edit or delete record stages
 
 - *No direct help link in frontend; related docs inferred from keywords.*
 


### PR DESCRIPTION
# Pull Request Description

## What and why?

Documents the risk tiering workflow integration shipped in [SC-17022](https://app.shortcut.com/validmind/story/17022/risk-tier-engine-workflow-integration) (validmind/backend#3347 + validmind/frontend#2714, merged 2026-08-07). The story carries the `needs-docs` label; nothing in the docs covered any of it before this PR.

**Before:** The risk tiering guides covered templates, calculation, and assessments only. The workflows guide had no mention of risk tiering — no Risk Tiering workflow target, no stage-change steps, no governance stages.

**After:**

- **New page — [Set up risk tiering workflows](site/guide/risk-tiering/set-up-risk-tiering-workflows.qmd):** governance stages (Settings → Risk Tier Stages, its two tabs, and which workflow step consumes each), adding a risk tiering workflow (Applies to: Assessment vs Template, scope, `Manually` / `On Risk Assessment Published` / `On Risk Tier Template Published` start modes, the one-publish-triggered-workflow-per-scope rule), configuring stage-change steps and branching on the assessed risk tier, the stage badge + Active Workflows rail, and the governance-run model (one run per published version; rejection ends the run; republishing aborts prior runs and starts a fresh review; approval never publishes — a person does).
- **Workflow step types** (`_workflow-step-types.qmd`): adds **Risk Assessment Stage Change** and **Risk Tier Template Stage Change** step reference sections (HTML + RevealJS variants), placed between Artifact Status Change and Workflow State Change to match the builder's step order.
- **Add workflows** (`_add-new-workflows.qmd`): adds the Risk Tiering target and an "Add risk tiering workflows" tab (HTML + RevealJS variants).
- **Workflow states** (`_workflow-states.qmd`): adds the Risk Tiering Workflows tab to the three tab lists.
- **Risk tiering pages**: governance-stage key concept and access paths on the overview page; Assessment Stage badge + Active Workflows rail in the assessment sidebar reference; publish-triggers-a-review notes on the assessment and template publish sections; sidebar/listing entries for the new page.

All UI labels, step names, trigger names, and constraints were verified against the merged frontend/backend code on `main` (not just the PR descriptions) — including the post-merge correction that displaced runs end as **aborted** (the separate `superseded` status was removed).

## How to test

Rendered locally, one page per invocation via the bundled helper:

```bash
skills/validmind-docs-coverage/scripts/render-pages.sh \
  guide/risk-tiering/set-up-risk-tiering-workflows.qmd \
  guide/risk-tiering/working-with-risk-tiering.qmd \
  guide/risk-tiering/manage-risk-tier-assessments.qmd \
  guide/risk-tiering/manage-risk-tier-templates.qmd \
  guide/workflows/workflow-step-types.qmd \
  guide/workflows/configure-workflows.qmd \
  guide/workflows/workflow-states.qmd \
  training/administrator-fundamentals/using-validmind-for-risk-management.qmd
```

All eight pages render cleanly; the only warning (`validmind/validmind.qmd`) is pre-existing site chrome from `_quarto.yml`, present on unmodified pages too. New anchors (`#risk-assessment-stage-change`, `#risk-tier-template-stage-change`, `#define-governance-stages`, `#add-a-risk-tiering-workflow`) verified in the rendered HTML. `git diff --check` clean.

Preview links (after the `validate` deploy finishes):

- https://docs-staging.validmind.ai/pr_previews/kam/sc-17022-risk-tiering-workflows-docs/guide/risk-tiering/set-up-risk-tiering-workflows.html
- https://docs-staging.validmind.ai/pr_previews/kam/sc-17022-risk-tiering-workflows-docs/guide/workflows/workflow-step-types.html#risk-assessment-stage-change
- https://docs-staging.validmind.ai/pr_previews/kam/sc-17022-risk-tiering-workflows-docs/guide/workflows/configure-workflows.html
- https://docs-staging.validmind.ai/pr_previews/kam/sc-17022-risk-tiering-workflows-docs/guide/workflows/workflow-states.html
- https://docs-staging.validmind.ai/pr_previews/kam/sc-17022-risk-tiering-workflows-docs/guide/risk-tiering/working-with-risk-tiering.html

## What needs special review?

- **Feature-flag stance:** the feature sits behind `launchdarkly.rollout.risk-tier-engine.workflows` (subordinate to `risk-tier-engine`), off by default. Following the existing risk-tiering docs convention, the pages do not mention flags — the new page's prerequisites say "Risk tiering enabled for your organization". Confirm this should merge now vs. being held for the flag rollout.
- **Governance-run semantics** ("How governance runs behave" section) are drawn from the story's docs-spec comment and the merged backend behavior — worth a product read to confirm the wording on rejection/republish/abort.
- The `_add-new-workflows.qmd` include still describes a "Workflow Target" selector for record/artifact workflows while the current UI uses tabs; that predates this story and was left as-is (flagging for a separate cleanup).

## Dependencies, breaking changes, and deployment notes

- Documents validmind/backend#3347 and validmind/frontend#2714 (both merged).
- No dependencies on other docs PRs; no breaking changes.

## Release notes

Added documentation for risk tiering workflows: define governance stages, start reviews automatically when an assessment or template is published (or on demand), move stages with dedicated workflow steps, branch on the assessed risk tier, and track review progress on the assessment and template pages. [Learn more ...](/guide/risk-tiering/set-up-risk-tiering-workflows.html)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [ ] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
