### PR TITLE
[SC-17866] Document publishing My Dashboard pages to the organization

### DIFF
--- a/site/guide/configuration/customize-your-dashboard.qmd
+++ b/site/guide/configuration/customize-your-dashboard.qmd
@@ -9,7 +9,7 @@ date: last-modified
 Customize what you see on the {{< var validmind.platform >}} when you first log in with dashboards and widgets, enabling you to review and access information at a glance. 
 
 :::{.callout}
-Changes are automatically saved to your account and do not affect other users.
+Changes are automatically saved to your account and do not affect other users, unless you publish a dashboard to your organization.[^share]
 :::
 
 ::: {.attn}
@@ -66,6 +66,74 @@ b. Make your edits then click **Save Changes** to apply your adjustments.
 a. To remove a dashboard, select **{{< fa trash-can >}} Delete**.
 
 b. Click **Yes, Delete Dashboard** to confirm permanent deletion of that dashboard.
+
+:::
+
+### Share a dashboard with your organization
+<span id="share-a-dashboard"></span>
+
+Publishing a dashboard adds it as a tab for members of your organization, so that everyone works from the same view instead of assembling their own.
+
+::: {.callout}
+To publish a dashboard, you need the **Manage Shared Dashboards** permission.[^permissions] No role holds it by default — [{{< fa hand >}} Customer Admin]{.bubble} users can publish, and an administrator can grant it to any other role.
+
+You can only publish a dashboard you own. Holding the permission does not let you publish someone else's dashboard.
+
+:::
+
+::: {.panel-tabset}
+
+#### Publish a dashboard
+
+1. In the left sidebar, click **{{< fa home >}} Dashboard**.
+
+2. Click on the tab for the dashboard you want to publish.
+
+3. Click **{{< fa pencil >}} Edit Dashboard**.
+
+4. Select **{{< fa upload >}} Publish to Organization**.
+
+5. (Optional) Select one or more roles under **Visible to Roles** to limit which users see the dashboard:
+
+    - Leave **Visible to Roles** empty to make the dashboard visible to everyone in your organization. This is the default.
+    - Only organization roles can be selected,[^roles] not record stakeholder types.[^stakeholders]
+    - [{{< fa hand >}} Customer Admin]{.bubble} users are not affected by role restrictions.
+
+6. Click **Publish Dashboard**.
+
+::: {.callout-important title="Every widget must already be shared with the same roles."}
+A dashboard cannot be published while it still contains a widget that your colleagues would not be able to see. If any widget is not shared with the organization, or is not visible to the roles you selected, the dashboard is not published and each blocking widget is listed by name.
+
+To resolve it, share those widgets with the same roles — you may need an administrator to do this — or remove them from the dashboard and publish again.
+
+:::
+
+#### What your colleagues see
+
+Once published, the dashboard appears as a tab for the members of your organization who hold the selected roles.
+
+- The dashboard is **view-only** for them. Only its owner or an administrator can change it.
+- A banner names who shared it.
+- If a viewer holds none of the roles a particular widget is restricted to, that widget is replaced by a placeholder telling them they don't have access. The widget's data is never sent to their browser.
+
+#### Unpublish a dashboard
+
+Unpublishing returns the dashboard to being private and removes it from other members' dashboard tabs.
+
+1. In the left sidebar, click **{{< fa home >}} Dashboard**.
+
+2. Click on the tab for the published dashboard.
+
+3. Click **{{< fa pencil >}} Edit Dashboard**.
+
+4. Select **{{< fa download >}} Unpublish**.
+
+5. Click **Yes, Unpublish Dashboard** to confirm.
+
+::: {.callout}
+Taking your own dashboard back does not require the **Manage Shared Dashboards** permission — if your permission is revoked after you publish, you can still unpublish. Administrators can also unpublish a dashboard shared by someone else, which removes their own access to it along with everyone else's.
+
+:::
 
 :::
 
