### PR TITLE
[SC-17836] Document inventory field variables in Long Text fields

### DIFF
--- a/site/guide/inventory/_field-types.qmd
+++ b/site/guide/inventory/_field-types.qmd
@@ -255,11 +255,18 @@ Date Time
 Email
 : Text value in valid email (`user@domain.com`) format.
 
+:::: {.content-visible when-format="html" when-meta="includes.inventory"}
+Long Text
+: Toggle **Enable rich text formatting** to create a template using the rich text editor. With rich text formatting enabled, you can reference other field values on the record by inserting them as variables — in the template^[[Insert field variables into a Long Text template](/guide/inventory/manage-inventory-fields.qmd#insert-field-variables)] and in the value on an individual record.^[[Insert field variables into a Long Text field](/guide/inventory/edit-inventory-fields.qmd#insert-field-variables)]
+::::
+
+:::: {.content-visible when-format="html" when-meta="includes.artifacts"}
 Long Text
 : Toggle **Enable rich text formatting** to create a template using the rich text editor.
+::::
 
 Multiple Select
-: Click **{{< fa plus >}} Add Option** to define a list of options. 
+: Click **{{< fa plus >}} Add Option** to define a list of options.
 
 Number
 : Text value in valid number format. Number display (comma, fullstop, etc.) is determined by your browser's locale. Select a **Number Type**:

--- a/site/guide/inventory/_field-variable-resolution.qmd
+++ b/site/guide/inventory/_field-variable-resolution.qmd
@@ -1,0 +1,21 @@
+<!-- Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+Refer to the LICENSE file in the root of this repository for details.
+SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
+
+Variables resolve when the field is displayed, so a referenced value stays current as the record changes. Inventory exports contain the resolved values rather than the variables.^[[Export inventory](/guide/reporting/export-inventory.qmd)]
+
+Where a value can't be shown, {{< var vm.product >}} displays a marker in place of the variable so that you can tell restricted or unresolvable content apart from an empty field:
+
+{{< fa lock >}} **Access denied**
+: You don't have read permissions for that field.^[[Manage permissions](/guide/configuration/manage-permissions.qmd)] The value is never sent to your browser.
+
+**Circular reference**
+: Two or more fields reference each other in a loop.
+
+**Exceeded max depth**
+: Expansion stopped at two levels. If you reference a Long Text field that itself contains variables, those nested variables resolve one level further — anything beyond that is not expanded.
+
+::: {.callout title="Attestation snapshots keep the values they were captured with."}
+Variables in a snapshot resolve from the snapshot itself, not from the current record, so an attestation continues to show the values as of the time it was captured.^[[Working with attestations](/guide/attestation/working-with-attestations.qmd)]
+
+:::

--- a/site/guide/inventory/_insert-field-variables.qmd
+++ b/site/guide/inventory/_insert-field-variables.qmd
@@ -1,0 +1,16 @@
+<!-- Copyright © 2023-2026 ValidMind Inc. All rights reserved.
+Refer to the LICENSE file in the root of this repository for details.
+SPDX-License-Identifier: AGPL-3.0 AND ValidMind Commercial -->
+
+3. Click **{ } Insert Variable {{< fa angle-down >}}** in the rich text editor toolbar.
+
+4. Select the variable you want to reference from the **Record {{< fa arrow-right >}}** drop-down menus:
+
+   - **Core Fields** — Default fields on the record.
+   - `{Group}` — Custom fields, listed under the inventory field group they belong to.^[[Add inventory field groups](/guide/inventory/manage-inventory-fields.qmd#add-inventory-field-groups)]
+   - **No Group** — Custom fields that aren't assigned to a group.
+   - **Stakeholders** — Assigned users, by record stakeholder type.^[[Manage record stakeholder types](/guide/configuration/manage-record-stakeholder-types.qmd)]
+
+   Only fields available on the record type are listed. Artifact fields cannot be referenced,^[[Manage artifact fields](/guide/validation/manage-artifact-fields.qmd)] and a field can't reference itself — the field you're editing is left out of its own drop-down.
+
+5. Click **Save** to apply your changes.

--- a/site/guide/inventory/edit-inventory-fields.qmd
+++ b/site/guide/inventory/edit-inventory-fields.qmd
@@ -87,6 +87,19 @@ Learn more: [Work with content blocks](/guide/documentation/work-with-content-bl
 
 :::
 
+### Insert field variables into a Long Text field
+<span id="insert-field-variables"></span>
+
+On a **Long Text** field that has rich text formatting enabled,[^13] you can reference other field values on the same record instead of retyping them — for example, composing a summary that stays in sync with the record's owner, tier, and review dates.
+
+1. On the record's detail page, click on the Long Text field you want to edit.
+
+2. In the rich text editor:
+
+{{< include /guide/inventory/_insert-field-variables.qmd >}}
+
+{{< include /guide/inventory/_field-variable-resolution.qmd >}}
+
 ### Manage attachments on records
 <span id="manage-attachments"></span>
 
@@ -161,6 +174,8 @@ In addition to editing individual fields on a per record basis, you can edit fie
 [^11]: [Work with content blocks](/guide/documentation/work-with-content-blocks.qmd#generate-content)
 
 [^12]: [Customize inventory layout](/guide/inventory/customize-inventory-layout.qmd#swap-between-views)
+
+[^13]: [Inventory field types](manage-inventory-fields.qmd#inventory-field-types)
 
 
 

--- a/site/guide/inventory/manage-inventory-fields.qmd
+++ b/site/guide/inventory/manage-inventory-fields.qmd
@@ -87,6 +87,24 @@ For example, if you first search by keyword for `date` under **Title** without c
 
 {{< include /guide/inventory/_add-edit-inventory-fields.qmd >}}
 
+### Insert field variables into a Long Text template
+<span id="insert-field-variables"></span>
+
+Reference other field values from a Long Text template so that every record of that type starts from the same structure — for example, a summary that pulls in a record's owner and tier alongside your own narrative.
+
+1. Add or edit a **Long Text** inventory field, then toggle **Enable rich text formatting** on.[^insert-variables]
+
+2. In the template editor:
+
+{{< include /guide/inventory/_insert-field-variables.qmd >}}
+
+::: {.callout-important title="A template can only reference fields that all of its record types share."}
+Because a template is applied to records of every **Inventory Record Type** you assign the field to, only variables available on all of those types can be inserted. Assign at least one record type before inserting variables.
+
+:::
+
+{{< include /guide/inventory/_field-variable-resolution.qmd >}}
+
 ### Rename custom field keys
 
 To rename the field keys for custom inventory fields:
@@ -162,3 +180,5 @@ Deleted records and archived workflows no longer block field deletion, even if t
 [^8]: [Manage record stakeholder types](/guide/configuration/manage-record-stakeholder-types.qmd)
 
 [^9]: [Add or edit inventory fields](#add-or-edit-inventory-fields)
+
+[^insert-variables]: [Add or edit inventory fields](#add-edit)


### PR DESCRIPTION
# Pull Request Description

## What and why?

Documents sc-17836 — inserting inventory field variables into rich-text Long Text fields, shipped in validmind/frontend#2822 and validmind/backend#3492.

Both surfaces that shipped are covered:

- **Settings → Inventory Record Fields** — the variable picker in a Long Text field's *template* editor. New section: `Manage inventory fields → Insert field variables into a Long Text template`.
- **A record's Long Text value** — the same picker while editing an individual record. New section: `Edit inventory fields → Insert field variables into a Long Text field`.

Two new includes carry the shared content so the two pages can't drift:

- `_insert-field-variables.qmd` — the picker steps and what the drop-down contains.
- `_field-variable-resolution.qmd` — when values resolve, the `Access denied` / `Circular reference` / `Exceeded max depth` markers, and attestation-snapshot behavior.

The `Long Text` entry in `_field-types.qmd` is split into inventory- and artifact-scoped variants, following the pattern the `Attachments` entry already uses in that file. Variables apply only to inventory record fields, so the artifact page keeps the original one-line text.

**Documented as implemented, not as specified.** Two places where the shipped behavior differs from the story's acceptance criteria, and the docs follow the code:

| Story AC | What shipped |
|---|---|
| Resolve one level only | Resolves **two** levels, with cycle detection and a visible `Exceeded max depth` marker (`RECORD_FIELD_MAX_DEPTH = 2`) |
| The edited field remains in its own picker (include self) | Self is **excluded** (`excludeFieldKey`), per backend `3221ecdd` / frontend `4ae0595a` |

Behavior documented that isn't in the story at all: field-level read permissions produce an `Access denied` marker rather than a blank (the value never reaches the browser); inventory CSV exports contain resolved values; a template assigned to several record types can only offer variables shared by all of them.

## How to test

Rendered locally against `--profile development`. All four consumers of the edited include render clean, with only the pre-existing `Unable to resolve link target: validmind/validmind.qmd` warning that any isolated single-page render produces.

Pages to review, on the deployed preview:

| Page | What to check |
|---|---|
| [Manage inventory fields](https://docs-staging.validmind.ai/pr_previews/stevenchand/sc-17836/inventory-field-variables-in-long-text/guide/inventory/manage-inventory-fields.html#insert-field-variables) | New *Insert field variables into a Long Text template* section, and the revised [`Long Text` field-type entry](https://docs-staging.validmind.ai/pr_previews/stevenchand/sc-17836/inventory-field-variables-in-long-text/guide/inventory/manage-inventory-fields.html#inventory-field-types) |
| [Edit inventory fields](https://docs-staging.validmind.ai/pr_previews/stevenchand/sc-17836/inventory-field-variables-in-long-text/guide/inventory/edit-inventory-fields.html#insert-field-variables) | New *Insert field variables into a Long Text field* section |
| [Manage artifact fields](https://docs-staging.validmind.ai/pr_previews/stevenchand/sc-17836/inventory-field-variables-in-long-text/guide/validation/manage-artifact-fields.html#artifact-field-types) | **Regression:** `Long Text` must still read as the original one-liner, with no variables guidance |
| [Customizing Your Inventory](https://docs-staging.validmind.ai/pr_previews/stevenchand/sc-17836/inventory-field-variables-in-long-text/training/administrator-fundamentals/customizing-your-inventory.html) | **Regression (RevealJS):** `Long Text` unchanged in both the inventory and artifact tabs |

I checked the deployed preview, not just the local render: the new section is present on the inventory page, and the variables wording appears **zero** times on both the artifact page and the training deck, so neither regression fired.

Verified in the rendered HTML: the `Long Text` definition list still emits proper `<dt>`/`<dd>` despite the new fenced divs, and step numbering continues across the include boundary (`<ol start="3">`) on both pages.

## What needs special review?

**1. The feature is behind a LaunchDarkly flag that currently defaults to off.** `launchdarkly.rollout.inventory-field-variables` (`OfflineFlags` default `false`). This PR documents it as generally available. Please confirm the flag will be on for 26.09 before merging, or tell me how the docs team prefers to stage docs ahead of a rollout — I did not invent a convention for it.

**2. The RevealJS training deck is deliberately not updated.** `_field-types.qmd` is included twice in `training/administrator-fundamentals/customizing-your-inventory.qmd` — once for inventory fields, once for artifact fields — and the RevealJS block is gated only on format, with no `includes.inventory` meta to switch on. Adding inventory-only guidance there would be wrong in the artifact tab. Training coverage for this feature therefore needs its own decision; happy to follow up.

**3. Terminology check on the picker labels.** The drop-down is documented as **Record → Core Fields / `{Group}` / No Group / Stakeholders**. Those come from the backend registry, relabeled from `Model Fields` to `Record` in the frontend, and match the existing wording in `_reference-field-values.qmd`. Worth a glance from someone who has the flag on.

**4. No screenshots.** I did not have the flag enabled against a live environment to capture the picker. Say the word if you want them and I'll add them.

## Dependencies, breaking changes, and deployment notes

- Implemented by validmind/frontend#2822 and validmind/backend#3492 (both merged).
- No dependency on another docs PR.

## Release notes

You can now reference other inventory field values from inside a rich-text Long Text field — both when defining the field's template and when editing the value on an individual record. Insert a field as a variable and it resolves to that record's current value, so a summary stays in sync as the record changes. [Learn more ...](/guide/inventory/manage-inventory-fields.qmd#insert-field-variables)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend) — n/a, see *What needs special review* #4
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied — `documentation`
- [ ] PR linked to Shortcut — sc-17836
- [ ] Unit tests added (Backend) — n/a
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required) — n/a
