### PR TITLE
[SC-17596] Note that a risk tier template can move between organizations

### DIFF
--- a/site/guide/risk-tiering/manage-risk-tier-templates.qmd
+++ b/site/guide/risk-tiering/manage-risk-tier-templates.qmd
@@ -122,6 +122,14 @@ Only **Draft** templates can be deleted. Active and Archived templates are perma
 
 Every template's detail page shows its full version history — all published versions with their version numbers, publication dates, and current status. Archived versions remain readable at any time for audit purposes and can be restored as described above.
 
+## Move a template to another organization
+
+An administrator can carry a published risk tier template to another organization as part of an organization template export, performed from the Admin UI rather than from Settings. Only the **Active** version of a lineage travels, and it arrives in the destination organization as a **Draft** to be published there. Governance stage lists and workflow bindings are not carried and need configuring in the new organization.
+
+:::{.callout-note}
+If the destination organization is missing an inventory field that one of the template's components scores, the whole template is skipped rather than imported with a gap — a partial methodology would score records differently without saying so. Nothing in the UI signals this, so if a template you expected does not appear, ask your administrator to check the service logs.
+:::
+
 ## What's next
 
 - [Configure risk tier calculation](configure-risk-tier-calculation.qmd) — set up scoring levels, factors, components, thresholds, and override rules.


### PR DESCRIPTION
# Pull Request Description

## What and why?

**Manage risk tier templates** covered the whole lifecycle of a template inside one organization — create, publish, version, duplicate, archive, restore, delete — and said nothing about carrying one to a *different* organization, which an organization template export supports. A governance admin who wants to reuse a methodology they have already built looks on this page first and finds nothing.

Adds a short **Move a template to another organization** section before **What's next**: a paragraph saying the move is an Admin UI task, that only the **Active** version of a lineage travels, that it arrives as a **Draft** to be published in the destination, and that governance stage lists and workflow bindings are not carried — plus one callout for the failure mode.

**Deliberately short.** Every other object in an organization template export — inventory record types, document types, workflows, finding types, inventory fields — was documented as a release-note bullet and nothing more. The direct sibling is finding types, in 25.09: *"Export/import: Organization templates now include configurations for finding types."* Risk tiering already has its equivalent release note on the implementing backend PR, landing in the 26.09 plan, and it covers the headline plus the drafts caveat. So this section records only the two things that have no signal anywhere else: stage lists and workflow bindings not travelling, and a template being skipped **whole and silently** when the destination organization lacks an inventory field one of its components scores. An earlier draft of this carried seven bullets and a companion section in the installation docs; both were cut as out of proportion to how the siblings are documented.

Before: the page implied a template lives and dies inside one organization. After: a reader knows the methodology is portable, knows it needs publishing on arrival, and knows the one way it can go missing without telling them.

## How to test

```
skills/validmind-docs-coverage/scripts/render-pages.sh guide/risk-tiering/manage-risk-tier-templates.qmd
```

Renders clean — the only warnings are the pre-existing `Unable to resolve link target: validmind/validmind.qmd` ones, which appear on untouched pages too. `git diff --check` is clean. The new heading renders the anchor `#move-a-template-to-another-organization` and the callout renders as a note.

## What needs special review?

Both retained claims were read off the merged implementation rather than the story, and one differs from how the story described it. The story said a factor whose field key is missing in the destination is skipped with a warning; the shipped code skips the **whole template** instead, because dropping one component leaves the saved thresholds calibrated to a score range that no longer exists, and a factor with no components scores nothing. The section documents the shipped behaviour.

The other is that only the Active version of a lineage is exported — Draft-only and fully-archived lineages are left out — which is worth a check from someone who knows the export path.

Also worth a view on placement: this went on **Manage risk tier templates** rather than **Working with risk tiering** because it is something you do to a template, alongside the other lifecycle operations, rather than a concept.

## Dependencies, breaking changes, and deployment notes

Documentation only. No dependencies — the section is self-contained and links nowhere new.

## Release notes

The risk tiering guide now explains that a risk tier template can be carried to another organization through an organization template export: only the active version travels, it arrives as a draft that has to be published before assessments can use it, and it is skipped entirely if the destination organization is missing an inventory field the template scores. [Learn more ...](/guide/risk-tiering/manage-risk-tier-templates.qmd#move-a-template-to-another-organization)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend)
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [x] Labels applied
- [x] PR linked to Shortcut
- [ ] Unit tests added (Backend)
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required)