@@ -198,3 +266,11 @@ Removing a widget from a dashboard will not delete the linked view or analytics 
 [^7]: [Widget types](#widget-types)
 
 [^8]: [Arrange widgets](#arrange-widgets)
+
+[^share]: [Share a dashboard with your organization](#share-a-dashboard)
+
+[^permissions]: [Manage permissions](/guide/configuration/manage-permissions.qmd)
+
+[^roles]: [Manage roles](/guide/configuration/manage-roles.qmd)
+
+[^stakeholders]: [Manage record stakeholder types](/guide/configuration/manage-record-stakeholder-types.qmd)


### PR DESCRIPTION
# Pull Request Description

> [!IMPORTANT]
> **Draft — must not merge before the feature ships.** sc-17866 is still *Under review* and is **not merged on either repo**: I checked `origin/main` in both `validmind/frontend` and `validmind/backend` and found no SC-17866 commits. This PR documents behavior from the unmerged branches, so merging it now would ship docs for a feature nobody can use. Mark ready for review once frontend#2767 and the backend PR land, and re-verify the details flagged below in case review changes them.

## What and why?

Documents sc-17866 — publishing a **My Dashboard** page to the organization with role visibility. Adds a *Share a dashboard with your organization* section to `guide/configuration/customize-your-dashboard.qmd`, structured as three tabs: publishing, what colleagues see, and unpublishing.

Sourced from the feature branches at frontend `9ed918f0b` and backend `a19668743`.

### The permission, including the late change

Publishing is gated on a **new permission** that arrived late in review (backend `a19668743`, frontend `17ca1d249`):

- **Dashboard / `manage_shared_dashboards`** — "Publish a My Dashboard page to the organization, and choose which roles can see it."
- **Nothing grants it by default.** `AuthService.enforce` short-circuits for org admins, so out of the box admins are the only ones who can publish; an administrator can grant it to any role.
- **Ownership is required on top of the permission** — holding it does not let you publish someone else's dashboard.
- **Unpublishing is deliberately *not* gated on it.** Requiring it to retract would trap an owner whose permission was revoked after publishing. Documented explicitly, since it's the kind of asymmetry users otherwise report as a bug.

### Other behavior documented

- **Publish is blocked by unshared widgets.** A dashboard can't be published while it carries a widget colleagues couldn't see; each blocker is listed by name with the reason (`not shared with the organization` / `not visible to the selected roles`). Documented with the remedy: share those widgets with the same roles, or remove them.
- **Published dashboards are view-only** for everyone but the owner and administrators, with a banner naming who shared it.
- **Restricted widgets show a placeholder** rather than vanishing, and the widget's data never reaches the viewer's browser.
- **Admins who unpublish someone else's dashboard lose their own access to it** along with everyone else's.
- The page's opening callout claimed dashboard changes "do not affect other users". Publishing makes that conditional, so it's now qualified.

## How to test

Rendered locally against `--profile development`; the page renders clean. `customize-your-dashboard.qmd` uses no shared includes and is not consumed by any other page or RevealJS deck, so this is the only affected page.

Verified in the rendered HTML: the three new tabs appear inside the existing tabset structure, the `#share-a-dashboard` anchor resolves for the callout that links to it, and all four new footnotes resolve with no literal `[^name]` left in the output.

Preview link to follow once the ready-for-review `validate` job deploys.

## What needs special review?

**1. Re-verify against the merged code before this goes ready.** Everything here comes from unmerged branches. The permission itself was added in review, so more could change.

**2. The permissions matrix in `manage-permissions.qmd` is not updated — deliberately.** The new `Dashboard` resource would warrant a section there, but that table has no `Saved View` section either, despite `SavedView / manage_shared` already shipping. Adding `Dashboard` alone would be inconsistent, and filling the gap properly is bigger than this checklist item. I documented the permission inline in the sharing flow instead. Flagging the matrix staleness as a separate piece of work.

**3. Role-visibility wording is duplicated with the sc-17750 docs PR.** That PR adds `site/guide/shared/manage-views/_role-visibility.qmd` with the same rules. I wrote them inline here instead of including that file, so each branch renders independently of the other and they can merge in any order. Once both land, this section could use the shared include — happy to do that as a follow-up.

**4. No screenshots.** The publish modal, the blocked-publish error list, the view-only banner, and the restricted-widget placeholder are all new UI. Worth capturing before this goes ready; I couldn't run the unmerged branches against a live environment.

## Dependencies, breaking changes, and deployment notes

- **Blocked on:** validmind/frontend#2767 and the backend PR for sc-17866. Neither is merged.
- Related: the sc-17750 docs PR covers role visibility for views, layouts, and Analytics pages — the same epic, [Views by Role / Default Views](https://app.shortcut.com/validmind/epic/17748). No file overlap, so no merge conflict in either order.
- The backend change adds a new RBAC resource and action. Deployments will need the RBAC resource load to run before publishing works.

## Release notes

You can now publish a **My Dashboard** page to your organization, so that colleagues see the same dashboard as a tab instead of building their own — and limit it to selected organization roles. Publishing requires the new **Manage Shared Dashboards** permission, which administrators can grant to any role. [Learn more ...](/guide/configuration/customize-your-dashboard.qmd#share-a-dashboard)

## Checklist
- [x] What and why
- [ ] Screenshots or videos (Frontend) — see *What needs special review* #4
- [x] How to test
- [x] What needs special review
- [x] Dependencies, breaking changes, and deployment notes
- [ ] Labels applied — `documentation`
- [ ] PR linked to Shortcut — sc-17866
- [ ] Unit tests added (Backend) — n/a
- [x] Tested locally
- [x] Documentation updated (if required)
- [ ] Environment variable additions/changes documented (if required) — n/a
